### PR TITLE
feat(security): surface gate blocks + audited Approve & retry (ADR-0019 C)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1516,7 +1516,7 @@ and looks for `conversations.json` then `MyActivity.json` (then a lone `.json`).
 ## ADR-0019 — Scanner homoglyph precision + source-scoped gate + block observability
 
 **Date:** 2026-06-20
-**Status:** Accepted. Part A + B built this increment; Part C (observability/review/approve) is next.
+**Status:** Accepted. Parts A, B, and C all built.
 **Relationship:** refines keystone #1 (the Unicode scanner) and the quarantine gate (invariant #3/#4).
 A deliberate, isolated fail-closed adjustment with its own ADR, as CLAUDE.md requires.
 
@@ -1553,13 +1553,22 @@ hard-block; a dangerous finding ALONGSIDE a demoted one still blocks (type-scope
 external/imported text — scanned on a different path with the strict `DEFAULT_POLICY` — is unchanged.
 The fail-closed law is untouched: a missing/failed scan still blocks (gate.failclosed.test green).
 
-### Decision C — block observability + review + approve (PLANNED, next increment)
+### Decision C — block observability + review + approve (BUILT)
 
-Move block PERSISTENCE to the GUI process (which owns the writable `agent_obs.duckdb`): the GUI
-already observes every block (the gate's stderr signal + tool_call_update rejection), so it records a
-quarantine/finding row there, surfaces it in the Security panel + rail badge + counts, makes the
-toast/chip "Review" open the specific finding, and adds an audited "Approve & retry" (a deliberate
-fail-closed override writing an `approval_event`). Not built this increment.
+Block persistence moved to the GUI process — but NOT into `agent_obs.duckdb` (that's the same
+single-writer file the gate's omp child can't reach; co-writing it from the GUI invites the same
+contention). Instead a dedicated GUI-owned store, `desktop/security_log.ts`: an append-only JSONL
+audit at `~/.omp/lucid-blocks.jsonl` + an in-memory view, metadata-only (tool/severity/findings/
+reason, never raw content). The ACP client (`acp_backend.ts`, in the GUI process) calls `recordBlock`
+on the gate's authoritative stderr `[BLOCKED …]` signal, and — importantly — the generic
+`tool_call_update` rejection is **relabelled "tool call rejected" (not a security block)**, fixing
+the mislabel that made ordinary tool failures look like quarantines. `/api/security` merges
+`liveBlocks()` (so blocks show even when the DuckDB views are empty); the Security panel gains a
+"Live blocks (this session)" accordion + the quarantined chip + rail badge count them; the
+toast/chip "Review" opens it. `POST /api/security/approve` + an "Approve & retry" button release one
+block (audited in the JSONL) and re-send the user's last message — the deliberate, bounded
+fail-closed override. The gate itself is unchanged (still fail-closed); this only surfaces +
+optionally overrides what it already did.
 
 ### Guardrails
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -899,3 +899,17 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
   an empty DB because the omp-child gate can't co-write the GUI's single-writer DuckDB) + the
   toast "Review" + an audited "Approve & retry". Next increment.
 - **next:** P11.2 — persist gate blocks GUI-side, wire Review to the finding, add approve/override.
+
+## P11.2: security block observability + review + approve/override (ADR-0019 C)
+- **shipped:** the gate's blocks now reach the UI. Root cause of "isn't in the metrics / Review did
+  nothing": the gate runs in the omp child and can't co-write the GUI's single-writer DuckDB, so
+  blocks only hit stderr. Fix: GUI-owned desktop/security_log.ts (append-only JSONL + in-memory),
+  recorded by acp_backend on the gate's authoritative stderr signal; the generic tool_call_update
+  rejection is relabelled "tool call rejected" (no longer a fake security block). /api/security
+  merges liveBlocks(); Security panel gains a "Live blocks" accordion + quarantined chip + rail
+  badge; toast/chip Review opens it; POST /api/security/approve + an "Approve & retry" button
+  release one block (audited) and re-send the last prompt. Verified live: endpoint returns live
+  blocks, approve is idempotent, panel + badge render. desktop tsc + bundle clean, harness 369 pass.
+- **stubbed:** approved blocks aren't yet replayed at the omp tool level (retry = re-send the turn);
+  live blocks are session/JSONL-scoped, not folded into the DuckDB quarantine views.
+- **next:** none queued.

--- a/desktop/acp_backend.ts
+++ b/desktop/acp_backend.ts
@@ -13,6 +13,7 @@ import { join } from "node:path";
 import { ACPClient } from "./acp.ts";
 import { currentWorkspace } from "./workspace.ts";
 import { learnFromTurn, recallPreamble } from "./personal.ts";
+import { recordBlock } from "./security_log.ts";
 
 const REPO = join(import.meta.dir, "..");
 // Absolute so the gate loads from THIS repo even when omp runs in another workspace.
@@ -33,7 +34,7 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 export type ChatEvent =
   | { type: "token"; text: string }
   | { type: "tool"; name: string; detail: string }
-  | { type: "block"; tool: string; reason: string; severity: string; findings: string }
+  | { type: "block"; tool: string; reason: string; severity: string; findings: string; id?: string; quarantined?: boolean }
   | { type: "usage"; used: number; size: number; cost: number }
   | { type: "done" };
 
@@ -68,7 +69,11 @@ class Backend {
           switch (u?.sessionUpdate) {
             case "agent_message_chunk": if (u.content?.type === "text") this.emit({ type: "token", text: u.content.text }); break;
             case "tool_call": this.emit({ type: "tool", name: String(u.kind ?? u.title ?? "tool"), detail: String(u.title ?? u.rawInput?.command ?? "") }); break;
-            case "tool_call_update": if (u.status === "failed" || u.status === "rejected") this.emit({ type: "block", tool: String(u.kind ?? "tool"), reason: "blocked by the security gate", severity: "high", findings: "" }); break;
+            // A failed/rejected tool call is omp's GENERIC signal — it fires for the security
+            // gate AND for ordinary tool failures, so it must NOT claim "blocked by the security
+            // gate" (that mislabel made benign failures look like quarantines). The authoritative
+            // security block is the gate's own stderr signal, handled in onStderr below.
+            case "tool_call_update": if (u.status === "failed" || u.status === "rejected") this.emit({ type: "block", tool: String(u.kind ?? "tool"), reason: "tool call rejected", severity: "low", findings: "", quarantined: false }); break;
             case "usage_update": this.emit({ type: "usage", used: Number(u.used ?? 0), size: Number(u.size ?? 0), cost: Number(u.cost?.amount ?? 0) }); break;
             case "available_commands_update": this.commands = u.availableCommands ?? []; break;
             case "config_option_update": if (u.configOptions) this.configOptions = u.configOptions; break;
@@ -85,7 +90,12 @@ class Backend {
         acp.onStderr = (chunk) => {
           for (const line of chunk.split("\n")) {
             const m = /\[BLOCKED tool_call:(\w+)\].*?severity=(\w+).*?findings=([^\s]+)/.exec(line);
-            if (m) this.emit({ type: "block", tool: m[1]!, reason: "hidden-Unicode content quarantined", severity: m[2]!, findings: m[3]! });
+            if (m) {
+              // The authoritative security-gate block. Persist it GUI-side (the gate's own omp
+              // child can't co-write the DB) so it reaches the Security panel + is reviewable.
+              const rec = recordBlock({ tool: m[1]!, severity: m[2]!, findings: m[3]!, reason: "hidden-Unicode content quarantined", sessionId: this.sessionId ?? undefined });
+              this.emit({ type: "block", tool: m[1]!, reason: "hidden-Unicode content quarantined", severity: m[2]!, findings: m[3]!, id: rec.id, quarantined: true });
+            }
           }
         };
         acp.start();

--- a/desktop/dev.ts
+++ b/desktop/dev.ts
@@ -10,6 +10,7 @@
 
 import { join } from "node:path";
 import { securitySnapshot } from "../tools/web/data.ts";
+import { approveBlock, liveBlocks } from "./security_log.ts";
 import { memorySnapshot, rateLimits, usageLedger } from "../tools/memory_data.ts";
 import { backend } from "./acp_backend.ts";
 import { listSessions, sessionMessages } from "./sessions.ts";
@@ -92,7 +93,14 @@ const server = Bun.serve({
         const { js } = await bundleApp();
         return new Response(js, { headers: { "content-type": "text/javascript; charset=utf-8", "cache-control": "no-store" } });
       }
-      if (p === "/api/security") return json({ ok: true, data: await securitySnapshot() });
+      // Security snapshot + the GUI-owned LIVE gate blocks (ADR-0019 C). Live blocks are merged
+      // in even when the DuckDB snapshot is null, so a fresh machine still shows quarantines.
+      if (p === "/api/security") {
+        const snap = await securitySnapshot();
+        return json({ ok: true, data: { ...(snap ?? {}), live: liveBlocks() } });
+      }
+      // Audited fail-closed override: release one quarantined call (ADR-0019 C).
+      if (p === "/api/security/approve" && req.method === "POST") { const b = await req.json(); return json({ ok: true, data: approveBlock(String(b.id ?? "")) }); }
       if (p === "/api/memory") return json({ ok: true, data: await memorySnapshot() });
       // Light, fast re-read of the provider rate-limit budget (omp's agent.db).
       // Used by the front-end's manual refresh + 5-minute auto-poll.

--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -38,6 +38,7 @@ const state = {
   settingsOpen: false,
   lastOk: 0,
   streaming: false,
+  lastPrompt: "" as string, // last user message — re-sent by an Approve & retry (ADR-0019 C)
 };
 const prettyModel = (v: string) => v.replace(/^anthropic\//, "");
 // Strip the redundant "· AskSage Gov" / "· Gov" suffix from a model's display name
@@ -358,6 +359,7 @@ async function send(): Promise<void> {
   const ta = $("#input") as HTMLTextAreaElement;
   const text = ta.value.trim();
   if (!text || state.streaming) return;
+  state.lastPrompt = text; // remembered so an Approve & retry can re-send it
   ta.value = ""; autosize(ta); setSendEnabled();
   addMessage("user", text);
   state.streaming = true; setSendEnabled();
@@ -421,19 +423,27 @@ async function send(): Promise<void> {
 }
 
 function onBlock(e: Extract<ChatEvent, { type: "block" }>): void {
+  // A generic tool rejection (omp couldn't run a call for non-security reasons) is NOT a
+  // security event — show a quiet, neutral chip and stop. Only the gate's authoritative
+  // quarantine (quarantined !== false) gets the loud treatment + Security-panel review.
+  if (e.quarantined === false) {
+    addEvent(`<div class="evt" data-tip="Tool call did not run">${icon("close", 14)}<span><b>${esc(e.tool)}</b> · ${esc(e.reason)}</span></div>`);
+    return;
+  }
+  const review = () => { OPEN.add("sec.live"); focusInspector("security"); void refresh(); };
   addEvent(`<div class="evt block" data-tip="Quarantined|Click to review in the Security panel" data-tip-icon="shield">
     ${icon("shield", 15)}<span>Blocked <b>${esc(e.tool)}</b> ·</span><span class="reason">${esc(e.reason)}</span></div>`)
-    .addEventListener("click", () => focusInspector("security"));
+    .addEventListener("click", review);
   showToast({
     title: "Tool call quarantined",
     desc: `${e.reason}.`,
-    meta: `tool=${e.tool} · severity=${e.severity} · ${e.findings}`,
+    meta: `tool=${e.tool} · severity=${e.severity}${e.findings ? " · " + e.findings : ""}`,
     actions: [
-      { label: "Review", run: () => focusInspector("security") },
+      { label: "Review", run: review },
       { label: "Dismiss", kind: "danger" },
     ],
   });
-  refresh(); // pull the new finding into the panels
+  void refresh(); // pull the new block into the panels + badge
 }
 
 function autosize(ta: HTMLTextAreaElement): void { ta.style.height = "auto"; ta.style.height = Math.min(ta.scrollHeight, 180) + "px"; }
@@ -908,35 +918,53 @@ function secIntro(): string {
   </div>`;
 }
 function securityHtml(d: SecuritySnapshot | null): string {
-  const totFind = d ? d.findings.reduce((a, r) => a + Number(r.n || 0), 0) : 0;
-  const promoted = d ? Number((d.promotion.find((r) => r.outcome === "promoted") || {}).n || 0) : 0;
-  const blocked = d ? Number((d.promotion.find((r) => r.outcome === "blocked") || {}).n || 0) : 0;
+  // The /api/security response always carries `live` (GUI-owned gate blocks), but the DuckDB
+  // arrays may be absent on a fresh machine — guard every one.
+  const quarantine = d?.quarantine ?? [], approvals = d?.approvals ?? [], findings = d?.findings ?? [];
+  const promotion = d?.promotion ?? [], exports = d?.exports ?? [], runs = d?.runs ?? [];
+  const live = d?.live ?? { quarantined: [], approved: [], total: 0 };
+  const totFind = findings.reduce((a, r) => a + Number(r.n || 0), 0);
+  const promoted = Number((promotion.find((r) => r.outcome === "promoted") || {}).n || 0);
+  const blocked = Number((promotion.find((r) => r.outcome === "blocked") || {}).n || 0);
   let h = secIntro();
   h += chips([
-    { cls: "q", n: d ? d.quarantine.length : 0, l: "quarantined" },
-    { cls: "a", n: d ? d.approvals.length : 0, l: "awaiting review" },
+    { cls: "q", n: quarantine.length + live.quarantined.length, l: "quarantined" },
+    { cls: "a", n: approvals.length, l: "awaiting review" },
     { cls: "f", n: totFind, l: "findings" },
     { cls: "g", n: promoted, l: "promoted facts" },
   ]);
-  if (!d) { h += `<div class="empty">Nothing has tripped the scanner yet. The moment a tool call carries hidden-Unicode or another injection, the finding, the quarantine queue, and the audit trail appear right here.</div>`; return h; }
+  // Live blocks (this session) — what the gate actually stopped in THIS GUI, with the audited
+  // "Approve & retry" override. Sits up top so the toast "Review" lands on something actionable.
+  if (live.quarantined.length || live.approved.length) {
+    const rows = live.quarantined.length
+      ? live.quarantined.map((b) => `<div class="liveblk">
+          <div class="lb-head"><span class="pill quarantined">${esc(b.severity)}</span><b>${esc(b.tool)}</b><span class="lb-reason">${esc(b.reason)}</span></div>
+          <div class="lb-foot"><span class="lb-meta">${esc(b.findings || "no detail")} · ${esc(relTime(Date.parse(b.at)))}</span>
+            <button class="btn-mini ok" data-approve="${esc(b.id)}" data-tip="Approve &amp; retry|Release this one blocked call (audited) and re-send your last message so the agent can try again. Use only if you're sure it was a false positive.">${icon("check", 13)} Approve &amp; retry</button></div>
+        </div>`).join("")
+      : `<div class="empty">No active blocks — everything released or clean.</div>`;
+    const approvedNote = live.approved.length ? `<div class="lb-approved">${icon("check", 12)} ${live.approved.length} released this session · audited</div>` : "";
+    h += accordion("sec.live", "Live blocks", "this session · gate-enforced", rows + approvedNote, true, String(live.quarantined.length));
+  }
+  if (!d && !live.total) { h += `<div class="empty">Nothing has tripped the scanner yet. The moment a tool call carries hidden-Unicode or another injection, the finding, the quarantine queue, and the audit trail appear right here.</div>`; return h; }
   h += accordion("sec.quarantine", "Quarantine review", "isolated · fail-closed",
-    table([{ key: "artifact_id", label: "artifact", mono: true }, { key: "source", label: "source" }, { key: "trust_label", label: "trust", pill: true }, { key: "risk_score", label: "risk", mono: true }], d.quarantine),
-    OPEN.has("sec.quarantine"), String(d.quarantine.length));
+    table([{ key: "artifact_id", label: "artifact", mono: true }, { key: "source", label: "source" }, { key: "trust_label", label: "trust", pill: true }, { key: "risk_score", label: "risk", mono: true }], quarantine),
+    OPEN.has("sec.quarantine"), String(quarantine.length));
   h += accordion("sec.approvals", "Approval queue", "blocked · awaiting a human",
-    table([{ key: "artifact_id", label: "artifact", mono: true }, { key: "source", label: "source" }, { key: "trust_label", label: "trust", pill: true }, { key: "verdict", label: "verdict", pill: true }], d.approvals)
-    + (d.approvals.length ? `<div class="row-actions"><button class="btn-mini ok" data-act="approve">${icon("check", 14)} Approve</button><button class="btn-mini danger" data-act="deny">${icon("close", 14)} Deny</button></div>` : ""),
-    OPEN.has("sec.approvals"), String(d.approvals.length));
+    table([{ key: "artifact_id", label: "artifact", mono: true }, { key: "source", label: "source" }, { key: "trust_label", label: "trust", pill: true }, { key: "verdict", label: "verdict", pill: true }], approvals)
+    + (approvals.length ? `<div class="row-actions"><button class="btn-mini ok" data-act="approve">${icon("check", 14)} Approve</button><button class="btn-mini danger" data-act="deny">${icon("close", 14)} Deny</button></div>` : ""),
+    OPEN.has("sec.approvals"), String(approvals.length));
   h += accordion("sec.findings", "Findings overview", "by type · severity · source",
-    table([{ key: "finding_type", label: "type" }, { key: "severity", label: "sev", pill: true }, { key: "source", label: "source" }, { key: "n", label: "n", mono: true }], d.findings),
+    table([{ key: "finding_type", label: "type" }, { key: "severity", label: "sev", pill: true }, { key: "source", label: "source" }, { key: "n", label: "n", mono: true }], findings),
     OPEN.has("sec.findings"));
   h += accordion("sec.gate", "Memory-promotion gate", "untrusted content can't auto-save",
     gauge("blocked", blocked + promoted ? blocked / (blocked + promoted) : 0, `<b>${blocked}</b>&nbsp;blocked / ${promoted} ok`),
     OPEN.has("sec.gate"));
   h += accordion("sec.exports", "Export audit", "what left, sanitized",
-    table([{ key: "export_type", label: "type" }, { key: "sanitization_status", label: "sanitized" }, { key: "reviewer", label: "by" }], d.exports),
+    table([{ key: "export_type", label: "type" }, { key: "sanitization_status", label: "sanitized" }, { key: "reviewer", label: "by" }], exports),
     OPEN.has("sec.exports"));
   h += accordion("sec.runs", "Active runs", "provenance lineage",
-    table([{ key: "kind", label: "kind" }, { key: "mode", label: "mode" }, { key: "sandbox_profile", label: "sandbox" }, { key: "status", label: "status" }], d.runs),
+    table([{ key: "kind", label: "kind" }, { key: "mode", label: "mode" }, { key: "sandbox_profile", label: "sandbox" }, { key: "status", label: "status" }], runs),
     OPEN.has("sec.runs"));
   return h;
 }
@@ -1091,11 +1119,12 @@ async function refresh(): Promise<void> {
     // content the gate flagged). Hidden when there's nothing to act on; coloured by the
     // worst trust label in the queue (quarantined = red, suspicious-only = amber).
     const approvals = sec?.approvals ?? [];
-    const awaiting = approvals.length;
+    const liveQ = sec?.live?.quarantined ?? []; // GUI-owned live gate blocks (ADR-0019 C)
+    const awaiting = approvals.length + liveQ.length;
     const badge = $("#railBadge")!;
     badge.hidden = awaiting === 0;
     if (awaiting > 0) {
-      const high = approvals.some((a) => String(a.trust_label) === "quarantined");
+      const high = liveQ.length > 0 || approvals.some((a) => String(a.trust_label) === "quarantined");
       badge.textContent = awaiting > 99 ? "99+" : String(awaiting);
       badge.className = high ? "badge" : "badge med";
       badge.setAttribute("data-tip", `${awaiting} item${awaiting === 1 ? "" : "s"} awaiting review|${high ? "Includes quarantined (blocked) content." : "Suspicious content flagged for review."} Open the Security panel to act.`);
@@ -1667,6 +1696,26 @@ function wire(): void {
     if ((e.target as HTMLElement).closest("[data-budget-refresh]")) { void refreshBudget(true); return; }
     const head = (e.target as HTMLElement).closest("[data-acc-toggle]") as HTMLElement | null;
     if (head) { const k = head.dataset.accToggle!; const acc = head.closest(".acc")!; const open = acc.classList.toggle("open"); open ? OPEN.add(k) : OPEN.delete(k); return; }
+    // Approve & retry: the audited fail-closed override for one live gate block (ADR-0019 C).
+    const approve = (e.target as HTMLElement).closest("[data-approve]") as HTMLElement | null;
+    if (approve) {
+      const id = approve.dataset.approve!;
+      (approve as HTMLButtonElement).disabled = true;
+      void (async () => {
+        const r = await bridge.securityApprove(id);
+        if (!r) { showToast({ title: "Already handled", desc: "That block was already released.", actions: [{ label: "OK" }], timeout: 3000 }); return; }
+        await refresh(); // drop it from the live-block list + counts + badge
+        const retry = state.lastPrompt.trim();
+        showToast({
+          title: "Released · audited",
+          desc: retry ? "Re-sending your last message so the agent can try again." : "Block released and recorded in the audit log.",
+          meta: `tool=${r.tool} · approved`,
+          actions: [{ label: "OK" }], timeout: 4500,
+        });
+        if (retry && !state.streaming) { const ta = $("#input") as HTMLTextAreaElement; ta.value = retry; void send(); }
+      })();
+      return;
+    }
     const act = (e.target as HTMLElement).closest("[data-act]") as HTMLElement | null;
     if (act) {
       const ok = act.dataset.act === "approve";

--- a/desktop/renderer/bridge.ts
+++ b/desktop/renderer/bridge.ts
@@ -7,9 +7,12 @@
 // native-only is window controls + crisp text zoom, exposed by the Electron
 // preload as `window.lucid`; in a plain browser those fall back to CSS zoom.
 
+export interface BlockRecord { id: string; tool: string; severity: string; findings: string; reason: string; at: string; status: "quarantined" | "approved"; reviewer?: string }
 export interface SecuritySnapshot {
   findings: any[]; unicode: any[]; approvals: any[]; quarantine: any[];
   promotion: any[]; exports: any[]; runs: any[];
+  // GUI-owned LIVE gate blocks (ADR-0019 C) — present even when the DuckDB views are empty.
+  live?: { quarantined: BlockRecord[]; approved: BlockRecord[]; total: number };
 }
 export interface MemorySnapshot {
   session: null | {
@@ -90,13 +93,15 @@ export interface WorkspaceInfo {
 export type ChatEvent =
   | { type: "token"; text: string }
   | { type: "tool"; name: string; detail: string }
-  | { type: "block"; tool: string; reason: string; severity: string; findings: string }
+  | { type: "block"; tool: string; reason: string; severity: string; findings: string; id?: string; quarantined?: boolean }
   | { type: "usage"; used: number; size: number; cost: number }
   | { type: "done" };
 
 export interface LucidBridge {
   isElectron: boolean;
   security(): Promise<SecuritySnapshot | null>;
+  /** Release one quarantined call — the audited fail-closed override (ADR-0019 C). */
+  securityApprove(id: string): Promise<BlockRecord | null>;
   memory(): Promise<MemorySnapshot | null>;
   budget(): Promise<{ label: string; used: number; status: string; resetsAt: number | null }[] | null>;
   usage(): Promise<UsageLedger | null>;
@@ -216,6 +221,7 @@ async function streamChat(text: string, onEvent: (e: ChatEvent) => void): Promis
 export const bridge: LucidBridge = {
   isElectron: !!shell?.isElectron,
   security: () => getData("/api/security"),
+  securityApprove: (id) => post("/api/security/approve", { id }),
   memory: () => getData("/api/memory"),
   budget: () => getData("/api/budget"),
   usage: () => getData("/api/usage"),

--- a/desktop/renderer/styles.css
+++ b/desktop/renderer/styles.css
@@ -511,6 +511,16 @@ body.resizing .sidebar,body.resizing .inspector{transition:none}
   border:1px dashed var(--line-strong);border-radius:10px;padding:14px;line-height:1.6}
 .empty code{font-family:var(--mono);color:var(--accent-2)}
 .row-actions{display:flex;gap:6px;margin-top:9px}
+/* live gate blocks (ADR-0019 C): one card per block this session, with Approve & retry */
+.liveblk{border:1px solid color-mix(in srgb,var(--red) 28%,var(--line));border-radius:9px;
+  background:linear-gradient(150deg,var(--red-dim),transparent 70%);padding:9px 11px;margin-bottom:8px;
+  box-shadow:var(--emboss,inset 0 1px 0 rgba(255,255,255,.03))}
+.lb-head{display:flex;align-items:center;gap:8px;font-size:12.5px;min-width:0}
+.lb-head b{color:var(--txt);flex:none}
+.lb-reason{color:var(--txt-2);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.lb-foot{display:flex;align-items:center;justify-content:space-between;gap:10px;margin-top:8px}
+.lb-meta{font-family:var(--mono);font-size:10.5px;color:var(--txt-4);min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.lb-approved{margin-top:6px;font-size:11px;color:var(--green);display:flex;align-items:center;gap:5px}
 .btn-mini{-webkit-app-region:no-drag;border:1px solid var(--line);background:var(--bg-2);color:var(--txt-2);
   font-size:11.5px;font-weight:600;padding:5px 10px;border-radius:7px;cursor:pointer;display:inline-flex;align-items:center;gap:6px;
   transition:background var(--t),color var(--t),border-color var(--t)}

--- a/desktop/security_log.ts
+++ b/desktop/security_log.ts
@@ -1,0 +1,83 @@
+// desktop/security_log.ts — a GUI-owned record of the security gate's live blocks (ADR-0019 C).
+//
+// WHY THIS EXISTS: the gate runs inside the omp CHILD process and can only signal a block over
+// stderr; it cannot co-write agent_obs.duckdb because the GUI server holds that single-writer DB
+// (two-process DuckDB contention). So blocks never reached the Security panel and the toast
+// "Review" opened an empty tab. The fix: the GUI process (which observes every block via the ACP
+// client) records them HERE — an append-only JSONL audit at ~/.omp/lucid-blocks.jsonl plus an
+// in-memory view — and the dashboard reads from this. Metadata only (tool/severity/findings/
+// reason), never raw scanned content.
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+import { Snowflake } from "@oh-my-pi/pi-utils";
+
+export interface BlockRecord {
+  id: string;
+  tool: string; // the tool whose call was blocked (e.g. "write", "eval", "bash")
+  severity: string;
+  findings: string; // short finding summary (e.g. "zero-width×2"); never raw content
+  reason: string;
+  sessionId?: string;
+  at: string; // ISO timestamp
+  status: "quarantined" | "approved";
+  reviewer?: string;
+  approvedAt?: string;
+}
+
+const LOG_PATH = join(homedir(), ".omp", "lucid-blocks.jsonl");
+let mem: BlockRecord[] | null = null;
+
+/** Load the append-only log into memory, applying approval markers in order. */
+function load(): BlockRecord[] {
+  if (mem) return mem;
+  const byId = new Map<string, BlockRecord>();
+  try {
+    if (existsSync(LOG_PATH)) {
+      for (const line of readFileSync(LOG_PATH, "utf8").split("\n")) {
+        if (!line.trim()) continue;
+        const o = JSON.parse(line) as BlockRecord & { _approval?: boolean };
+        if (o._approval) { const r = byId.get(o.id); if (r) { r.status = "approved"; r.reviewer = o.reviewer; r.approvedAt = o.approvedAt; } }
+        else byId.set(o.id, { ...o, status: o.status ?? "quarantined" });
+      }
+    }
+  } catch { /* corrupt line / unreadable — best-effort, keep what we have */ }
+  mem = [...byId.values()];
+  return mem;
+}
+
+function append(obj: unknown): void {
+  try { mkdirSync(dirname(LOG_PATH), { recursive: true }); appendFileSync(LOG_PATH, JSON.stringify(obj) + "\n"); }
+  catch { /* audit is best-effort; the in-memory view still works for the session */ }
+}
+
+/** Record a freshly-observed gate block. Returns the new record (its id wires the UI's review). */
+export function recordBlock(b: { tool: string; severity?: string; findings?: string; reason: string; sessionId?: string }): BlockRecord {
+  const rec: BlockRecord = {
+    id: Snowflake.next(), tool: b.tool || "tool", severity: b.severity || "high",
+    findings: b.findings || "", reason: b.reason, sessionId: b.sessionId,
+    at: new Date().toISOString(), status: "quarantined",
+  };
+  load().push(rec);
+  append(rec);
+  return rec;
+}
+
+/** Mark a block approved (the audited fail-closed override). Returns false if unknown/already approved. */
+export function approveBlock(id: string, reviewer = "user"): BlockRecord | null {
+  const r = load().find((x) => x.id === id);
+  if (!r || r.status === "approved") return null;
+  r.status = "approved"; r.reviewer = reviewer; r.approvedAt = new Date().toISOString();
+  append({ _approval: true, id, reviewer, approvedAt: r.approvedAt });
+  return r;
+}
+
+export interface LiveBlocks { quarantined: BlockRecord[]; approved: BlockRecord[]; total: number }
+
+/** The live-block view for the Security panel (most-recent first, capped). */
+export function liveBlocks(): LiveBlocks {
+  const all = load();
+  const recent = (s: BlockRecord["status"]) => all.filter((b) => b.status === s).slice(-100).reverse();
+  return { quarantined: recent("quarantined"), approved: recent("approved"), total: all.length };
+}


### PR DESCRIPTION
Makes the security gate's blocks visible + reviewable + overridable. GUI-owned block log (the omp-child gate can't co-write the GUI's single-writer DuckDB), 'Live blocks' panel accordion + rail badge + counts, toast Review opens it, audited Approve & retry. Generic tool rejections relabelled so they stop masquerading as security blocks. Verified live; desktop tsc+bundle clean, harness 369 pass. ADR-0019 C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)