### PR TITLE
feat(cost): live API-key rate-limit probe — completes ADR-0011 P10.3

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -861,8 +861,10 @@ prerequisite for everything, has the smallest surface, needs no DuckDB migration
 ## ADR-0011 — Observability & cost intelligence (roadmap)
 
 **Date:** 2026-06-19
-**Status:** Accepted as a roadmap. **P10.1 BUILT** + **P10.2 BUILT**. **P10.3 PARTIAL** — the proactive
-budget warning shipped (chip turns red + a once-per-window toast at ≥90%, so you see the wall coming);
+**Status:** Accepted as a roadmap. **P10.1 BUILT** + **P10.2 BUILT** + **P10.3 BUILT** (the live
+header probe landed as an opt-in — `desktop/ratelimit_probe.ts`, parsers unit-tested, surfaced in
+the budget panel). **P10.4 remains Proposed.** The proactive budget warning also shipped earlier
+(chip turns red + a once-per-window toast at ≥90%, so you see the wall coming);
 the live header probe is deferred. **P10.4 remains Proposed**.
 
 > **P10.3 design note (learned in build):** the user's binding limit is the **Claude oauth 5-hour

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -922,3 +922,15 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
   and piped (not inherited) stdio with output forwarded for dev. desktop tsc clean.
 - **stubbed:** Bun.spawn auth-broker (OAuth-only, transient) left as-is (no windowsHide option on Bun.spawn).
 - **next:** P10.3 rate-limit header probe; ADR-0009 Phase D dev-logging view.
+
+## P10.3: live API-key rate-limit probe (ADR-0011, completes P10.3)
+- **shipped:** the deferred half of P10.3. desktop/ratelimit_probe.ts probes a keyed provider's
+  rate-limit response headers (Anthropic anthropic-ratelimit-*, OpenAI x-ratelimit-*) → remaining /
+  resets-at, 5-min cache, fails soft. OPT-IN (off by default; each check is one tiny request that
+  costs a token or two). Pure header parsers unit-tested (4 pass). Settings/state: rateLimitProbe +
+  setRateLimitProbe; GET/POST /api/ratelimits; bridge rateLimits/setRateLimitProbe; budget panel
+  shows probed limits (cyan "API key · live" tag) + an in-panel toggle. Verified live: off→[],
+  toggle flips, no probe fires without a key. desktop+root tsc clean, bundle OK, harness 369 pass.
+- **stubbed:** live header correctness needs a real Anthropic/OpenAI key to fully validate (parsers
+  tested, gating + graceful-empty verified). Probe model ids (haiku/gpt-4o-mini) are sensible defaults.
+- **next:** ADR-0009 Phase D — developer-mode logging view.

--- a/desktop/dev.ts
+++ b/desktop/dev.ts
@@ -11,12 +11,13 @@
 import { join } from "node:path";
 import { securitySnapshot } from "../tools/web/data.ts";
 import { approveBlock, liveBlocks } from "./security_log.ts";
+import { probeRateLimits } from "./ratelimit_probe.ts";
 import { memorySnapshot, rateLimits, usageLedger } from "../tools/memory_data.ts";
 import { backend } from "./acp_backend.ts";
 import { listSessions, sessionMessages } from "./sessions.ts";
 import { providerAuth } from "./auth_status.ts";
 import { cloneRepo, setWorkspace, workspaceInfo } from "./workspace.ts";
-import { applyEnv, load as loadSettings, setAsksage, setKey, setUsername } from "./settings_store.ts";
+import { applyEnv, load as loadSettings, setAsksage, setKey, setRateLimitProbe, setUsername } from "./settings_store.ts";
 import { asksageConfig, listDatasets, listPersonas, monthlyTokens, scanPersona, wrapPersona } from "./asksage.ts";
 import { listSkills } from "./skills_data.ts";
 import { headroomStatus, setHeadroomEnabled, startHeadroom } from "./headroom.ts";
