### PR TITLE
fix(desktop): silent launch — no console window pop-up on Windows

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -913,3 +913,12 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
 - **stubbed:** approved blocks aren't yet replayed at the omp tool level (retry = re-send the turn);
   live blocks are session/JSONL-scoped, not folded into the DuckDB quarantine views.
 - **next:** none queued.
+
+## P-FIX: silent launch (no console pop-up on Windows)
+- **shipped:** the installed app flashed a black `bun-win32-x64.exe` console window on launch. Cause:
+  Electron main spawned the bundled Bun GUI server with stdio:"inherit" + no windowsHide, so the
+  console-subsystem child allocated its own window in the packaged (console-less) GUI app. Fixed all
+  three Node child spawns (main.ts server, runtime.ts provisioning, acp.ts omp child): windowsHide:true
+  and piped (not inherited) stdio with output forwarded for dev. desktop tsc clean.
+- **stubbed:** Bun.spawn auth-broker (OAuth-only, transient) left as-is (no windowsHide option on Bun.spawn).
+- **next:** P10.3 rate-limit header probe; ADR-0009 Phase D dev-logging view.

--- a/desktop/acp.ts
+++ b/desktop/acp.ts
@@ -27,7 +27,7 @@ export class ACPClient {
   constructor(private cmd: string, private args: string[], private cwd: string) {}
 
   start(): void {
-    this.proc = spawn(this.cmd, this.args, { cwd: this.cwd, stdio: ["pipe", "pipe", "pipe"] });
+    this.proc = spawn(this.cmd, this.args, { cwd: this.cwd, stdio: ["pipe", "pipe", "pipe"], windowsHide: true });
     this.proc.stdout!.on("data", (d) => this.onData(String(d)));
     this.proc.stderr!.on("data", (d) => this.onStderr(String(d)));
     this.proc.on("exit", (code) => this.onExit(code));

--- a/desktop/main.ts
+++ b/desktop/main.ts
@@ -31,8 +31,14 @@ function startDevServer(): void {
   dev = spawn(findBun(), ["run", "desktop/dev.ts"], {
     cwd: REPO,
     env: { ...process.env, ...runtimeEnv, PORT: String(PORT) },
-    stdio: "inherit",
+    // NOT "inherit": in a packaged GUI app the Electron main has no console, so inheriting
+    // makes the console-subsystem Bun allocate its OWN console window (the black pop-up).
+    // Pipe instead + windowsHide so no window ever appears; forward output for dev runs.
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
   });
+  dev.stdout?.on("data", (d) => process.stdout.write(d));
+  dev.stderr?.on("data", (d) => process.stderr.write(d));
 }
 async function waitForServer(timeoutMs = 12000): Promise<void> {
   const deadline = Date.now() + timeoutMs;

--- a/desktop/runtime.ts
+++ b/desktop/runtime.ts
@@ -90,7 +90,11 @@ export function needsBootstrap(): boolean {
 
 function run(cmd: string, args: string[], extraEnv: Record<string, string> = {}): Promise<void> {
   return new Promise((resolve, reject) => {
-    const p = spawn(cmd, args, { stdio: "inherit", env: { ...process.env, ...extraEnv } });
+    // windowsHide + piped (not inherited) stdio so provisioning never flashes a console window
+    // in the packaged GUI app; output is forwarded for terminal/dev runs.
+    const p = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"], windowsHide: true, env: { ...process.env, ...extraEnv } });
+    p.stdout?.on("data", (d) => process.stdout.write(d));
+    p.stderr?.on("data", (d) => process.stderr.write(d));
     p.on("error", reject);
     p.on("exit", (code) => (code === 0 ? resolve() : reject(new Error(`${cmd} exited ${code}`))));
   });


### PR DESCRIPTION
The installed app flashed a black bun-win32-x64.exe console window on launch. Fixed all three node child spawns (server, provisioning, omp) with windowsHide:true + piped stdio. desktop tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)