### PR TITLE
docs(adr): align ADR-0020 (MCP auth hub) with the harness invariants + add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,147 @@
+# AGENTS.md — Invariants
+
+> Read this file at the start of EVERY session before touching code.
+> These are the load-bearing rules. Breaking one silently is how this project
+> rots across sessions. If you must break one, it’s a deliberate, isolated
+> increment with its own ADR in DECISIONS.md — never a side effect.
+
+-----
+
+## Session ritual
+
+**START**
+
+1. Read this file.
+1. `make test && make demo-<previous-increment>` — the baseline must be green
+   before you change anything.
+1. State out loud the single increment ID you are building this session. One
+   increment per session.
+
+**END**
+
+1. New `make demo-<this-increment>` passes.
+1. Full `make test` green (every prior demo still passes).
+1. If you touched the prompt prefix, re-run the prefix-hash test.
+1. Append exactly 3 lines to PROGRESS.md: shipped / stubbed / next.
+
+Do not start the next increment in the same session. A half-finished second
+increment is the exact failure this whole structure exists to prevent.
+
+-----
+
+## The architecture in one paragraph
+
+We are building a security/provenance/memory layer **around** oh-my-pi (omp),
+not from scratch. The harness is **TypeScript on Bun, in-process with omp**. The
+**only** Python is `scanner-sidecar/` (the pure Unicode scanner). We extend omp
+through hooks, custom tools, and its SDK. See DECISIONS.md ADR-0001.
+
+-----
+
+## Invariants (do not violate)
+
+### 1. Extend omp; never fork it.
+
+Prefer a hook or custom tool over any change that would require forking omp.
+omp ships hundreds of releases; a fork is permanent merge pain. If you believe
+something genuinely cannot be done via hook/tool/SDK, STOP and write an ADR
+before forking anything.
+
+### 2. The language boundary is fixed.
+
+The harness is TypeScript. The ONLY directory containing Python is
+`scanner-sidecar/`. Never add a `.py` file anywhere else. Never reimplement the
+scanner in TypeScript. If a second Python surface seems necessary, that’s a
+drift signal — stop and write an ADR.
+
+### 3. Fail-closed is law.
+
+Any failure to obtain a valid scan result — sidecar dead, malformed response,
+timeout, missing id — MUST be treated as “block / quarantine,” never “safe.”
+No code path may treat “scan unavailable” as “pass.” There is a test that kills
+the sidecar mid-run and asserts the gate blocks; it must stay green forever.
+
+### 4. The quarantine gate runs in-process.
+
+The security gate is a `pre` hook inside omp’s runtime. It must not depend on a
+network call or a fragile boundary to do its blocking. The scanner (pure, behind
+the sidecar) may be out-of-process; the GATE that acts on its output may not.
+
+### 5. Untrusted content is always delimited and always late.
+
+All user-provided, retrieved, imported, or externally stored text enters prompts
+only inside `UNTRUSTED_CONTENT_START` / `UNTRUSTED_CONTENT_END`, only after
+scanning + sanitation, and only AFTER the cache breakpoint (never in the frozen
+prefix). The system prompt instructs the model to treat delimited content as
+data, never instructions.
+
+### 6. The prompt prefix is frozen and byte-stable.
+
+Prompt layers 1–4 (identity/safety, tool-use/permission policy, stable coding
+rules, security/trust-boundary rules) are byte-identical across all requests.
+Volatile context — date, cwd, git branch/status, env — that omp auto-injects
+MUST live in the tail, after the cache breakpoint. Putting volatile bytes in the
+prefix busts the KV cache every turn. Verify with the prefix-hash test.
+
+### 7. Trust labels are a closed set.
+
+Exactly: `trusted | untrusted | suspicious | quarantined`. No other values.
+
+### 8. Events use exact names.
+
+Every logged event uses a name from the `EventName` enum in `contracts.ts`.
+Emitting an unknown event name must raise. Every event carries `run_id`,
+`session_id`, and `artifact_id` when an artifact is in scope.
+
+### 9. Stable IDs everywhere.
+
+Every run, finding, and approval has a stable string `*_id`. Reuse omp’s
+Snowflake session/run IDs; mint your own for findings/approvals. IDs are never
+regenerated for the same logical entity.
+
+### 10. DuckDB schema freezes on first write.
+
+Schema changes only ever happen through numbered migration files. Never edit a
+table definition in place. The schema is a frozen contract.
+
+-----
+
+## Frozen contract files (changing any one is its own increment + ADR)
+
+- `harness/contracts.ts` — TrustLabel, AgentMode, EventName, ExecutionProfile,
+  ToolResult (PRD shape, translated to TS).
+- `harness/tools/result_adapter.ts` — the ONLY place omp’s
+  `{ content: [{type,text}] }` and the PRD `ToolResult` meet.
+- The scanner IPC contract (DECISIONS.md ADR-0002).
+- DuckDB schema migration files.
+- The frozen prompt prefix (layers 1–4).
+
+If you import one of these, import it — never redefine its types locally.
+
+-----
+
+## Two correctness keystones (over-test these)
+
+- **The Unicode scanner** (`scanner-sidecar/`, increment P2.1). Every finding
+  type has fixtures; clean control corpus must produce zero false positives.
+- **The semantic-promotion gate** (increment P4.3). Suspicious-source content
+  must never auto-promote into semantic memory.
+
+Everything security-related leans on these two. Treat a failing test in either
+as a stop-the-line event.
+
+-----
+
+## Known wrinkles carried forward
+
+- The PRD wrote `contracts` and `ToolResult` as Python dataclasses. Under
+  Option A they are TypeScript in `contracts.ts`. The Python sidecar only needs
+  the finding shape. Translate other PRD Python samples to TS as needed; note
+  non-obvious translations in an ADR.
+- The integration seams were written from omp’s README. The FIRST task of
+  Increment 0 is to confirm the real `createAgentSession`, hook API, and
+  custom-tool factory shapes against the installed omp version, and ADR any
+  deltas.
+- DuckDB uses the Node binding (less mature than DuckDB-Python). If a specific
+  analytics task is blocked by it, that’s a localized future ADR — not a reason
+  to revisit the harness language.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1586,8 +1586,9 @@ optionally overrides what it already did.
 ## ADR-0020 — MCP Enterprise-Managed Auth Hub
 
 **Date:** 2026-06-20