@@ -105,6 +106,12 @@ const server = Bun.serve({
       // Light, fast re-read of the provider rate-limit budget (omp's agent.db).
       // Used by the front-end's manual refresh + 5-minute auto-poll.
       if (p === "/api/budget") return json({ ok: true, data: rateLimits() });
+      // P10.3: live rate-limit probe for API-KEY providers (opt-in). GET returns probed limits
+      // (cached 5 min; [] when off); POST {enabled} flips the opt-in.
+      if (p === "/api/ratelimits") {
+        if (req.method === "POST") { const b = await req.json(); return json({ ok: true, data: setRateLimitProbe(!!b.enabled) }); }
+        return json({ ok: true, data: { enabled: !!loadSettings().rateLimitProbe, limits: await probeRateLimits(url.searchParams.get("force") === "1") } });
+      }
       // P10.2: cross-model usage & cost ledger (per-model totals + estimated cache savings).
       if (p === "/api/usage") return json({ ok: true, data: usageLedger() });
       if (p === "/api/health") return json({ ok: true });

--- a/desktop/ratelimit_probe.test.ts
+++ b/desktop/ratelimit_probe.test.ts
@@ -1,0 +1,45 @@
+// desktop/ratelimit_probe.test.ts — P10.3 pure header-parser coverage. The live fetch needs a real
+// key to exercise; these lock the parsing/math that turns provider headers into the budget shape.
+import { expect, test } from "bun:test";
+import { parseAnthropic, parseDuration, parseOpenAI } from "./ratelimit_probe.ts";
+
+test("parseAnthropic: token limit/remaining + RFC3339 reset → used fraction", () => {
+  const h = new Headers({
+    "anthropic-ratelimit-tokens-limit": "100000",
+    "anthropic-ratelimit-tokens-remaining": "25000",
+    "anthropic-ratelimit-tokens-reset": "2026-06-20T12:00:00Z",
+  });
+  const r = parseAnthropic(h)!;
+  expect(r.provider).toBe("anthropic");
+  expect(r.limit).toBe(100000);
+  expect(r.remaining).toBe(25000);
+  expect(r.used).toBeCloseTo(0.75, 5);
+  expect(r.resetsAt).toBe(Date.parse("2026-06-20T12:00:00Z"));
+});
+
+test("parseAnthropic: missing headers → null (fails soft)", () => {
+  expect(parseAnthropic(new Headers())).toBeNull();
+  expect(parseAnthropic(new Headers({ "anthropic-ratelimit-tokens-limit": "0", "anthropic-ratelimit-tokens-remaining": "0" }))).toBeNull();
+});
+
+test("parseOpenAI: token headers + duration reset → absolute time", () => {
+  const now = 1_000_000;
+  const r = parseOpenAI(new Headers({
+    "x-ratelimit-limit-tokens": "200000",
+    "x-ratelimit-remaining-tokens": "180000",
+    "x-ratelimit-reset-tokens": "6m0s",
+  }), now)!;
+  expect(r.provider).toBe("openai");
+  expect(r.used).toBeCloseTo(0.1, 5);
+  expect(r.resetsAt).toBe(now + 6 * 60_000);
+});
+
+test("parseDuration: ms/s/m/h + compound + invalid", () => {
+  expect(parseDuration("100ms", 0)).toBe(100);
+  expect(parseDuration("1.5s", 0)).toBe(1500);
+  expect(parseDuration("6m0s", 0)).toBe(360_000);
+  expect(parseDuration("1h2m", 0)).toBe(3_600_000 + 120_000);
+  expect(parseDuration("", 0)).toBeNull();
+  expect(parseDuration(null, 0)).toBeNull();
+  expect(parseDuration("garbage", 0)).toBeNull();
+});

--- a/desktop/ratelimit_probe.ts
+++ b/desktop/ratelimit_probe.ts
@@ -1,0 +1,94 @@
+// desktop/ratelimit_probe.ts — P10.3: live rate-limit probe for API-KEY providers (ADR-0011).
+//
+// The user's OAuth 5-hour window has NO rate-limit header (already shown from omp's agent.db).
+// For providers configured with an API KEY, the real remaining budget rides response rate-limit
+// headers — Anthropic `anthropic-ratelimit-*`, OpenAI `x-ratelimit-*`. This makes ONE minimal
+// request per keyed provider (OPT-IN: it costs a token or two), caches for 5 min, and surfaces
+// "remaining / resets-at". Fails soft: any error → that provider is simply omitted. The pure
+// header parsers below are unit-tested; the live fetch only wraps them.
+
+import { load } from "./settings_store.ts";
+
+export interface ProbedLimit {
+  provider: string;
+  label: string;
+  used: number; // 0..1 (1 - remaining/limit), so it slots into the existing budget UI
+  remaining: number;
+  limit: number;
+  resetsAt: number | null; // absolute epoch-ms, or null
+}
+
+// ── pure parsers (the verifiable core) ───────────────────────────────────────────
+/** Anthropic resets are RFC3339 timestamps; tokens are the usually-binding axis. */
+export function parseAnthropic(h: Headers): ProbedLimit | null {
+  const limit = Number(h.get("anthropic-ratelimit-tokens-limit"));
+  const remaining = Number(h.get("anthropic-ratelimit-tokens-remaining"));
+  if (!Number.isFinite(limit) || !Number.isFinite(remaining) || limit <= 0) return null;
+  const reset = h.get("anthropic-ratelimit-tokens-reset");
+  const resetsAt = reset ? Date.parse(reset) || null : null;
+  return { provider: "anthropic", label: "Anthropic API", limit, remaining, used: clamp01(1 - remaining / limit), resetsAt };
+}
+
+/** OpenAI resets are durations like "6m0s" / "1.5s" / "100ms" — converted to an absolute ms time. */
+export function parseOpenAI(h: Headers, nowMs?: number): ProbedLimit | null {
+  const limit = Number(h.get("x-ratelimit-limit-tokens"));
+  const remaining = Number(h.get("x-ratelimit-remaining-tokens"));
+  if (!Number.isFinite(limit) || !Number.isFinite(remaining) || limit <= 0) return null;
+  return { provider: "openai", label: "OpenAI API", limit, remaining, used: clamp01(1 - remaining / limit), resetsAt: parseDuration(h.get("x-ratelimit-reset-tokens"), nowMs) };
+}
+
+/** Parse an OpenAI-style duration ("6m0s", "1.5s", "100ms", "1h2m") → absolute epoch-ms (or null). */
+export function parseDuration(d: string | null, nowMs?: number): number | null {
+  if (!d) return null;
+  let ms = 0, matched = false;
+  for (const m of d.matchAll(/([\d.]+)(ms|s|m|h|d)/g)) {
+    matched = true;
+    const v = Number(m[1]);
+    ms += m[2] === "ms" ? v : m[2] === "s" ? v * 1e3 : m[2] === "m" ? v * 6e4 : m[2] === "h" ? v * 36e5 : v * 864e5;
+  }
+  return matched ? (nowMs ?? Date.now()) + ms : null;
+}
+
+const clamp01 = (n: number): number => Math.max(0, Math.min(1, n));
+
+// ── live probes (minimal request; reads headers regardless of body) ──────────────
+const AV = "2023-06-01";
+async function probeAnthropic(key: string): Promise<ProbedLimit | null> {
+  try {
+    const r = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: { "x-api-key": key, "anthropic-version": AV, "content-type": "application/json" },
+      body: JSON.stringify({ model: "claude-haiku-4-5", max_tokens: 1, messages: [{ role: "user", content: "." }] }),
+      signal: AbortSignal.timeout(8000),
+    });
+    return parseAnthropic(r.headers);
+  } catch { return null; }
+}
+async function probeOpenAI(key: string): Promise<ProbedLimit | null> {
+  try {
+    const r = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: { authorization: `Bearer ${key}`, "content-type": "application/json" },
+      body: JSON.stringify({ model: "gpt-4o-mini", max_tokens: 1, messages: [{ role: "user", content: "." }] }),
+      signal: AbortSignal.timeout(8000),
+    });
+    return parseOpenAI(r.headers);
+  } catch { return null; }
+}
+
+let cache: { at: number; data: ProbedLimit[] } | null = null;
+const TTL = 5 * 60_000;
+
+/** Probe each keyed provider (when the opt-in is on), cached for 5 min. [] when off/no keys. */
+export async function probeRateLimits(force = false): Promise<ProbedLimit[]> {
+  const s = load();
+  if (!s.rateLimitProbe) { cache = null; return []; } // off → no live calls, ever
+  if (!force && cache && Date.now() - cache.at < TTL) return cache.data;
+  const keys = s.keys ?? {};
+  const tasks: Promise<ProbedLimit | null>[] = [];
+  if (keys.ANTHROPIC_API_KEY) tasks.push(probeAnthropic(keys.ANTHROPIC_API_KEY));
+  if (keys.OPENAI_API_KEY) tasks.push(probeOpenAI(keys.OPENAI_API_KEY));
+  const data = (await Promise.all(tasks)).filter((x): x is ProbedLimit => !!x);
+  cache = { at: Date.now(), data };
+  return data;
+}

