### PR TITLE
UI polish 1/12 — Foundation: design tokens, soft typography, global base

### DIFF
--- a/desktop/renderer/index.html
+++ b/desktop/renderer/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" content="dark" />
   <meta http-equiv="Content-Security-Policy"
         content="default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' http://localhost:* ws://localhost:*; script-src 'self'" />
   <title>LucidAgentIDE</title>

--- a/desktop/renderer/styles.css
+++ b/desktop/renderer/styles.css
@@ -15,31 +15,56 @@
 
   --r-lg:12px; --r-md:9px; --r-sm:6px;
   --ease:cubic-bezier(.2,.8,.2,1); --ease-out:cubic-bezier(.16,1,.3,1);
+  --spring:cubic-bezier(.34,1.56,.64,1);
   --t-fast:130ms; --t:180ms; --t-slow:240ms;
+
+  /* Elevation — layered, soft, low-opacity. Stack a tight contact shadow
+     under a broad ambient one so surfaces lift without muddying the dark UI. */
   --shadow:0 12px 34px -12px rgba(0,0,0,.55), 0 2px 6px rgba(0,0,0,.35);
+  --shadow-sm:0 1px 2px rgba(0,0,0,.30), 0 2px 6px -2px rgba(0,0,0,.32);
+  --shadow-md:0 2px 5px rgba(0,0,0,.32), 0 8px 20px -6px rgba(0,0,0,.44);
+  --shadow-lg:0 4px 10px rgba(0,0,0,.36), 0 18px 44px -12px rgba(0,0,0,.58);
+  /* Inset top highlight — the faint catch-of-light on raised edges. */
+  --emboss:inset 0 1px 0 rgba(255,255,255,.04);
+  /* Hairline focus/selection ring, on-brand. */
+  --ring:0 0 0 1px color-mix(in srgb,var(--accent-2) 55%,transparent), 0 0 0 4px var(--accent-dim);
 
   --font:"Inter",ui-sans-serif,-apple-system,"Segoe UI",Roboto,system-ui,sans-serif;
   --mono:ui-monospace,"Cascadia Code","SF Mono",Menlo,Consolas,monospace;
+
+  color-scheme:dark;
 }
 
-@media (prefers-reduced-motion: reduce){ *{transition:none!important;animation:none!important} }
+@media (prefers-reduced-motion: reduce){
+  *{transition-duration:.01ms!important;animation-duration:.01ms!important;
+    animation-iteration-count:1!important;scroll-behavior:auto!important}
+}
 
 *{box-sizing:border-box}
+html{color-scheme:dark}
 html,body{height:100%;margin:0}
 body{
   background:radial-gradient(1200px 700px at 80% -10%, #16101f 0%, transparent 55%), var(--bg-0);
   color:var(--txt); font-family:var(--font); font-size:15px; line-height:1.55;
+  letter-spacing:.002em;
   -webkit-font-smoothing:antialiased; -moz-osx-font-smoothing:grayscale; text-rendering:optimizeLegibility;
+  font-feature-settings:"kern" 1,"liga" 1,"calt" 1;
+  font-variant-ligatures:common-ligatures contextual;
   overflow:hidden; user-select:none;
 }
+/* Tabular, slashed-zero numerals everywhere mono is used (IDs, counters, code). */
+.mono,code,pre,kbd,samp{font-family:var(--mono);font-feature-settings:"zero" 1,"calt" 0;font-variant-numeric:tabular-nums slashed-zero}
 #app{transform-origin:top left}
-.mono{font-family:var(--mono)}
-::selection{background:rgba(198,75,214,.32)}
+::selection{background:color-mix(in srgb,var(--accent) 34%,transparent);color:var(--txt)}
 ::-webkit-scrollbar{width:11px;height:11px}
-::-webkit-scrollbar-thumb{background:#222838;border:3px solid transparent;background-clip:content-box;border-radius:8px}
+::-webkit-scrollbar-track{background:transparent}
+::-webkit-scrollbar-thumb{background:#222838;border:3px solid transparent;background-clip:content-box;border-radius:8px;
+  transition:background var(--t) var(--ease)}
 ::-webkit-scrollbar-thumb:hover{background:#2f3750;background-clip:content-box}
+::-webkit-scrollbar-thumb:active{background:#3a4361;background-clip:content-box}
+::-webkit-scrollbar-corner{background:transparent}
 button{font-family:inherit}
-:focus-visible{outline:2px solid var(--accent-2);outline-offset:2px;border-radius:4px}
+:focus-visible{outline:none;box-shadow:var(--ring);border-radius:4px;transition:box-shadow var(--t-fast) var(--ease-out)}
 
 /* ───────────────────────── app frame ───────────────────────── */
 #app{display:grid;grid-template-rows:auto 1fr auto;height:100vh}


### PR DESCRIPTION
Part of the Apple-level UI/UX polish batch. Independent, region-scoped slice (`polish/foundation-tokens`) so it merges on its own.

Gate per worker: `desktop tsc --noEmit` + `bun build desktop/renderer/app.ts --target=browser` + `bun test harness` (green) + `/code-review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)