### PR TITLE
fix(security): stop math-Unicode false positives — confusable-only homoglyphs + source-scoped gate (ADR-0019 A+B)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1510,3 +1510,58 @@ and looks for `conversations.json` then `MyActivity.json` (then a lone `.json`).
   sees it; the model can't pull facts from un-scanned text.
 - `complete()` bypasses persona/recall and runs in an isolated session — no prompt-prefix impact.
 - Cap is surfaced, never silent (no false "imported everything").
+
+-----
+
+## ADR-0019 — Scanner homoglyph precision + source-scoped gate + block observability
+
+**Date:** 2026-06-20
+**Status:** Accepted. Part A + B built this increment; Part C (observability/review/approve) is next.
+**Relationship:** refines keystone #1 (the Unicode scanner) and the quarantine gate (invariant #3/#4).
+A deliberate, isolated fail-closed adjustment with its own ADR, as CLAUDE.md requires.
+
+### Context
+
+A user generating an image of a physics answer hit repeated false-positive blocks: the gate
+quarantined the model's own `generate_image` content because it contained ordinary scientific
+Unicode (`Δv`, `Σ`, `5μm`). Two distinct defects:
+1. **Scanner over-flagged** — `mixed-script-homoglyph` fired on ANY Latin+Greek/Cyrillic token, so
+   legitimate math notation (Greek letters with no Latin look-alike) was treated as a spoof.
+2. **Blocks were invisible** — the chat showed 8 "Blocked …" chips, but the Security panel read
+   0 quarantined / 0 findings (verified against `agent_obs.duckdb`), and the toast "Review" did
+   nothing. Root cause: the gate runs in the omp CHILD process and only writes the block to stderr;
+   its DuckDB persistence fails because the GUI server (a separate process) holds the single-writer
+   DB. So nothing reaches the tables the panel reads, and "Review" opens an empty panel.
+
+### Decision A — confusable-only homoglyph detection (scanner, keystone #1)
+
+`_detect_homoglyphs` now flags a Greek/Cyrillic letter only when its codepoint is a genuine Latin
+look-alike (`_LATIN_CONFUSABLE`: Α Β Ε … ο ν ρ; а е о р с …), not the whole Greek/Cyrillic block.
+Non-confusable math/scientific letters (Δ Σ Π Λ Φ λ μ π θ) mixed with Latin pass clean. Real spoofs
+(Cyrillic `а` in "pаypаl", Greek omicron in "lοgin") still fire — the existing adversarial fixtures
+stay green, and new clean-corpus fixtures assert the physics case produces zero findings.
+
+### Decision B — source-scoped gate (gate policy, invariant #3)
+
+The gate scans the model's OWN tool args. A homoglyph-only hit there is not an injection against the
+model, so it is **recorded-but-not-blocked**. New optional `GatePolicy.nonBlockingTypes` demotes
+specified finding types: they stay in `findings` and keep the label **suspicious** (so keystone #2
+still blocks promotion into memory), but don't quarantine on their own. The omp gate uses
+`TOOL_POLICY = { blockAtOrAbove: "high", nonBlockingTypes: {mixed-script-homoglyph} }`. This is a
+**bounded** relaxation: the never-legitimate vectors (zero-width, bidi-control, tag-block, PUA) still
+hard-block; a dangerous finding ALONGSIDE a demoted one still blocks (type-scoped, not blanket); and
+external/imported text — scanned on a different path with the strict `DEFAULT_POLICY` — is unchanged.
+The fail-closed law is untouched: a missing/failed scan still blocks (gate.failclosed.test green).
+
+### Decision C — block observability + review + approve (PLANNED, next increment)
+
+Move block PERSISTENCE to the GUI process (which owns the writable `agent_obs.duckdb`): the GUI
+already observes every block (the gate's stderr signal + tool_call_update rejection), so it records a
+quarantine/finding row there, surfaces it in the Security panel + rail badge + counts, makes the
+toast/chip "Review" open the specific finding, and adds an audited "Approve & retry" (a deliberate
+fail-closed override writing an `approval_event`). Not built this increment.
+
+### Guardrails
+
+- Fail-closed law intact; scanner clean-corpus still zero false-positives; adversarial spoofs still
+  caught; keystone #2 (suspicious can't auto-promote) unaffected. harness 369 pass, scanner pytest green.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -887,3 +887,15 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
 - **stubbed:** OAuth-restart + post-login poll can't be exercised headless (need a real provider
   login); logic typechecks. Perplexity OAuth (OTP/macOS-app) intentionally not wired here.
 - **next:** surface which credential (oauth vs key) a model came from in the picker hover card.