--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -39,6 +39,8 @@ const state = {
   lastOk: 0,
   streaming: false,
   lastPrompt: "" as string, // last user message — re-sent by an Approve & retry (ADR-0019 C)
+  probedLimits: [] as import("./bridge.ts").ProbedLimit[], // P10.3 live API-key rate limits
+  probeEnabled: false, // P10.3 opt-in state for the live rate-limit probe
 };
 const prettyModel = (v: string) => v.replace(/^anthropic\//, "");
 // Strip the redundant "· AskSage Gov" / "· Gov" suffix from a model's display name
@@ -1059,10 +1061,17 @@ function budgetBody(budgets: NonNullable<MemorySnapshot["budgets"]>): string {
     return `<div class="bgt${on ? " on" : ""}">${on ? `<span class="bgt-tag" data-tip="Provider for your current model">current model</span>` : ""}${
       gauge(b.label.replace(/^Claude /, ""), b.used, `<span style="color:var(--txt-4)">${esc(b.status)} · resets ${ageStr(b.resetsAt)}</span>`)}</div>`;
   }).join("");
+  // P10.3: live API-key rate-limit probes (opt-in) render as extra gauges, tagged so they're
+  // distinct from omp's subscription/OAuth windows above.
+  const probed = state.probedLimits.map((b) =>
+    `<div class="bgt${active(b.label) ? " on" : ""}"><span class="bgt-tag live" data-tip="Live from the provider's rate-limit headers (API key)">API key · live</span>${
+      gauge(b.label, b.used, `<span style="color:var(--txt-4)">${fmtNum(b.remaining)} left · resets ${ageStr(b.resetsAt)}</span>`)}</div>`).join("");
+  const probeToggle = `<label class="set-toggle bgt-probe"><input type="checkbox" id="ratelimitToggle" ${state.probeEnabled ? "checked" : ""}/>
+    <span>Live API-key probe ${state.probeEnabled ? "" : ""}<button class="info-dot" data-tip="Live rate-limit probe|For providers set with an API KEY (Anthropic / OpenAI), read the real remaining limit from response headers. Off by default — each check makes one tiny request (a token or two). Your OAuth 5-hour window is already shown above and has no header to probe.">${icon("info", 11)}</button></span></label>`;
   return `<div class="bgt-head">
       <button class="btn-mini" data-budget-refresh data-tip="Re-check provider usage now">${icon("refresh", 13)} Refresh</button>
       <span class="bgt-note">auto every 5 min</span>
-    </div>${rows}`;
+    </div>${rows}${probed}${probeToggle}`;
 }
 
 const RICHTIP_DUCKDB = `<div class="rt-h">${icon("shield", 14)} Where this is stored</div>
