### PR TITLE
UI polish 5/12 — Chat readability + markdown typography + embossed code

### DIFF
--- a/desktop/renderer/styles.css
+++ b/desktop/renderer/styles.css
@@ -132,19 +132,19 @@ body.resizing .sidebar,body.resizing .inspector{transition:none}
 .thread{max-width:min(1080px,94vw);margin:0 auto;padding:0 30px;display:flex;flex-direction:column;gap:20px}
 .msg{position:relative;display:flex;gap:11px;align-items:flex-start;animation:rise var(--t-slow) var(--ease-out)}
 /* per-message actions (copy markdown · save .md) — appear on hover */
-.msg-actions{position:absolute;top:-3px;right:0;display:flex;gap:4px;opacity:0;transition:opacity var(--t);pointer-events:none}
-.msg:hover .msg-actions{opacity:1;pointer-events:auto}
-.msg-act{-webkit-app-region:no-drag;border:1px solid var(--line);background:var(--bg-2);color:var(--txt-3);width:27px;height:27px;border-radius:7px;display:grid;place-items:center;cursor:pointer;transition:background var(--t),color var(--t),border-color var(--t)}
-.msg-act:hover{background:var(--bg-3);color:var(--txt)}
+.msg-actions{position:absolute;top:-3px;right:0;display:flex;gap:4px;opacity:0;transform:translateY(-2px);transition:opacity var(--t) var(--ease-out),transform var(--t) var(--ease-out);pointer-events:none}
+.msg:hover .msg-actions,.msg:focus-within .msg-actions{opacity:1;transform:none;pointer-events:auto}
+.msg-act{-webkit-app-region:no-drag;border:1px solid var(--line);background:var(--bg-2);color:var(--txt-2);width:27px;height:27px;border-radius:7px;display:grid;place-items:center;cursor:pointer;transition:background var(--t),color var(--t),border-color var(--t)}
+.msg-act:hover{background:var(--bg-3);color:var(--txt);border-color:var(--line-strong)}
 .msg-act.ok{color:var(--green);border-color:color-mix(in srgb,var(--green) 45%,var(--line))}
 @keyframes rise{from{opacity:0;transform:translateY(7px)}to{opacity:1;transform:none}}
-.msg .who{flex:none;width:84px;text-align:right;font-size:12.5px;font-weight:600;letter-spacing:.2px;padding-top:5px;white-space:nowrap}
-.msg.user .who{color:var(--txt-3)}
+.msg .who{flex:none;width:84px;text-align:right;font-size:12.5px;font-weight:600;letter-spacing:.3px;padding-top:5px;white-space:nowrap}
+.msg.user .who{color:var(--txt-2)}
 .msg.assistant .who{color:var(--accent-2)}