+
+## P11.1: scanner homoglyph precision + source-scoped gate (ADR-0019 A+B)
+- **shipped:** fixed the generate_image false positives. (A) scanner mixed-script-homoglyph now
+  flags ONLY Latin-confusable Greek/Cyrillic codepoints — math (Δ Σ λ μ π) passes, real spoofs
+  (Cyrillic а, Greek omicron) still caught; clean-corpus + adversarial fixtures green. (B) gate
+  GatePolicy.nonBlockingTypes demotes homoglyph-only hits in the model's OWN tool content to
+  recorded-but-not-blocked (suspicious), while dangerous vectors still hard-block and external
+  text stays strict; fail-closed law untouched. harness 369 pass, scanner pytest green.
+- **stubbed:** Part C — block observability (the chat shows blocks but the Security panel reads
+  an empty DB because the omp-child gate can't co-write the GUI's single-writer DuckDB) + the
+  toast "Review" + an audited "Approve & retry". Next increment.
+- **next:** P11.2 — persist gate blocks GUI-side, wire Review to the finding, add approve/override.

--- a/harness/omp/security_extension.ts
+++ b/harness/omp/security_extension.ts
@@ -17,7 +17,7 @@
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { ScannerClient } from "../security/scanner_client.ts";
-import { DEFAULT_POLICY, scanAndDecide } from "../security/gate.ts";
+import { scanAndDecide, type GatePolicy } from "../security/gate.ts";
 import { buildNotification, summarizeNotification } from "../security/notification.ts";
 import type { Db } from "../memory/db.ts";
 
@@ -27,6 +27,14 @@ const LIVE_RUN = "omp-live";
 
 const scanner = new ScannerClient();
 scanner.start();
+
+// The gate scans the model's OWN tool args (the bash command it wrote, the file content it
+// authored, custom-tool inputs). A homoglyph-only hit there is not an injection against the
+// model — it's legitimate when the model emits a Greek-letter variable (Δv, νₑ) or writes
+// about spoofing — so it is RECORDED-but-not-blocked. The dangerous, never-legitimate vectors
+// (zero-width, bidi-control, tag-block, private-use) still hard-block. External / imported
+// text is scanned on a different path with the strict DEFAULT_POLICY. See ADR-0019.
+const TOOL_POLICY: GatePolicy = { blockAtOrAbove: "high", nonBlockingTypes: new Set(["mixed-script-homoglyph"]) };
 
 let dbHandle: Db | undefined;
 let dbInit: Promise<Db | null> | undefined;
