### PR TITLE
feat(dev): developer-mode Logs view — ADR-0009 Phase D (scoped)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -614,9 +614,10 @@ collapsed on boot (`toggleSidebar(true)` + `setInspectorRail(true)`) for a calme
 ## ADR-0009 — Memory continuity, knowledge-graph export, and developer observability (roadmap)
 
 **Date:** 2026-06-19
-**Status:** Accepted as a roadmap. Phases P8.1–P8.4 are **Proposed** — each is built in
-its own future increment with its own confirming ADR (or an addendum here) when the
-frozen-contract changes land.
+**Status:** Accepted as a roadmap. **Phase C** superseded by ADR-0013 (vault export, built).
+**Phase D BUILT** (scoped — Logs view; transcripts + raw-reveal deferred, see Phase D below).
+**Phase A** (cross-session memory recall) and **Phase B** (traceability) remain **Proposed** and are
+assigned to contributor alexander-blackwell (issues #11 / #12). Each lands in its own increment.
 **Context increment:** P8.0 (planning only — no functional code shipped this session).
 
 ### Context
@@ -687,15 +688,18 @@ impacts:* **no migration** for the sanitized path (reuses `semantic_*`, `archive
 `export_events`); reuse `safe_export_created`; raw path shares `raw_revealed` (Phase D). New
 `harness/export/vault_export.ts`; `POST /api/vault/export` in `dev.ts`.
 
-**Phase D — `P8.4-dev-logging` (Developer-mode admin view).** Satisfies #4. Depends on B.
-A Settings-gated, read-only view of telemetry, run lineage, and per-turn transcripts, with the
-audited raw-reveal. Add `developerMode?: boolean` to `settings_store.ts` (+ `setDeveloperMode`)
-and a Settings checkbox copying `headroomToggle`; when ON, reveal a new **Logs** rail tab.
-Surfaces (READ_ONLY, gated server-side on `developerMode`): `telemetry_events` stream,
-`getRunTree` lineage, `turns` transcripts (sanitized). Endpoints `GET
-/api/dev/{telemetry,lineage,turns}` and `POST /api/dev/reveal` (the audited raw path).
-*Frozen-contract impacts:* no migration; `raw_revealed` (shared with C); recommended
-`developer_mode_toggled` (flipping the gate's posture is auditable).
+**Phase D — `P8.4-dev-logging` (Developer-mode admin view). BUILT (scoped).** Satisfies #4.
+`developerMode?: boolean` + `setDeveloperMode` in `settings_store.ts`; a Settings toggle reveals a
+read-only **Logs** rail panel (`data-rail="dev"`, third inspector view). `GET /api/dev` is gated
+server-side on `developerMode` (returns `{enabled:false, snapshot:null}` when off) and surfaces, all
+READ_ONLY + metadata-only: the **telemetry_events stream** (new `telemetryStream` view), **run
+lineage** (`activeRuns`), the **gate block audit** (the ADR-0019-C `security_log`), and the **export
+audit**. `POST /api/dev {enabled}` flips the mode.
+*Deferred (honest scope):* (1) **per-turn transcripts** depend on Phase B (traceability — open
+ticket #12, not built), so the transcript surface is omitted, not faked; (2) the **audited
+raw-reveal** (`POST /api/dev/reveal` + `raw_revealed`) is a deliberate fail-closed weakening best
+done as its own careful pass — left for a follow-up. *Frozen-contract impacts of what shipped:* a
+new additive read-only dashboard view (`telemetry_stream`); no migration; no new EventName.
 
 ### Recommended build order
 
@@ -1576,3 +1580,33 @@ optionally overrides what it already did.
 
 - Fail-closed law intact; scanner clean-corpus still zero false-positives; adversarial spoofs still
   caught; keystone #2 (suspicious can't auto-promote) unaffected. harness 369 pass, scanner pytest green.
+
+-----
+
+## ADR-0020 — MCP Enterprise-Managed Auth Hub
+
+**Date:** 2026-06-20
+**Status:** Accepted
+**Context increment:** Integration Phase
+
+### Decision
+
+We are building a centralized **MCP Server Connection Hub** into the IDE to automatically authenticate against enterprise MCP servers (such as internal tools or commercial SaaS) using the Zero-Touch, Identity-Provider-driven authorization model. 
+This will support **Okta, Entra ID (Azure AD), and GCP Workload Identity Federation (WIF)** natively.
+
+1. **Pop-out UI Behavior:** Advanced configurations will "pop out... into the main window" as a full-height overlay panel that slides over the main chat/workspace area when an MCP connector is clicked in the Settings sidebar. This gives maximum real estate for forms, logs, and token status without cluttering the narrow sidebar.
+2. **Token Storage Security:** OAuth Access Tokens will be stored using an **OS-level secure credential vault interface** via Electron's `safeStorage`. We have added a roadmap path for integrating Post-Quantum Cryptography (PQC) algorithms (e.g., NIST ML-KEM/Kyber) once they are standardized by OS vendors.
+3. **OAuth Redirect URIs:** We will use an **Ephemeral Localhost Server with PKCE** for handling OAuth redirects, which adheres to IETF RFC 8252 (OAuth 2.0 for Native Apps) as the most secure and auditable standard for desktop applications.
+4. **GCP WIF Profiles:** Because most enterprises use Entra ID, Yubikeys, or PIV tokens, we will configure GCP WIF to directly trust the Entra ID OIDC provider. The IDE will perform the Entra ID flow and exchange the resulting Entra ID token directly with GCP STS for a GCP access token, avoiding the need for standalone Google credentials.
+5. **Terraform Scope:** We will provide Terraform snippets to aid in configuring the Identity Provider side (Okta, Entra ID, GCP WIF pool), accompanied by README links to official docs for configuring the actual MCP server side.
+
+### Why
+
+Anthropic's Enterprise-Managed Auth demonstrated the power of zero-touch IdP integration for MCP. By managing auth centrally rather than requiring individual user API keys or personal access tokens, we maintain strong governance, auditability, and ease of use in enterprise deployments.
+
+### Consequences
+
+- A new `desktop/mcp_hub.ts` backend to handle the PKCE flows, localhost redirect catchers, and GCP STS exchanges.
+- Electron's `safeStorage` dependency for token persistence.
+- A new UI overlay system integrated into `desktop/renderer/app.ts` that interacts seamlessly with the existing `settingsShell()`.
+- A set of Terraform modules (`terraform/mcp_auth/`) included in the repo for deploying the required IdP configuration.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -934,3 +934,15 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
 - **stubbed:** live header correctness needs a real Anthropic/OpenAI key to fully validate (parsers
   tested, gating + graceful-empty verified). Probe model ids (haiku/gpt-4o-mini) are sensible defaults.
 - **next:** ADR-0009 Phase D — developer-mode logging view.
+
+## P8.4 / Phase D: developer-mode Logs view (ADR-0009 Phase D, scoped)
+- **shipped:** a Settings "Developer mode" toggle reveals a read-only Logs rail panel (third
+  inspector view). GET /api/dev (gated server-side on developerMode) surfaces, metadata-only +
+  READ_ONLY: telemetry_events stream (new telemetryStream dashboard view), run lineage (activeRuns),
+  the gate block audit (ADR-0019-C security_log), and the export audit. settings_store
+  developerMode/setDeveloperMode; bridge dev()/setDeveloperMode; new desktop/ratelimit-free devHtml
+  renderer + rail button (hidden until on). Verified live: off→null, toggle reveals the rail +
+  renders the 4 accordions. harness 369 pass (telemetry view + count test updated), tsc+bundle clean.
+- **stubbed:** per-turn transcripts (depend on Phase B / alex's #12 — omitted, not faked); the
+  audited raw-reveal (POST /api/dev/reveal + raw_revealed) left as a careful follow-up.
+- **next:** ADR-0009 Phase A/B (alex); optional Phase D raw-reveal; ADR-0015 PQC when FIPS requires.

--- a/desktop/dev.ts
+++ b/desktop/dev.ts
@@ -9,7 +9,7 @@
 //   bun run desktop:web        # http://localhost:5319
 
 import { join } from "node:path";
-import { securitySnapshot } from "../tools/web/data.ts";
+import { devSnapshot, securitySnapshot } from "../tools/web/data.ts";
 import { approveBlock, liveBlocks } from "./security_log.ts";
 import { probeRateLimits } from "./ratelimit_probe.ts";
 import { memorySnapshot, rateLimits, usageLedger } from "../tools/memory_data.ts";
@@ -17,7 +17,7 @@ import { backend } from "./acp_backend.ts";
 import { listSessions, sessionMessages } from "./sessions.ts";
 import { providerAuth } from "./auth_status.ts";
 import { cloneRepo, setWorkspace, workspaceInfo } from "./workspace.ts";
-import { applyEnv, load as loadSettings, setAsksage, setKey, setRateLimitProbe, setUsername } from "./settings_store.ts";
+import { applyEnv, load as loadSettings, setAsksage, setDeveloperMode, setKey, setRateLimitProbe, setUsername } from "./settings_store.ts";
 import { asksageConfig, listDatasets, listPersonas, monthlyTokens, scanPersona, wrapPersona } from "./asksage.ts";
 import { listSkills } from "./skills_data.ts";
 import { headroomStatus, setHeadroomEnabled, startHeadroom } from "./headroom.ts";
@@ -103,6 +103,13 @@ const server = Bun.serve({
       // Audited fail-closed override: release one quarantined call (ADR-0019 C).
       if (p === "/api/security/approve" && req.method === "POST") { const b = await req.json(); return json({ ok: true, data: approveBlock(String(b.id ?? "")) }); }
       if (p === "/api/memory") return json({ ok: true, data: await memorySnapshot() });
+      // ADR-0009 Phase D: developer-mode logging view. GET is gated server-side on developerMode
+      // (returns null when off); POST {enabled} flips the mode. Read-only, metadata-only.
+      if (p === "/api/dev") {
+        if (req.method === "POST") { const b = await req.json(); return json({ ok: true, data: setDeveloperMode(!!b.enabled) }); }
+        if (!loadSettings().developerMode) return json({ ok: true, data: { enabled: false, snapshot: null, blocks: { quarantined: [], approved: [], total: 0 } } });
+        return json({ ok: true, data: { enabled: true, snapshot: await devSnapshot(), blocks: liveBlocks() } });
+      }
       // Light, fast re-read of the provider rate-limit budget (omp's agent.db).
       // Used by the front-end's manual refresh + 5-minute auto-poll.
       if (p === "/api/budget") return json({ ok: true, data: rateLimits() });

--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -14,7 +14,7 @@ import { type GraphHandle, kindLabel, mountGraph } from "./graph.ts";
 import type { PersonalGraphData } from "./bridge.ts";
 import { type Action, attachRichTip, createPalette, initTooltips, popover, showToast } from "./ui.ts";
 
-type Tab = "security" | "memory";
+type Tab = "security" | "memory" | "dev";
 const state = {
   inspectorTab: "security" as Tab,
   sidebarCollapsed: false,
@@ -41,6 +41,8 @@ const state = {
   lastPrompt: "" as string, // last user message — re-sent by an Approve & retry (ADR-0019 C)
   probedLimits: [] as import("./bridge.ts").ProbedLimit[], // P10.3 live API-key rate limits
   probeEnabled: false, // P10.3 opt-in state for the live rate-limit probe
+  developerMode: false, // ADR-0009 Phase D
+  dev: null as import("./bridge.ts").DevView | null, // ADR-0009 Phase D logs snapshot
 };
 const prettyModel = (v: string) => v.replace(/^anthropic\//, "");
 // Strip the redundant "· AskSage Gov" / "· Gov" suffix from a model's display name
@@ -105,6 +107,7 @@ function buildShell(): void {
         <button class="rail-btn" data-rail="memory" data-tip="Memory & context|Context window, prompt-cache savings, semantic memory" data-tip-icon="brain">${icon("brain", 20)}</button>
         <button class="rail-btn" data-rail="runs" data-tip="Runs|Provenance lineage" data-tip-icon="runs">${icon("runs", 20)}</button>
         <button class="rail-btn" data-rail="knowledge" data-tip="Knowledge graph|Your private, encrypted personalization graph - nodes, edges, drill-down" data-tip-icon="graph">${icon("graph", 20)}</button>
+        <button class="rail-btn" id="railLogs" data-rail="dev" hidden data-tip="Logs · Developer|Read-only telemetry, run lineage, and audit trails. Enabled in Settings → Developer mode." data-tip-icon="layout">${icon("layout", 20)}</button>
         <div class="spacer"></div>
         <button class="rail-btn" id="railCmd" data-tip="Commands|Ctrl / ⌘ K" data-tip-icon="command">${icon("command", 20)}</button>
         <button class="rail-btn" data-rail="settings" data-tip="Settings" data-tip-icon="sliders">${icon("sliders", 20)}</button>
@@ -472,6 +475,14 @@ function inspSkeleton(): string {
     + `<div class="skel-group">${Array.from({ length: 5 }, () => `<div class="skel skel-row"></div>`).join("")}</div>`;
 }
 function renderInspector(): void {
+  if (state.inspectorTab === "dev") {
+    const html = devHtml(state.dev);
+    const hash = "dev" + html.length + html.slice(0, 80);
+    if (hash === lastInspHash) return;
+    lastInspHash = hash;
+    const body = $("#inspBody")!; const top = body.scrollTop; body.innerHTML = html; body.scrollTop = top;
+    return;
+  }
   const snap = state.inspectorTab === "security" ? state.security : state.memory;
   // First-load only: no successful poll yet AND no snapshot for this tab.
   if (state.lastOk === 0 && snap === null) {
@@ -639,7 +650,10 @@ function secCompression(hr: import("./bridge.ts").HeadroomStatus | null): string
         <span><b>Compress context with headroom</b> - fewer tokens before they reach the model. ${hr.running ? `<span class="abadge ok">running · :${hr.port}</span>` : ""}</span></label>
       <div class="set-note">${icon("info", 12)} Runs entirely on your machine (${esc(hr.version ?? "installed")}). Request-routing + a gov-deployment security review are next - see ADR-0008.</div>`
     : `<div class="set-note">${icon("info", 12)} Optional: install <b>headroom</b> to compress context on-device (60–95% fewer tokens). Run <code>${esc(hr?.installHint ?? "pip install headroom-ai[proxy]")}</code>, then this toggle appears.</div>`;
-  return setCard("compression", "Token compression", "headroom · on-device · opt-in", body, true);
+  // ADR-0009 Phase D: Developer mode toggle (reveals the read-only Logs rail panel).
+  const dev = `<label class="set-toggle" style="margin-top:12px;border-top:1px solid var(--line-soft);padding-top:12px"><input type="checkbox" id="devModeToggle" ${state.developerMode ? "checked" : ""}/>
+    <span><b>Developer mode</b> - reveal a read-only <b>Logs</b> panel in the rail: telemetry stream, run lineage, and audit trails (metadata only).</span></label>`;
+  return setCard("compression", "Token compression & developer", "on-device · opt-in", body + dev, true);
 }
 function secOthers(auth: import("./bridge.ts").AuthStatus | null): string {
   return setCard("others", "More providers", "", (auth?.others ?? []).map(provCard).join("") || `<div class="empty">none</div>`, true);
@@ -969,6 +983,39 @@ function securityHtml(d: SecuritySnapshot | null): string {
     table([{ key: "kind", label: "kind" }, { key: "mode", label: "mode" }, { key: "sandbox_profile", label: "sandbox" }, { key: "status", label: "status" }], runs),
     OPEN.has("sec.runs"));
   return h;
+}
+
+// ── ADR-0009 Phase D: developer Logs view (read-only; metadata only) ──────────────
+function devHtml(d: import("./bridge.ts").DevView | null): string {
+  let h = `<div class="sec-intro"><div class="sec-intro-h"><span class="sec-pulse">${icon("layout", 17)}</span><b>Developer logs</b></div>
+    <div class="sec-intro-d">Read-only telemetry, run lineage, and audit trails from this machine - metadata only, no prompt or file content. Per-turn transcripts arrive with ADR-0009 Phase B.</div></div>`;
+  if (!d || !d.enabled) { h += `<div class="empty">Developer mode is off. Turn it on in <b>Settings → Developer mode</b> to see the telemetry stream, run lineage, and the audit trail.</div>`; return h; }
+  const tel = d.snapshot?.telemetry ?? [], runs = d.snapshot?.runs ?? [], exp = d.snapshot?.exports ?? [], blk = d.blocks?.quarantined ?? [];
+  h += chips([
+    { cls: "f", n: tel.length, l: "events" },
+    { cls: "g", n: runs.length, l: "runs" },
+    { cls: "q", n: blk.length, l: "live blocks" },
+    { cls: "a", n: exp.length, l: "exports" },
+  ]);
+  h += accordion("dev.telemetry", "Telemetry stream", "recent · metadata only",
+    table([{ key: "event", label: "event" }, { key: "run_id", label: "run", mono: true }, { key: "session_id", label: "session", mono: true }, { key: "created_at", label: "at", mono: true }], tel),
+    true, String(tel.length));
+  h += accordion("dev.runs", "Run lineage", "provenance",
+    table([{ key: "run_id", label: "run", mono: true }, { key: "kind", label: "kind" }, { key: "mode", label: "mode" }, { key: "sandbox_profile", label: "sandbox" }, { key: "status", label: "status" }], runs),
+    OPEN.has("dev.runs"), String(runs.length));
+  h += accordion("dev.blocks", "Gate block audit", "this session",
+    table([{ key: "tool", label: "tool" }, { key: "severity", label: "sev", mono: true }, { key: "reason", label: "reason" }, { key: "status", label: "status", pill: true }], blk as unknown as Record<string, unknown>[]),
+    OPEN.has("dev.blocks"), String(blk.length));
+  h += accordion("dev.exports", "Export audit", "what left, sanitized",
+    table([{ key: "export_type", label: "type" }, { key: "sanitization_status", label: "sanitized" }, { key: "reviewer", label: "by" }], exp),
+    OPEN.has("dev.exports"));
+  return h;
+}
+async function loadDev(): Promise<void> {
+  state.dev = await bridge.dev();
+  state.developerMode = state.dev?.enabled ?? false;
+  const btn = $("#railLogs"); if (btn) (btn as HTMLElement).hidden = !state.developerMode;
+  if (state.inspectorTab === "dev") { lastInspHash = ""; renderInspector(); }
 }
 
 function memoryHtml(d: MemorySnapshot | null): string {
@@ -1377,6 +1424,7 @@ function wire(): void {
     const r = (b as HTMLElement).dataset.rail!;
     if (r !== "knowledge") closeKnowledge();
     if (r === "security" || r === "memory") focusInspector(r);
+    else if (r === "dev") { focusInspector("dev"); void loadDev(); } // ADR-0009 Phase D
     else if (r === "chat") { closeSettings(); $("#input")?.focus(); $$(".rail-btn").forEach((x) => x.classList.toggle("active", x === b)); }
     else if (r === "runs") { focusInspector("security"); $("#inspBody")?.querySelector('[data-acc="sec.runs"] .acc-head')?.dispatchEvent(new Event("click", { bubbles: true })); }
     else if (r === "settings") openSettings();
@@ -1575,6 +1623,14 @@ function wire(): void {
       const st = await bridge.setHeadroom(enabled);
       showToast({ title: enabled ? "Compression on" : "Compression off", desc: enabled ? (st?.running ? `headroom proxy running on :${st.port}.` : "headroom enabled - proxy will start.") : "headroom proxy stopped.", actions: [{ label: "OK" }], timeout: 2800 });
       void renderSettings();
+      return;
+    }
+    // ADR-0009 Phase D: Developer mode → reveal/hide the Logs rail panel.
+    if (t.closest("#devModeToggle")) {
+      const enabled = ($("#devModeToggle", $("#setBody")!) as HTMLInputElement)?.checked ?? false;
+      await bridge.setDeveloperMode(enabled);
+      await loadDev();
+      showToast({ title: enabled ? "Developer mode on" : "Developer mode off", desc: enabled ? "A read-only Logs panel is now in the rail (telemetry, lineage, audit)." : "The Logs panel is hidden.", actions: [{ label: "OK" }], timeout: 3000 });
       return;
     }
     // ── Personalization (ADR-0010/0012) ──
@@ -2170,6 +2226,7 @@ void loadConfig().then(renderStatus);
 void loadWorkspace();
 void loadAsksage();
 void loadSkills();
+void loadDev(); // ADR-0009 Phase D: reveal the Logs rail panel if developer mode is on
 void bridge.getSettings().then((s) => { // your saved name → the "You" label on your messages
   if (s?.username) { state.username = s.username; $$(".msg.user .who").forEach((w) => { w.textContent = s.username!; }); }
 });

--- a/desktop/renderer/bridge.ts
+++ b/desktop/renderer/bridge.ts
@@ -32,6 +32,13 @@ export interface MemorySnapshot {
 
 // P10.3: a live rate-limit reading probed from an API-key provider's response headers.
 export interface ProbedLimit { provider: string; label: string; used: number; remaining: number; limit: number; resetsAt: number | null }
+
+// ADR-0009 Phase D: read-only developer Logs view (gated on Developer mode).
+export interface DevView {
+  enabled: boolean;
+  snapshot: { telemetry: any[]; runs: any[]; exports: any[] } | null;
+  blocks: { quarantined: BlockRecord[]; approved: BlockRecord[]; total: number };
+}
 // P10.2 cross-model usage & cost ledger
 export interface ModelUsage {
   model: string; provider: string; source: "subscription" | "local";
@@ -111,6 +118,9 @@ export interface LucidBridge {
   // `setRateLimitProbe` flips the opt-in.
   rateLimits(force?: boolean): Promise<{ enabled: boolean; limits: ProbedLimit[] } | null>;
   setRateLimitProbe(enabled: boolean): Promise<unknown>;
+  // ADR-0009 Phase D: developer Logs view + its opt-in toggle.
+  dev(): Promise<DevView | null>;
+  setDeveloperMode(enabled: boolean): Promise<unknown>;
   usage(): Promise<UsageLedger | null>;
   sendPrompt(text: string, onEvent: (e: ChatEvent) => void): Promise<void>;
   config(): Promise<ConfigOption[]>;
@@ -233,6 +243,8 @@ export const bridge: LucidBridge = {
   budget: () => getData("/api/budget"),
   rateLimits: (force) => getData(`/api/ratelimits${force ? "?force=1" : ""}`),
   setRateLimitProbe: (enabled) => post("/api/ratelimits", { enabled }),
+  dev: () => getData("/api/dev"),
+  setDeveloperMode: (enabled) => post("/api/dev", { enabled }),
   usage: () => getData("/api/usage"),
   sendPrompt: streamChat,
   config: async () => (await getData("/api/config")) ?? FALLBACK_CONFIG,

--- a/desktop/settings_store.ts
+++ b/desktop/settings_store.ts
@@ -41,6 +41,9 @@ export interface GuiSettings {
   // P10.3: opt-in live rate-limit probe for API-KEY providers (Anthropic/OpenAI). OFF by default —
   // it makes a tiny request per provider to read the rate-limit headers, which costs a token or two.
   rateLimitProbe?: boolean;
+  // ADR-0009 Phase D: developer-mode logging view (telemetry + lineage + audit trails, read-only).
+  // OFF by default; flips on the "Logs" rail tab. Gated server-side too.
+  developerMode?: boolean;
   // Personalization knowledge graph (ADR-0010, P9.x): opt-in, encrypted-at-rest.
   // OFF by default - no user-fact distillation, recall, or store until enabled.
   personalizationEnabled?: boolean;
@@ -72,6 +75,9 @@ export function setPersonalization(enabled: boolean): GuiSettings {
 }
 export function setRateLimitProbe(enabled: boolean): GuiSettings {
   const s = load(); s.rateLimitProbe = enabled; save(s); return s;
+}
+export function setDeveloperMode(enabled: boolean): GuiSettings {
+  const s = load(); s.developerMode = enabled; save(s); return s;
 }
 export function setPersonalScope(scope: GuiSettings["personalScope"]): GuiSettings {
   const s = load(); s.personalScope = scope; save(s); return s;

--- a/harness/dashboards/dashboards.test.ts
+++ b/harness/dashboards/dashboards.test.ts
@@ -20,6 +20,7 @@ const VIEW_NAMES = [
   "memory_promotion_risk",
   "export_audit",
   "active_runs",
+  "telemetry_stream",
 ];
 
 function hasInvisible(s: string): boolean {
@@ -55,7 +56,7 @@ test("rowsToCsv writes a quoted header + rows; empty -> empty", () => {
   expect(rowsToCsv([{ a: 1, b: "x" }])).toBe('"a","b"\n"1","x"');
 });
 
-test("materialize writes all seven view files", async () => {
+test("materialize writes all eight view files", async () => {
   const out = join(dir, "data");
   const r = await materializeDashboards(db, out);
   expect(r.files.map((f) => f.name).sort()).toEqual([...VIEW_NAMES].sort());

--- a/harness/dashboards/views.ts
+++ b/harness/dashboards/views.ts
@@ -88,6 +88,15 @@ export function activeRuns(db: Db): Promise<Row[]> {
   );
 }
 
+/** ADR-0009 Phase D: the recent telemetry-event stream (metadata only — names + ids + time,
+ *  never content). Read-only; surfaced in the Developer-mode Logs view. */
+export function telemetryStream(db: Db): Promise<Row[]> {
+  return db.all(
+    `SELECT event, run_id, session_id, artifact_id, ts AS created_at
+     FROM telemetry_events ORDER BY ts DESC LIMIT 200`,
+  );
+}
+
 /** All dashboard views keyed by their output file basename. */
 export const DASHBOARD_VIEWS: Record<string, (db: Db) => Promise<Row[]>> = {
   findings_overview: findingsOverview,
@@ -97,4 +106,5 @@ export const DASHBOARD_VIEWS: Record<string, (db: Db) => Promise<Row[]>> = {
   memory_promotion_risk: memoryPromotionRisk,
   export_audit: exportAudit,
   active_runs: activeRuns,
+  telemetry_stream: telemetryStream,
 };

--- a/tools/web/data.ts
+++ b/tools/web/data.ts
@@ -72,4 +72,31 @@ export async function securitySnapshot(): Promise<SecuritySnapshot | null> {
   }
 }
 
+export interface DevSnapshot {
+  telemetry: Record<string, unknown>[];
+  runs: Record<string, unknown>[];
+  exports: Record<string, unknown>[];
+}
+
+/** ADR-0009 Phase D: read-only developer-logging snapshot from agent_obs.duckdb (null if absent).
+ *  Metadata only (the views never select raw content). The caller gates on Developer mode. */
+export async function devSnapshot(): Promise<DevSnapshot | null> {
+  const dbPath = join(import.meta.dir, "..", "..", "agent_obs.duckdb");
+  if (!existsSync(dbPath)) return null;
+  let ro: Awaited<ReturnType<typeof openReadOnly>> | undefined;
+  try {
+    ro = await openReadOnly(dbPath);
+    const { dbLike } = ro;
+    return {
+      telemetry: clean(await views.telemetryStream(dbLike)),
+      runs: clean(await views.activeRuns(dbLike)),
+      exports: clean(await views.exportAudit(dbLike)),
+    };
+  } catch {
+    return null;
+  } finally {
+    ro?.close();
+  }
+}
+
 export const OBS_DB = OBS_DB_PATH;


### PR DESCRIPTION
Settings 'Developer mode' toggle reveals a read-only Logs rail panel: telemetry stream + run lineage + gate block audit + export audit (all metadata-only, READ_ONLY). Per-turn transcripts deferred to Phase B (#12); raw-reveal left as a follow-up. harness 369 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)