-.msg .av{flex:none;width:28px;height:28px;border-radius:8px;display:grid;place-items:center;font-size:12px;font-weight:700;margin-top:1px}
-.msg.user .av{background:var(--bg-3);color:var(--txt-2)}
-.msg.assistant .av{background:linear-gradient(150deg,var(--accent),#7d39c4);color:#fff;box-shadow:0 0 14px rgba(198,75,214,.35)}
-.msg .text{flex:1;min-width:0;font-size:16px;line-height:1.66;color:var(--txt);user-select:text;padding-top:2px}
+.msg .av{flex:none;width:28px;height:28px;border-radius:8px;display:grid;place-items:center;font-size:12px;font-weight:700;margin-top:1px;border:1px solid transparent}
+.msg.user .av{background:var(--bg-3);color:var(--txt-2);border-color:var(--line)}
+.msg.assistant .av{background:linear-gradient(150deg,var(--accent),#7d39c4);color:#fff;box-shadow:0 0 14px rgba(198,75,214,.38),inset 0 1px 0 rgba(255,255,255,.18)}
+.msg .text{flex:1;min-width:0;font-size:16px;line-height:1.68;letter-spacing:.07px;color:var(--txt);user-select:text;padding-top:2px}
 /* ── rendered markdown (assistant + user replies) ── */
 .msg .text>:first-child{margin-top:0}
 .msg .text>:last-child{margin-bottom:0}
@@ -172,36 +172,45 @@ body.resizing .sidebar,body.resizing .inspector{transition:none}
 .lc-foot{margin-top:7px;padding-top:7px;border-top:1px solid var(--line-soft);font-size:10.5px;color:var(--txt-4);display:flex;align-items:center;gap:5px;flex-wrap:wrap}
 .lc-foot.warn{color:var(--amber);border-top:0;padding-top:2px;margin-top:3px}
 .lc-local{color:var(--cyan)}
-.msg .text p{margin:0 0 10px}
-.msg .text h1,.msg .text h2,.msg .text h3,.msg .text h4{margin:16px 0 8px;line-height:1.3;font-weight:650}
-.msg .text h1{font-size:1.4em}.msg .text h2{font-size:1.22em}.msg .text h3{font-size:1.08em}.msg .text h4{font-size:1em;color:var(--txt-2)}
-.msg .text ul,.msg .text ol{margin:0 0 10px;padding-left:22px}
-.msg .text li{margin:3px 0}
+/* reading column: a comfortable measure keeps long prose calm and scannable */
+.msg .text p,.msg .text ul,.msg .text ol,.msg .text blockquote{max-width:72ch}
+.msg .text p{margin:0 0 12px}
+.msg .text h1,.msg .text h2,.msg .text h3,.msg .text h4{margin:20px 0 9px;line-height:1.3;font-weight:660;letter-spacing:-.01em;color:var(--txt)}
+.msg .text h1{font-size:1.42em}.msg .text h2{font-size:1.24em}.msg .text h3{font-size:1.09em}.msg .text h4{font-size:1em;color:var(--txt-2);letter-spacing:.01em}
+.msg .text h1{padding-bottom:6px;border-bottom:1px solid var(--line-soft)}
+.msg .text ul,.msg .text ol{margin:0 0 12px;padding-left:24px}
+.msg .text li{margin:4px 0;padding-left:2px}
 .msg .text li::marker{color:var(--accent-2)}
-.msg .text a{color:var(--cyan);text-decoration:none;border-bottom:1px solid color-mix(in srgb,var(--cyan) 35%,transparent)}
-.msg .text a:hover{border-bottom-color:var(--cyan)}
+.msg .text a{color:var(--cyan);text-decoration:none;border-bottom:1px solid color-mix(in srgb,var(--cyan) 38%,transparent);transition:color var(--t),border-color var(--t)}
+.msg .text a:hover{color:color-mix(in srgb,var(--cyan) 80%,#fff);border-bottom-color:var(--cyan)}
 .msg .text strong{color:var(--txt);font-weight:680}
-.msg .text hr{border:0;border-top:1px solid var(--line);margin:14px 0}
-.msg .text blockquote{margin:0 0 10px;padding:2px 0 2px 12px;border-left:3px solid var(--accent-dim);color:var(--txt-2)}
-.msg .text code{font-family:var(--mono);font-size:13px;background:var(--bg-2);
-  border:1px solid var(--line-soft);padding:1px 6px;border-radius:5px;color:var(--cyan)}
-/* code blocks: clearly demarcated — distinct surface, accent edge, padded gutter, smooth scroll */
-.msg .text pre{position:relative;margin:0 0 12px;padding:13px 15px;background:#0c0e15;border:1px solid var(--line-strong);
-  border-left:3px solid color-mix(in srgb,var(--accent) 55%,var(--line-strong));border-radius:10px;overflow-x:auto;max-width:100%;
-  scrollbar-width:thin;box-shadow:inset 0 1px 0 rgba(255,255,255,.02)}
-.msg .text pre code{display:block;background:transparent;border:0;padding:0;color:#d6dbe8;font-size:12.75px;line-height:1.62;white-space:pre;font-variant-ligatures:none}
+.msg .text em{color:var(--txt);font-style:italic}
+.msg .text hr{border:0;height:1px;margin:18px 0;background:linear-gradient(90deg,transparent,var(--line-strong) 18%,var(--line-strong) 82%,transparent)}
+.msg .text blockquote{margin:0 0 12px;padding:6px 0 6px 15px;border-left:3px solid color-mix(in srgb,var(--accent) 60%,var(--line-strong));color:var(--txt-2);font-style:italic}
+.msg .text blockquote p:last-child{margin-bottom:0}
+.msg .text code{font-family:var(--mono);font-size:.86em;background:var(--cyan-dim);
+  border:1px solid color-mix(in srgb,var(--cyan) 22%,var(--line-soft));padding:1.5px 6px;border-radius:5px;color:color-mix(in srgb,var(--cyan) 86%,#fff)}
+/* code blocks: embossed premium panel — distinct surface, accent edge, inset highlight, smooth scroll */
+.msg .text pre{position:relative;margin:0 0 14px;padding:14px 16px;background:linear-gradient(180deg,#0e1119,#0b0d14);border:1px solid var(--line-strong);
+  border-left:3px solid color-mix(in srgb,var(--accent) 58%,var(--line-strong));border-radius:11px;overflow-x:auto;max-width:100%;
+  scrollbar-width:thin;box-shadow:var(--emboss,0 10px 26px -14px rgba(0,0,0,.6)),inset 0 1px 0 rgba(255,255,255,.04);transition:border-color var(--t),box-shadow var(--t)}
+.msg .text pre:hover{border-left-color:color-mix(in srgb,var(--accent) 72%,var(--line-strong))}
+.msg .text pre code{display:block;background:transparent;border:0;padding:0;color:#dde2ef;font-size:13px;line-height:1.65;white-space:pre;font-variant-ligatures:none}
 .msg .text pre::-webkit-scrollbar{height:9px}
-.msg .text pre::-webkit-scrollbar-thumb{background:var(--line-strong);border-radius:6px}
-.msg .text table{border-collapse:collapse;margin:0 0 10px;font-size:13.5px;display:block;overflow:auto;max-width:100%}
-.msg .text th,.msg .text td{border:1px solid var(--line);padding:5px 10px;text-align:left}
-.msg .text th{background:var(--bg-2);font-weight:600}
+.msg .text pre::-webkit-scrollbar-thumb{background:var(--line-strong);border-radius:6px;border:2px solid transparent;background-clip:content-box}
+.msg .text pre::-webkit-scrollbar-thumb:hover{background:#3c4564;background-clip:content-box}
+.msg .text table{border-collapse:collapse;margin:0 0 12px;font-size:13.5px;display:block;overflow:auto;max-width:100%;border:1px solid var(--line);border-radius:9px}
+.msg .text th,.msg .text td{border-bottom:1px solid var(--line-soft);padding:7px 12px;text-align:left}
+.msg .text td{color:var(--txt-2)}
+.msg .text tr:last-child td{border-bottom:0}
+.msg .text th{background:var(--bg-2);font-weight:650;color:var(--txt);border-bottom:1px solid var(--line)}
 .msg .text img,.msg .text svg{max-width:100%;height:auto;border-radius:8px;vertical-align:middle}
 .chat-hint{display:flex;flex-direction:column;align-items:center;text-align:center;gap:9px;
-  padding:64px 20px 20px;color:var(--txt-3);animation:rise var(--t-slow) var(--ease-out)}
+  padding:64px 20px 20px;color:var(--txt-2);animation:rise var(--t-slow) var(--ease-out)}
 .chat-hint .bs{width:46px;height:46px;border-radius:14px;display:grid;place-items:center;
-  background:linear-gradient(150deg,var(--accent),#7d39c4);color:#fff;box-shadow:0 0 22px rgba(198,75,214,.4);transform:scale(1.5)}
-.chat-hint .h{font-size:18px;font-weight:600;color:var(--txt);margin-top:8px}
-.chat-hint .d{font-size:13.5px;max-width:340px;line-height:1.6}
+  background:linear-gradient(150deg,var(--accent),#7d39c4);color:#fff;box-shadow:0 0 22px rgba(198,75,214,.4),inset 0 1px 0 rgba(255,255,255,.18);transform:scale(1.5)}
+.chat-hint .h{font-size:18px;font-weight:600;color:var(--txt);margin-top:8px;letter-spacing:-.01em}
+.chat-hint .d{font-size:13.5px;max-width:340px;line-height:1.62;color:var(--txt-2)}
 .cursor{display:inline-block;width:7px;height:16px;vertical-align:-2px;background:var(--accent-2);
   border-radius:2px;animation:blink 1s steps(2) infinite}
 @keyframes blink{50%{opacity:0}}


### PR DESCRIPTION
Part of the Apple-level UI/UX polish batch. Independent, region-scoped slice (`polish/chat-readability`) so it merges on its own.

Gate per worker: `desktop tsc --noEmit` + `bun build desktop/renderer/app.ts --target=browser` + `bun test harness` (green) + `/code-review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)