@@ -102,7 +110,7 @@ export default function securityExtension(pi: any): void {
   pi.on("tool_call", async (event: any) => {
     const toolName: string = event?.toolName ?? "tool";
     const text = collectStrings(event);
-    const decision = await scanAndDecide(scanner, text, DEFAULT_POLICY);
+    const decision = await scanAndDecide(scanner, text, TOOL_POLICY);
     if (!decision.block) {
       if (text.trim()) void rememberActivity(toolName, text); // allow + remember (provenance/memory)
       return;

--- a/harness/security/gate.failclosed.test.ts
+++ b/harness/security/gate.failclosed.test.ts
@@ -59,3 +59,23 @@ test("decideFromFindings is pure and severity-gated", () => {
   expect(sub.block).toBe(false);
   expect(sub.trustLabel).toBe("suspicious");
 });
+
+test("nonBlockingTypes (source-scoped): a homoglyph-only hit is recorded, not blocked (ADR-0019)", () => {
+  const policy = { blockAtOrAbove: "high" as const, nonBlockingTypes: new Set(["mixed-script-homoglyph" as const]) };
+  // homoglyph-only → demoted to suspicious (allowed), but the finding is still carried
+  const homo = decideFromFindings([{ type: "mixed-script-homoglyph", codepoint: "U+0430", index: 0, severity: "high" }], policy);
+  expect(homo.block).toBe(false);
+  expect(homo.trustLabel).toBe("suspicious");
+  expect(homo.findings.length).toBe(1); // recorded, not dropped
+  // a DANGEROUS vector alongside a demoted one still blocks — demotion is type-scoped, not blanket
+  const mixed = decideFromFindings(
+    [
+      { type: "mixed-script-homoglyph", codepoint: "U+0430", index: 0, severity: "high" },
+      { type: "zero-width", codepoint: "U+200B", index: 1, severity: "high" },
+    ],
+    policy,
+  );
+  expect(mixed.block).toBe(true);
+  // without the policy, the same homoglyph hard-blocks (external/untrusted text path)
+  expect(decideFromFindings([{ type: "mixed-script-homoglyph", codepoint: "U+0430", index: 0, severity: "high" }]).block).toBe(true);
+});

--- a/harness/security/gate.ts
+++ b/harness/security/gate.ts
@@ -10,7 +10,7 @@
 // out-of-process (the Python sidecar); the gate that ACTS on the result may not
 // (CLAUDE.md invariant #4).
 
-import type { Finding, Severity, TrustLabel } from "../contracts.ts";
+import type { Finding, FindingType, Severity, TrustLabel } from "../contracts.ts";
 import { ScannerClient, ScanUnavailableError } from "./scanner_client.ts";
 
 const SEVERITY_RANK: Record<Severity, number> = {
@@ -24,6 +24,12 @@ const SEVERITY_RANK: Record<Severity, number> = {
 export interface GatePolicy {
   /** Findings at or above this severity block. Default: "high". */
   blockAtOrAbove: Severity;
+  /** Finding types that are RECORDED but do not, on their own, force a block. Scopes the
+   *  gate by source: the model's OWN tool content shouldn't hard-block on a homoglyph-only
+   *  hit (legit when it writes about spoofing or uses a Greek variable), while external /
+   *  untrusted text stays strict (DEFAULT_POLICY demotes nothing). The genuinely dangerous
+   *  vectors (zero-width, bidi-control, tag-block, PUA) still block. See ADR-0019. */
+  nonBlockingTypes?: ReadonlySet<FindingType>;
 }
 
 export const DEFAULT_POLICY: GatePolicy = { blockAtOrAbove: "high" };
@@ -43,7 +49,13 @@ export function decideFromFindings(findings: Finding[], policy: GatePolicy = DEF
     return { block: false, reason: "clean", trustLabel: "trusted", findings, failClosed: false };
   }
   const threshold = SEVERITY_RANK[policy.blockAtOrAbove];
-  const top = findings.reduce((m, f) => Math.max(m, SEVERITY_RANK[f.severity]), 0);
+  // Only findings whose type is NOT demoted can force a block. Demoted types (e.g. a
+  // homoglyph-only hit in the model's own tool content) are still recorded — they remain
+  // in `findings` and keep the label suspicious — but never quarantine on their own.
+  const blockingFindings = policy.nonBlockingTypes
+    ? findings.filter((f) => !policy.nonBlockingTypes!.has(f.type))
+    : findings;
+  const top = blockingFindings.reduce((m, f) => Math.max(m, SEVERITY_RANK[f.severity]), 0);
   if (top >= threshold) {
     return {
       block: true,

--- a/scanner-sidecar/fixtures/adversarial.py
+++ b/scanner-sidecar/fixtures/adversarial.py
@@ -127,4 +127,10 @@ CLEAN_CORPUS = [
     "مرحبا بالعالم hello world",  # Arabic + Latin (different words)
     "한국어 텍스트 sample",  # Hangul + Latin
     "Markdown: # Heading, **bold**, `code`, [link](http://example.com)",
+    # legitimate math/scientific notation: non-confusable Greek mixed with Latin in
+    # one token (Δv, 5μm, Σλ) is ordinary physics, NOT a homoglyph spoof. Regression
+    # for the generate_image false-positive (Δ Σ λ μ π θ φ ω have no Latin look-alike).
+    "Δv = vexh·ln(m0/mf) ⇒ exponential rocket equation",
+    "resolution 5μm, wavelength 532nm, ΔT = 300K, Σλ over modes",
+    "let λx be the eigenvalue and θphase the angle; ∇·E = ρ/ε0",
 ]

--- a/scanner-sidecar/scanner.py
+++ b/scanner-sidecar/scanner.py
@@ -62,6 +62,29 @@ _SEVERITY = {
 # the confusable set (Cherokee, Coptic, fullwidth, ...) is a future enhancement.
 _HOMOGLYPH_PRONE = {"CYRILLIC", "GREEK"}
 
+# A Greek/Cyrillic letter mixed into a Latin token is only a homoglyph SPOOF when that
+# specific codepoint is a genuine Latin look-alike. Non-confusable letters (Δ Σ Π Λ Φ Ψ Ω
+# Γ Θ Ξ λ μ π θ σ φ …) are ordinary math/scientific notation and MUST NOT be flagged —
+# "Δv", "5μm", "Σλ" are not attacks. This set is the Latin-confusable subset only; it
+# preserves real spoof detection (Cyrillic 'а' in "pаypаl", Greek omicron in "lοgin")
+# while letting legitimate scientific Unicode through. (The gate additionally treats
+# homoglyph-only hits in the model's OWN tool content as non-blocking — see ADR-0019.)
+_LATIN_CONFUSABLE = frozenset(
+    {
+        # Greek capitals that mirror Latin capitals (A B E Z H I K M N O P T Y X)
+        0x0391, 0x0392, 0x0395, 0x0396, 0x0397, 0x0399, 0x039A, 0x039C,
+        0x039D, 0x039F, 0x03A1, 0x03A4, 0x03A5, 0x03A7,
+        # Greek lowercase look-alikes: omicron→o, nu→v, rho→p, lunate sigma→c, gamma→y
+        0x03BF, 0x03BD, 0x03C1, 0x03F2, 0x03B3,
+        # Cyrillic capitals that mirror Latin (A B E K M H O P C T Y X, plus S J)
+        0x0410, 0x0412, 0x0415, 0x041A, 0x041C, 0x041D, 0x041E, 0x0420,
+        0x0421, 0x0422, 0x0423, 0x0425, 0x0405, 0x0408,
+        # Cyrillic lowercase look-alikes: a e o p c y x s i j
+        0x0430, 0x0435, 0x043E, 0x0440, 0x0441, 0x0443, 0x0445, 0x0455,
+        0x0456, 0x0458,
+    }
+)
+
 
 def _classify(code: int, name: str, cat: str) -> str | None:
     """Return a FindingType string, or None if the character is unremarkable."""
@@ -119,6 +142,10 @@ def _detect_homoglyphs(text: str) -> list[dict]:
             continue
         for prone in _HOMOGLYPH_PRONE & scripts.keys():
             for idx in scripts[prone]:
+                # Only a genuine Latin look-alike is a spoof; non-confusable math/
+                # scientific letters (Δ Σ λ μ π …) mixed with Latin are legitimate.
+                if ord(text[idx]) not in _LATIN_CONFUSABLE:
+                    continue
                 ch = text[idx]
                 findings.append(
                     {


### PR DESCRIPTION
Fixes the generate_image false-positive quarantines (Δv, Σ, 5μm). (A) scanner flags only Latin-confusable Greek/Cyrillic; real spoofs still caught. (B) gate demotes homoglyph-only hits in the model's own tool content (recorded-but-not-blocked); dangerous vectors still block; external text strict; fail-closed intact. +1 test, harness 369 pass, scanner pytest green. ADR-0019.

Observability (toast Review + Security-panel metrics) is the planned Part C — diagnosed (two-process DuckDB) but not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)