@@ -1165,6 +1174,9 @@ async function refreshBudget(manual = false): Promise<void> {
   const budgets = await bridge.budget();
   if (budgets && state.memory) state.memory.budgets = budgets;
   checkBudgetWarning(budgets);
+  // P10.3: live API-key rate-limit probe (no-op + [] unless the opt-in is on). force on manual.
+  const rl = await bridge.rateLimits(manual);
+  state.probedLimits = rl?.limits ?? []; state.probeEnabled = rl?.enabled ?? false;
   if (state.asksage?.configured) state.asksageTokens = await bridge.asksageTokens(); // gov usage on the same cadence
   if (state.inspectorTab === "memory" && !state.inspectorRail) renderInspector();
   renderStatus();
@@ -1694,6 +1706,17 @@ function wire(): void {
   // accordion toggles (delegated; flips OPEN + .open without a full re-render)
   $("#inspBody")!.addEventListener("click", (e) => {
     if ((e.target as HTMLElement).closest("[data-budget-refresh]")) { void refreshBudget(true); return; }
+    // P10.3: flip the live API-key rate-limit probe opt-in, then re-poll.
+    if ((e.target as HTMLElement).closest("#ratelimitToggle")) {
+      const on = ($("#ratelimitToggle") as HTMLInputElement)?.checked ?? false;
+      void (async () => {
+        await bridge.setRateLimitProbe(on);
+        state.probeEnabled = on;
+        showToast({ title: on ? "Live probe on" : "Live probe off", desc: on ? "Reading API-key rate-limit headers every 5 min (one tiny request per keyed provider)." : "Stopped probing provider rate-limit headers.", actions: [{ label: "OK" }], timeout: 3000 });
+        await refreshBudget(true);
+      })();
+      return;
+    }
     const head = (e.target as HTMLElement).closest("[data-acc-toggle]") as HTMLElement | null;
     if (head) { const k = head.dataset.accToggle!; const acc = head.closest(".acc")!; const open = acc.classList.toggle("open"); open ? OPEN.add(k) : OPEN.delete(k); return; }
     // Approve & retry: the audited fail-closed override for one live gate block (ADR-0019 C).

--- a/desktop/renderer/bridge.ts
+++ b/desktop/renderer/bridge.ts
@@ -29,6 +29,9 @@ export interface MemorySnapshot {
     gate: { promoted: number; blocked: number };
   };
 }
+
+// P10.3: a live rate-limit reading probed from an API-key provider's response headers.
+export interface ProbedLimit { provider: string; label: string; used: number; remaining: number; limit: number; resetsAt: number | null }
 // P10.2 cross-model usage & cost ledger
 export interface ModelUsage {
   model: string; provider: string; source: "subscription" | "local";
@@ -104,6 +107,10 @@ export interface LucidBridge {
   securityApprove(id: string): Promise<BlockRecord | null>;
   memory(): Promise<MemorySnapshot | null>;
   budget(): Promise<{ label: string; used: number; status: string; resetsAt: number | null }[] | null>;
+  // P10.3: live API-key rate-limit probe (opt-in). `rateLimits()` returns probed limits ([] when off);
+  // `setRateLimitProbe` flips the opt-in.
+  rateLimits(force?: boolean): Promise<{ enabled: boolean; limits: ProbedLimit[] } | null>;
+  setRateLimitProbe(enabled: boolean): Promise<unknown>;
   usage(): Promise<UsageLedger | null>;
   sendPrompt(text: string, onEvent: (e: ChatEvent) => void): Promise<void>;
   config(): Promise<ConfigOption[]>;
@@ -224,6 +231,8 @@ export const bridge: LucidBridge = {
   securityApprove: (id) => post("/api/security/approve", { id }),
   memory: () => getData("/api/memory"),
   budget: () => getData("/api/budget"),
+  rateLimits: (force) => getData(`/api/ratelimits${force ? "?force=1" : ""}`),
+  setRateLimitProbe: (enabled) => post("/api/ratelimits", { enabled }),
   usage: () => getData("/api/usage"),
   sendPrompt: streamChat,
   config: async () => (await getData("/api/config")) ?? FALLBACK_CONFIG,

--- a/desktop/renderer/styles.css
+++ b/desktop/renderer/styles.css
@@ -536,6 +536,9 @@ body.resizing .sidebar,body.resizing .inspector{transition:none}
   border-radius:9px;padding:8px 8px 4px;margin:0 -2px 6px}
 .bgt-tag{display:inline-block;font-size:9.5px;font-weight:700;letter-spacing:.4px;text-transform:uppercase;
   color:var(--accent-2);background:rgba(198,75,214,.16);border-radius:5px;padding:1px 6px;margin-bottom:5px}
+.bgt-tag.live{color:var(--cyan);background:var(--cyan-dim)}
+.bgt-probe{margin-top:10px;padding-top:9px;border-top:1px solid var(--line-soft);font-size:11.5px}
+.bgt-probe .info-dot{vertical-align:-1px}
 .statusbar .seg.seg-btn{cursor:pointer;border-radius:6px;padding:0 5px;
   transition:background var(--t-fast) var(--ease),color var(--t-fast) var(--ease)}
 .statusbar .seg.seg-btn:hover{background:var(--bg-3);color:var(--txt-2)}

--- a/desktop/settings_store.ts
+++ b/desktop/settings_store.ts
@@ -38,6 +38,9 @@ export interface GuiSettings {
   asksagePersona?: string;
   // headroom token-compression proxy (opt-in, on-device). See ADR-0008.
   headroomEnabled?: boolean;
+  // P10.3: opt-in live rate-limit probe for API-KEY providers (Anthropic/OpenAI). OFF by default —
+  // it makes a tiny request per provider to read the rate-limit headers, which costs a token or two.
+  rateLimitProbe?: boolean;
   // Personalization knowledge graph (ADR-0010, P9.x): opt-in, encrypted-at-rest.
   // OFF by default - no user-fact distillation, recall, or store until enabled.
   personalizationEnabled?: boolean;
@@ -66,6 +69,9 @@ export function personalVaultDir(): string { return join(homedir(), ".omp", "luc
 export function personalCuiArchiveDir(): string { return join(homedir(), ".omp", "lucid-cui-archive"); }
 export function setPersonalization(enabled: boolean): GuiSettings {
   const s = load(); s.personalizationEnabled = enabled; save(s); return s;
+}
+export function setRateLimitProbe(enabled: boolean): GuiSettings {
+  const s = load(); s.rateLimitProbe = enabled; save(s); return s;
 }
 export function setPersonalScope(scope: GuiSettings["personalScope"]): GuiSettings {
   const s = load(); s.personalScope = scope; save(s); return s;


### PR DESCRIPTION
Completes P10.3: opt-in live rate-limit probe for API-key providers (Anthropic/OpenAI headers → remaining/resets-at). Pure parsers unit-tested, surfaced in the budget panel with an in-panel toggle. Off by default. harness 369 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)