-**Status:** Accepted
-**Context increment:** Integration Phase
+**Status:** Accepted as a roadmap — phased build **P-MCP.1–4** (see "Phases" below). New surface, not
+a refinement. Review addendum added 2026-06-20 to align it with the harness invariants.
+**Context increment:** planning only (no functional code this increment).
 
 ### Decision
 
@@ -1595,10 +1596,10 @@ We are building a centralized **MCP Server Connection Hub** into the IDE to auto
 This will support **Okta, Entra ID (Azure AD), and GCP Workload Identity Federation (WIF)** natively.
 
 1. **Pop-out UI Behavior:** Advanced configurations will "pop out... into the main window" as a full-height overlay panel that slides over the main chat/workspace area when an MCP connector is clicked in the Settings sidebar. This gives maximum real estate for forms, logs, and token status without cluttering the narrow sidebar.
-2. **Token Storage Security:** OAuth Access Tokens will be stored using an **OS-level secure credential vault interface** via Electron's `safeStorage`. We have added a roadmap path for integrating Post-Quantum Cryptography (PQC) algorithms (e.g., NIST ML-KEM/Kyber) once they are standardized by OS vendors.
-3. **OAuth Redirect URIs:** We will use an **Ephemeral Localhost Server with PKCE** for handling OAuth redirects, which adheres to IETF RFC 8252 (OAuth 2.0 for Native Apps) as the most secure and auditable standard for desktop applications.
-4. **GCP WIF Profiles:** Because most enterprises use Entra ID, Yubikeys, or PIV tokens, we will configure GCP WIF to directly trust the Entra ID OIDC provider. The IDE will perform the Entra ID flow and exchange the resulting Entra ID token directly with GCP STS for a GCP access token, avoiding the need for standalone Google credentials.
-5. **Terraform Scope:** We will provide Terraform snippets to aid in configuring the Identity Provider side (Okta, Entra ID, GCP WIF pool), accompanied by README links to official docs for configuring the actual MCP server side.
+2. **Token Storage Security:** OAuth Access Tokens will be stored using an **OS-level secure credential vault interface** via Electron's `safeStorage`. **Seam:** `safeStorage` is an Electron **main-process** API, and our GUI server runs as a *separate* Bun process (ADR-0006) — so token seal/unseal must route through `main.ts` + preload (the exact custody seam ADR-0010 already uses), with a PBKDF2 passphrase fallback in the plain-Bun dev runtime. PQC note: ML-KEM is **already standardized** (FIPS 203, Aug 2024 — see ADR-0015); the real dependency is OS-vendor *keystore* adoption, so track it under ADR-0015 (crypto-agility) rather than as a fresh roadmap path here.
+3. **OAuth Redirect URIs:** We will use an **Ephemeral Localhost Server with PKCE** for handling OAuth redirects, which adheres to IETF RFC 8252 (OAuth 2.0 for Native Apps) as the most secure and auditable standard for desktop applications. **Coordination:** we already run a localhost OAuth catcher (omp `auth-broker`, ~:1455). The MCP PKCE catcher MUST bind a *distinct ephemeral* port, validate `state`, and fully drain its child pipes + close on callback — the exact failure mode that previously took down provider OAuth (a wrapper that stopped draining stdout/stderr blocked the callback server).
+4. **GCP WIF Profiles:** Because most enterprises front identity with **Entra ID or Okta** (with Yubikey / PIV as the *factors* behind it), we will configure GCP WIF to directly trust the Entra ID **OIDC provider**. The IDE performs the Entra ID flow and exchanges the resulting OIDC token directly with **GCP STS** (`token` endpoint) for a short-lived GCP access token, avoiding standalone Google credentials.
+5. **Terraform Scope:** We will provide Terraform snippets to aid in configuring the Identity Provider side (Okta, Entra ID, GCP WIF pool), accompanied by README links to official docs for configuring the actual MCP server side. **Boundary:** `terraform/mcp_auth/` is **deployment IaC + docs only** — never on the build/test path, never imported by the harness, kept isolated like `scanner-sidecar/` so it does not widen the fixed TypeScript-+-one-Python language boundary (inv. #2).
 
 ### Why
 
@@ -1608,5 +1609,45 @@ Anthropic's Enterprise-Managed Auth demonstrated the power of zero-touch IdP int
 
 - A new `desktop/mcp_hub.ts` backend to handle the PKCE flows, localhost redirect catchers, and GCP STS exchanges.
 - Electron's `safeStorage` dependency for token persistence.
-- A new UI overlay system integrated into `desktop/renderer/app.ts` that interacts seamlessly with the existing `settingsShell()`.
+- A new UI overlay system integrated into `desktop/renderer/app.ts` that interacts seamlessly with the existing `settingsShell()` (reusing the same slide-over pattern as Settings / Knowledge / the dev Logs view).
 - A set of Terraform modules (`terraform/mcp_auth/`) included in the repo for deploying the required IdP configuration.
+
+### Integration with the invariants (review addendum — 2026-06-20)
+
+6. **Extend omp; never fork it (invariant #1) — the load-bearing decision.** omp ALREADY terminates
+   MCP: `session/new` / `session/load` accept an `mcpServers[]` array (today `[]` in
+   `acp_backend.ts:112/209`). The hub's job is **authentication + config assembly only** — it runs
+   the IdP / PKCE / STS flows, obtains the token, and hands omp a fully-authenticated MCP server
+   entry (URL + headers/token) through that `mcpServers` array on the next `session/new`. It does
+   **not** implement MCP transport, tool discovery, or tool calling — omp owns that. So
+   `desktop/mcp_hub.ts` is *auth + sealed storage + the omp-config seam*, nothing more. Re-implementing
+   an MCP client would be a fork-shaped design and is out of scope.
+
+**Security guardrails (load-bearing, not optional):**
+- **Untrusted MCP output (invariant #5).** An MCP server is an untrusted source until scanned. Any
+  tool result that re-enters the prompt passes the existing fail-closed gate (`scanAndDecide`,
+  keystone #1) and is wrapped in `UNTRUSTED_CONTENT_START/END` after the cache breakpoint — exactly
+  like imported/fetched text. Auth governs *access*; the gate still governs *content*.
+- **Tokens never logged, never in the frozen prefix.** Access tokens live only in the sealed store +
+  memory, are redacted from telemetry, and never touch prompt layers 1–4.
+- **safeStorage only via Electron main** (Decision 2 seam); PBKDF2 passphrase fallback in dev.
+- **Localhost catcher**: distinct ephemeral port, PKCE + `state`, drain-and-close on callback.
+
+**Phases — one increment each (session ritual):**
+- **P-MCP.1** — the omp `mcpServers` config seam + a manual (paste-a-token) MCP connector + the
+  slide-over overlay UI. Proves auth→omp end-to-end with no IdP yet. EventName `mcp_server_connected`.
+- **P-MCP.2** — Entra ID / Okta OIDC via the ephemeral-localhost PKCE catcher + token seal through
+  Electron main. EventName `mcp_auth_completed` (+ `mcp_auth_failed`).
+- **P-MCP.3** — GCP WIF: exchange the Entra OIDC token with GCP STS for a short-lived GCP token.
+- **P-MCP.4** — Terraform IaC modules + docs (deployment-only; no harness coupling).
+Recommended first build: **P-MCP.1** (smallest surface; reuses the existing overlay + settings-key
+storage pattern; proves the omp seam before any IdP work).
+
+**Frozen-contract impacts:**
+- New `EventName`s — `mcp_server_connected`, `mcp_auth_completed`, `mcp_auth_failed` — each added in
+  the increment that emits it (emitting an unknown name throws; inv. #8). Enumerate before building.
+- **No DuckDB migration** (tokens live in the sealed safeStorage blob, not DuckDB).
+- The MCP server registry persists in the git-ignored GUI settings file (`lucid-gui.json`, mode 0600)
+  like provider keys — **never committed** (the standing keys-stay-out-of-git constraint).
+- New deps: Electron `safeStorage` only (already implied by ADR-0010); Terraform is out-of-band
+  tooling, not an npm/bun dependency.


### PR DESCRIPTION
Review addendum to ADR-0020: extend-omp framing (feed authenticated configs into omp's mcpServers, not a parallel client), the safeStorage/Electron-main seam, the scan-untrusted-MCP-output guardrail, localhost PKCE coordination, Terraform-as-IaC boundary, phases P-MCP.1–4, and frozen-contract impacts. Adds AGENTS.md (mirror of CLAUDE.md). Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)