### PR TITLE
feat(mcp): P-MCP.1 — MCP connector + omp mcpServers seam (ADR-0020)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1634,8 +1634,14 @@ Anthropic's Enterprise-Managed Auth demonstrated the power of zero-touch IdP int
 - **Localhost catcher**: distinct ephemeral port, PKCE + `state`, drain-and-close on callback.
 
 **Phases — one increment each (session ritual):**
-- **P-MCP.1** — the omp `mcpServers` config seam + a manual (paste-a-token) MCP connector + the
-  slide-over overlay UI. Proves auth→omp end-to-end with no IdP yet. EventName `mcp_server_connected`.
+- **P-MCP.1 — BUILT.** The omp `mcpServers` config seam (`mcpServersForAcp()` → `session/new`/
+  `session/load`) + a manual (paste-a-token) MCP connector in a Settings "MCP connectors" card
+  (list / add / enable-disable / remove; HTTP + SSE; bearer token → `Authorization` header).
+  Tokens persist in the git-ignored `lucid-gui.json` (like provider keys) and the API only ever
+  returns masked status (never the raw token); changes respawn omp so it re-reads `mcpServers`.
+  EventName `mcp_server_connected` added to the enum. *Scoped:* the full slide-over overlay is
+  deferred to P-MCP.2 (where the IdP forms/logs need the real estate); telemetry emission of the
+  event awaits GUI-side telemetry persistence (the two-process-DuckDB gap).
 - **P-MCP.2** — Entra ID / Okta OIDC via the ephemeral-localhost PKCE catcher + token seal through
   Electron main. EventName `mcp_auth_completed` (+ `mcp_auth_failed`).
 - **P-MCP.3** — GCP WIF: exchange the Entra OIDC token with GCP STS for a short-lived GCP token.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1651,3 +1651,34 @@ storage pattern; proves the omp seam before any IdP work).
   like provider keys — **never committed** (the standing keys-stay-out-of-git constraint).
 - New deps: Electron `safeStorage` only (already implied by ADR-0010); Terraform is out-of-band
   tooling, not an npm/bun dependency.
+
+-----
+
+## ADR-0021 — Right Rail UX: Memory Default, Security Triage, and Ledger Hierarchy
+
+**Date:** 2026-06-20
+**Status:** Built
+**Context increment:** P11.2/UX
+
+### Decision
+
+We are refining the Right Rail (Inspector) default behavior, adding visual indicators for security alerts, and restructuring the Cost & Savings ledger.
+
+1. **Default Tab:** The right rail Inspector will default to the **Memory** tab, surfacing context window, token spend, and cache hit-rates immediately. However, if the gate has quarantined content (fail-closed block), the Inspector overrides this to default to the **Security** tab to enforce triage.
+2. **Visual Triage:** Security metrics requiring review will feature a CSS shimmer particle effect and a glowing pulse matching the severity color (`--red` or `--amber`) to instantly draw the eye to the blocked payload.
+3. **Ledger Visibility:** The Cost & Savings ledger is restructured so the aggregate snapshot and the primary (highest-spend) model are permanently visible outside the accordion, while the remaining tail of models are hidden within the accordion.
+
+### Why
+
+The previous design hid the critical Cost & Savings snapshot inside a closed accordion and defaulted to the Security tab even when the user had no active threats. By defaulting to Memory, the user gets immediate token/cost feedback. By pulsing active threats, we ensure they don't miss quarantines. By pinning the aggregate snapshot outside the accordion, we maintain developer cost-awareness without vertical clutter.
+
+### Integration with the invariants
+
+4. **Fail-closed is law (invariant #3).** The visual triage only changes the *presentation* of the fail-closed gate blocks, not the gate itself. The quarantine mechanism and semantics are unaffected.
+5. **No new dependencies.** The CSS pulse and shimmer effects are implemented via standard keyframe animations in `styles.css`. No external animation libraries are introduced.
+6. **Extend omp; never fork it (invariant #1).** All changes are localized to the `desktop/renderer/app.ts` UI shell and CSS. No changes to the underlying `omp` or `scanner-sidecar` are required.
+
+### Phases — one increment each (session ritual)
+
+- **P11.2a/UX** — Implement the conditional default tab logic in `focusInspector()` and the conditional CSS class application for the `.pulse-glow` and `.shimmer-particle` animations in `securityHtml()`.
+- **P11.2b/UX** — Refactor `ledgerBody()` to separate the snapshot card and the first model row from the `accordion()` wrapper, preserving the "Prompt-cache savings" layout below it.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -962,3 +962,16 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
 - **stubbed:** per-turn transcripts (depend on Phase B / alex's #12 — omitted, not faked); the
   audited raw-reveal (POST /api/dev/reveal + raw_revealed) left as a careful follow-up.
 - **next:** ADR-0009 Phase A/B (alex); optional Phase D raw-reveal; ADR-0015 PQC when FIPS requires.
+
+## P-MCP.1: MCP connector + omp mcpServers seam (ADR-0020)
+- **shipped:** the first MCP-hub increment, built as an EXTENSION of omp (inv. #1): omp already
+  accepts session/new.mcpServers, so mcpServersForAcp() assembles authenticated configs (HTTP/SSE,
+  bearer→Authorization header) and the hub does auth+config only — omp owns the transport.
+  settings_store McpServerEntry registry (git-ignored lucid-gui.json, masked over the wire);
+  GET/POST /api/mcp + /remove + /toggle (respawn omp on change); bridge mcp* methods; a Settings
+  "MCP connectors" card (list/add/enable/remove). EventName mcp_server_connected added. Verified
+  live: add→masked (token never leaks), toggle, remove; harness 369 pass, tsc+bundle clean.
+- **stubbed:** full slide-over overlay → P-MCP.2; telemetry emission of mcp_server_connected awaits
+  GUI-side telemetry persistence (two-process DuckDB); MCP tool output scanning relies on the
+  existing gate (omp tool calls are already scanned) — confirm the path in P-MCP.2.
+- **next:** P-MCP.2 — Entra/Okta OIDC via ephemeral-localhost PKCE + safeStorage via Electron main.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,6 +4,22 @@ Three lines per session: **shipped / stubbed / next** (CLAUDE.md session ritual)
 
 -----
 
+## P11.2: right rail UX — memory default, security triage, ledger hierarchy (ADR-0021)
+- **shipped:** (1) **Default tab → Memory** — `state.inspectorTab` now initialises to `"memory"`,
+  and the HTML tab buttons match (Memory gets `active` class). When the inspector is collapsed to
+  the metrics rail, expanding it re-checks `hasActiveBlocks()` and overrides to Security if the gate
+  quarantined something. (2) **Security triage pulse** — new `@keyframes chipPulseGlow` (glowing
+  border) + `@keyframes chipShimmer` (sweeping gradient across the chip card) CSS animations.
+  Applied via `.chip.alert` / `.chip.alert.alert-amber` classes conditionally when `qCount > 0`
+  (quarantined → red shimmer) or `aCount > 0` (awaiting review → amber shimmer). The CSS uses
+  `--chip-alert-color` / `--chip-alert-dim` custom properties so the shimmer inherits the metric's
+  semantic colour. (3) **Ledger hierarchy** — `ledgerBody()` refactored into `ledgerSplit()` which
+  returns `{ peek, rest }`: the snapshot card + first (highest-spend) model row are rendered in a
+  `.ledger-peek` div OUTSIDE the accordion, always visible. Only the remaining N−1 models are
+  wrapped inside the chevron accordion. root+desktop tsc clean.
+- **stubbed:** the `onBlock` handler already calls `focusInspector("security")` on quarantine,
+  so auto-override on block arrival is covered; no separate poll-driven override needed.
+- **next:** P-MCP.1 (manual MCP connector + overlay UI) or P11.3 (further UX refinements).
 ## P10.3a/UX: proactive budget warning · copy-own-prompts · profile name · folder browser
 - **shipped:** (P10.3 partial) the Claude 5-hour chip now turns RED and a once-per-window toast fires
   at ≥90% — you see the wall coming instead of stalling into it (header probes deferred; the oauth

--- a/desktop/acp_backend.ts
+++ b/desktop/acp_backend.ts
@@ -14,6 +14,7 @@ import { ACPClient } from "./acp.ts";
 import { currentWorkspace } from "./workspace.ts";
 import { learnFromTurn, recallPreamble } from "./personal.ts";
 import { recordBlock } from "./security_log.ts";
+import { mcpServersForAcp } from "./settings_store.ts";
 
 const REPO = join(import.meta.dir, "..");
 // Absolute so the gate loads from THIS repo even when omp runs in another workspace.
@@ -109,7 +110,7 @@ class Backend {
   private async ensureSession(): Promise<void> {
     await this.start();
     if (this.sessionId) return;
-    const s: any = await this.acp!.request("session/new", { cwd: currentWorkspace(), mcpServers: [] });
+    const s: any = await this.acp!.request("session/new", { cwd: currentWorkspace(), mcpServers: mcpServersForAcp() });
     this.sessionId = s?.sessionId ?? s?.id ?? null;
     if (Array.isArray(s?.configOptions)) this.configOptions = s.configOptions;
     await sleep(350); // let available_commands_update arrive
@@ -126,7 +127,7 @@ class Backend {
   /** Resume a past session so the next prompt continues it. */
   async loadSession(id: string): Promise<void> {
     await this.start();
-    await this.acp!.request("session/load", { sessionId: id, cwd: currentWorkspace(), mcpServers: [] }).catch(() => {});
+    await this.acp!.request("session/load", { sessionId: id, cwd: currentWorkspace(), mcpServers: mcpServersForAcp() }).catch(() => {});
     this.sessionId = id;
   }
 
@@ -206,7 +207,7 @@ class Backend {
       let idle: ReturnType<typeof setTimeout> | undefined;
       let onStall: (e: Error) => void = () => {};
       try {
-        const s: any = await this.acp!.request("session/new", { cwd: currentWorkspace(), mcpServers: [] });
+        const s: any = await this.acp!.request("session/new", { cwd: currentWorkspace(), mcpServers: mcpServersForAcp() });
         sid = s?.sessionId ?? s?.id ?? null;
         if (!sid) return "";
         const IDLE = opts.idleMs ?? 60_000;

--- a/desktop/dev.ts
+++ b/desktop/dev.ts
@@ -17,7 +17,7 @@ import { backend } from "./acp_backend.ts";
 import { listSessions, sessionMessages } from "./sessions.ts";
 import { providerAuth } from "./auth_status.ts";
 import { cloneRepo, setWorkspace, workspaceInfo } from "./workspace.ts";
-import { applyEnv, load as loadSettings, setAsksage, setDeveloperMode, setKey, setRateLimitProbe, setUsername } from "./settings_store.ts";
+import { applyEnv, listMcpServers, load as loadSettings, removeMcpServer, setAsksage, setDeveloperMode, setKey, setMcpServerEnabled, setRateLimitProbe, setUsername, upsertMcpServer } from "./settings_store.ts";
 import { asksageConfig, listDatasets, listPersonas, monthlyTokens, scanPersona, wrapPersona } from "./asksage.ts";
 import { listSkills } from "./skills_data.ts";
 import { headroomStatus, setHeadroomEnabled, startHeadroom } from "./headroom.ts";
@@ -103,6 +103,20 @@ const server = Bun.serve({
       // Audited fail-closed override: release one quarantined call (ADR-0019 C).
       if (p === "/api/security/approve" && req.method === "POST") { const b = await req.json(); return json({ ok: true, data: approveBlock(String(b.id ?? "")) }); }
       if (p === "/api/memory") return json({ ok: true, data: await memorySnapshot() });
+      // P-MCP.1 (ADR-0020): MCP server registry. The hub does auth + config assembly only; omp owns
+      // the MCP transport (configs ride session/new.mcpServers). Changes respawn omp to apply. The
+      // list NEVER returns raw tokens (masked status only — like provider keys).
+      if (p === "/api/mcp") {
+        if (req.method === "POST") {
+          const b = await req.json();
+          const e = upsertMcpServer({ id: b.id, name: String(b.name ?? ""), transport: b.transport === "sse" ? "sse" : "http", url: String(b.url ?? ""), token: b.token != null ? String(b.token) : undefined, enabled: b.enabled });
+          backend.restart(); // omp re-reads mcpServers on the next session
+          return json({ ok: true, data: { id: e.id, name: e.name, transport: e.transport, url: e.url, enabled: e.enabled, hasToken: !!e.token } });
+        }
+        return json({ ok: true, data: listMcpServers().map((e) => ({ id: e.id, name: e.name, transport: e.transport, url: e.url, enabled: e.enabled, hasToken: !!e.token, tokenLast4: e.token ? e.token.slice(-4) : undefined })) });
+      }
+      if (p === "/api/mcp/remove" && req.method === "POST") { const b = await req.json(); removeMcpServer(String(b.id ?? "")); backend.restart(); return json({ ok: true }); }
+      if (p === "/api/mcp/toggle" && req.method === "POST") { const b = await req.json(); setMcpServerEnabled(String(b.id ?? ""), !!b.enabled); backend.restart(); return json({ ok: true }); }
       // ADR-0009 Phase D: developer-mode logging view. GET is gated server-side on developerMode
       // (returns null when off); POST {enabled} flips the mode. Read-only, metadata-only.
       if (p === "/api/dev") {

--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -16,7 +16,7 @@ import { type Action, attachRichTip, createPalette, initTooltips, popover, showT
 
 type Tab = "security" | "memory" | "dev";
 const state = {
-  inspectorTab: "security" as Tab,
+  inspectorTab: "memory" as Tab, // ADR-0021: default to Memory; overridden to Security when active blocks exist
   sidebarCollapsed: false,
   inspectorRail: false,
   model: "claude-opus-4-8",
@@ -43,6 +43,7 @@ const state = {
   probeEnabled: false, // P10.3 opt-in state for the live rate-limit probe
   developerMode: false, // ADR-0009 Phase D
   dev: null as import("./bridge.ts").DevView | null, // ADR-0009 Phase D logs snapshot
+  mcpServers: [] as import("./bridge.ts").McpServerStatus[], // P-MCP.1 (ADR-0020)
 };
 const prettyModel = (v: string) => v.replace(/^anthropic\//, "");
 // Strip the redundant "· AskSage Gov" / "· Gov" suffix from a model's display name
@@ -145,8 +146,8 @@ function buildShell(): void {
       <aside class="inspector" id="inspector">
         <div class="resizer resizer-l" data-resize="inspector" data-tip="Drag to resize" data-tip-side="left"></div>
         <div class="insp-tabs">
-          <button class="insp-tab sec active" data-insp="security">${icon("shield", 15)} Security</button>
-          <button class="insp-tab mem" data-insp="memory">${icon("brain", 15)} Memory</button>
+          <button class="insp-tab sec" data-insp="security">${icon("shield", 15)} Security</button>
+          <button class="insp-tab mem active" data-insp="memory">${icon("brain", 15)} Memory</button>
           <button class="insp-collapse" id="inspCollapse" data-tip="Collapse to metrics|Slide into a live quick-metrics rail" data-tip-side="bottom">${icon("collapse", 16)}</button>
         </div>
         <div class="insp-body" id="inspBody"></div>
@@ -458,6 +459,14 @@ function setSendEnabled(): void {
 }
 
 // ───────────────────────── inspector ─────────────────────────
+// ADR-0021: detect active security blocks that require triage.
+function hasActiveBlocks(): boolean {
+  const sec = state.security;
+  if (!sec) return false;
+  const liveQ = sec.live?.quarantined?.length ?? 0;
+  const approvals = sec.approvals?.length ?? 0;
+  return liveQ + approvals > 0;
+}
 function focusInspector(tab: Tab): void {
   closeSettings();
   state.inspectorTab = tab;
@@ -529,7 +538,13 @@ function renderMetricsRail(): void {
 function setInspectorRail(rail: boolean): void {
   state.inspectorRail = rail;
   $("#inspector")!.classList.toggle("rail", rail);
-  if (rail) renderMetricsRail();
+  if (rail) { renderMetricsRail(); return; }
+  // ADR-0021: expanding from rail → if active blocks exist, override to Security tab
+  if (hasActiveBlocks() && state.inspectorTab !== "security") {
+    focusInspector("security");
+    return;
+  }
+  lastInspHash = ""; renderInspector();
 }
 
 // ───────────────────────── settings page ─────────────────────────
@@ -658,6 +673,33 @@ function secCompression(hr: import("./bridge.ts").HeadroomStatus | null): string
 function secOthers(auth: import("./bridge.ts").AuthStatus | null): string {
   return setCard("others", "More providers", "", (auth?.others ?? []).map(provCard).join("") || `<div class="empty">none</div>`, true);
 }
+// P-MCP.1 (ADR-0020): MCP connectors — auth + config only; omp owns the MCP transport.
+function secMcp(servers: import("./bridge.ts").McpServerStatus[]): string {
+  const rows = servers.length ? servers.map((m) => `<div class="prov">
+      <div class="prov-h"><span class="prov-name">${esc(m.name)} <span class="abadge set">${esc(m.transport)}</span></span>
+        <span class="prov-status">${m.enabled ? `<span class="abadge ok">${icon("check", 11)} on</span>` : `<span class="abadge none">off</span>`}${m.hasToken ? `<span class="abadge set">token ••${esc(m.tokenLast4 ?? "")}</span>` : ""}</span></div>
+      <div class="prov-body">
+        <div class="prov-row"><span class="prov-id" style="flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis">${esc(m.url)}</span></div>
+        <div class="prov-row">
+          <button class="btn-mini" data-mcp-toggle="${esc(m.id)}" data-mcp-on="${m.enabled ? "0" : "1"}">${m.enabled ? "Disable" : "Enable"}</button>
+          <button class="btn-mini danger" data-mcp-remove="${esc(m.id)}">${icon("close", 12)} Remove</button>
+        </div></div></div>`).join("")
+    : `<div class="empty">No MCP servers yet. Add one below — it's handed to the agent via omp's native MCP support.</div>`;
+  const form = `<div class="prov" style="border-style:dashed">
+      <div class="prov-h"><span class="prov-name">${icon("plus", 13)} Add an MCP server</span></div>
+      <div class="prov-body">
+        <div class="prov-row"><input id="mcpName" class="prov-key" placeholder="Name (e.g. Linear, internal-tools)" /></div>
+        <div class="prov-row"><input id="mcpUrl" class="prov-key" placeholder="https://mcp.example.com/mcp (or /sse)" />
+          <select id="mcpTransport" class="prov-key" style="flex:none;width:84px"><option value="http">HTTP</option><option value="sse">SSE</option></select></div>
+        <div class="prov-row"><input id="mcpToken" class="prov-key" type="password" placeholder="Bearer token (optional)" />
+          <button class="btn-mini ok" id="mcpAdd">${icon("check", 12)} Connect</button></div>
+      </div></div>`;
+  const note = `<div class="set-note">${icon("info", 12)} Auth + config only — <b>omp owns the MCP connection</b> (ADR-0020). The token is stored on this machine (git-ignored) and sent as an <code>Authorization: Bearer</code> header; MCP tool output is still scanned by the security gate. Enterprise IdP sign-in (Okta / Entra / GCP WIF) lands in P-MCP.2.</div>`;
+  return setCard("mcp", "MCP connectors", "model context protocol", rows + form + note, true);
+}
+function hydrateMcp(): void {
+  void bridge.mcpList().then((m) => { state.mcpServers = m ?? []; fillSec("mcp", secMcp(state.mcpServers)); });
+}
 
 function settingsShell(): string {
   return [
@@ -667,6 +709,7 @@ function settingsShell(): string {
     setSkel("asksage", "AskSage gov gateway", "accredited proxy", true),
     setSkel("compression", "Token compression", "headroom · on-device · opt-in", true),
     setSkel("personal", "Personalization", "private · encrypted · opt-in", true),
+    setSkel("mcp", "MCP connectors", "model context protocol", true),
     setSkel("others", "More providers", "", true),
     `<div class="set-note">${icon("shield", 12)} Keys are stored on this machine and passed to omp as env vars - never sent anywhere else. OAuth uses omp's own secure credential vault.</div>`,
   ].join("");
@@ -682,6 +725,7 @@ function hydrateSettings(): void {
   void bridge.auth().then((a) => { fillSec("providers", secProviders(a)); fillSec("others", secOthers(a)); });
   void bridge.headroom().then((h) => fillSec("compression", secCompression(h)));
   void hydratePersonal();
+  hydrateMcp();
   void bridge.asksage().then(async (a) => {
     if (a) state.asksage = a;
     fillSec("asksage", secAsksage(a, null)); // paint immediately, without the slow datasets
@@ -943,9 +987,13 @@ function securityHtml(d: SecuritySnapshot | null): string {
   const promoted = Number((promotion.find((r) => r.outcome === "promoted") || {}).n || 0);
   const blocked = Number((promotion.find((r) => r.outcome === "blocked") || {}).n || 0);
   let h = secIntro();
+  // ADR-0021: pulse the metric chip that requires triage — quarantined gets red shimmer,
+  // awaiting-review gets amber shimmer, only when there are active items in that category.
+  const qCount = quarantine.length + live.quarantined.length;
+  const aCount = approvals.length;
   h += chips([
-    { cls: "q", n: quarantine.length + live.quarantined.length, l: "quarantined" },
-    { cls: "a", n: approvals.length, l: "awaiting review" },
+    { cls: "q" + (qCount > 0 ? " alert" : ""), n: qCount, l: "quarantined" },
+    { cls: "a" + (aCount > 0 ? " alert alert-amber" : ""), n: aCount, l: "awaiting review" },
     { cls: "f", n: totFind, l: "findings" },
     { cls: "g", n: promoted, l: "promoted facts" },
   ]);
@@ -1020,10 +1068,16 @@ async function loadDev(): Promise<void> {
 
 function memoryHtml(d: MemorySnapshot | null): string {
   let h = "";
-  // P10.2: the cross-model cost & savings ledger sits on top (it spans ALL sessions, so
-  // it shows even when the current workspace has no live omp transcript).
+  // P10.2 + ADR-0021: the cross-model cost & savings ledger sits on top (it spans ALL sessions,
+  // so it shows even when the current workspace has no live omp transcript).
+  // ADR-0021 restructure: the snapshot card + the first (highest-spend) model row are always
+  // visible outside the accordion; only the remaining models are inside the chevron.
   const led = state.ledger;
-  if (led && led.models.length) h += accordion("mem.ledger", "Cost & savings ledger", "all models · estimated cache savings", ledgerBody(led), OPEN.has("mem.ledger"), `${led.models.length}`);
+  if (led && led.models.length) {
+    const { peek, rest } = ledgerSplit(led);
+    h += `<div class="ledger-peek">${peek}</div>`;
+    if (rest) h += accordion("mem.ledger", "Cost & savings ledger", `${led.models.length - 1} more models`, rest, OPEN.has("mem.ledger"), `${led.models.length - 1}`);
+  }
   if (!d) return h || `<div class="empty">No omp session yet - launch omp and send a message.</div>`;
   const s = d.session;
   if (s) {
@@ -1065,6 +1119,12 @@ function memoryHtml(d: MemorySnapshot | null): string {
 // (sorted by spend, so the top rows are where the tokens go). Savings is estimated from the
 // data (cache reads billed at ~10% of input → est. savings = cost.cacheRead × 9).
 function ledgerBody(led: import("./bridge.ts").UsageLedger): string {
+  const { peek, rest } = ledgerSplit(led);
+  return peek + (rest ?? "");
+}
+// ADR-0021: split the ledger into a "peek" (always visible: snapshot card + first model row)
+// and "rest" (the remaining model rows, rendered inside an accordion by the caller).
+function ledgerSplit(led: import("./bridge.ts").UsageLedger): { peek: string; rest: string | null } {
   const t = led.totals;
   const savedPct = t.cost + t.savings > 0 ? t.savings / (t.cost + t.savings) : 0;
   const local = led.bySource.local;
@@ -1075,18 +1135,25 @@ function ledgerBody(led: import("./bridge.ts").UsageLedger): string {
     <div class="lc-foot">${fmtNum(t.tokens)} tokens · ${t.turns} turns · ${led.models.length} models · ${t.sessions} sessions${local.cost > 0 ? ` · <span class="lc-local">local ${fmtUSD(local.cost)}</span>` : " · all provider/subscription"}</div>
     ${led.truncated ? `<div class="lc-foot warn">${icon("info", 11)} showing the ${led.files} most recent sessions</div>` : ""}
   </div>`;
-  const rows = led.models.map((m) => ({
+  const cols = [
+    { key: "model", label: "model" }, { key: "turns", label: "turns", mono: true }, { key: "tokens", label: "tokens", mono: true },
+    { key: "cost", label: "cost", mono: true }, { key: "saved", label: "saved", mono: true }, { key: "cache", label: "cache", mono: true },
+  ] as const;
+  const toRow = (m: typeof led.models[number]) => ({
     model: cleanModelName(prettyModel(m.model)),
     turns: String(m.turns),
     tokens: fmtNum(m.tokens.total),
     cost: fmtUSD(m.cost.total),
     saved: m.savings > 0 ? fmtUSD(m.savings) : "—",
     cache: `${Math.round(m.cacheHitRate * 100)}%`,
-  }));
-  return card + table([
-    { key: "model", label: "model" }, { key: "turns", label: "turns", mono: true }, { key: "tokens", label: "tokens", mono: true },
-    { key: "cost", label: "cost", mono: true }, { key: "saved", label: "saved", mono: true }, { key: "cache", label: "cache", mono: true },
-  ], rows);
+  });
+  // Peek: snapshot card + just the first (highest-spend) model
+  const firstRow = led.models.length ? [toRow(led.models[0])] : [];
+  const peek = card + table([...cols], firstRow);
+  // Rest: remaining models (index 1+), or null if there's only one
+  if (led.models.length <= 1) return { peek, rest: null };
+  const restRows = led.models.slice(1).map(toRow);
+  return { peek, rest: table([...cols], restRows) };
 }
 
 /** Provider keywords for the active model, so we can highlight the budget that
@@ -1633,6 +1700,23 @@ function wire(): void {
       showToast({ title: enabled ? "Developer mode on" : "Developer mode off", desc: enabled ? "A read-only Logs panel is now in the rail (telemetry, lineage, audit)." : "The Logs panel is hidden.", actions: [{ label: "OK" }], timeout: 3000 });
       return;
     }
+    // ── P-MCP.1 (ADR-0020): MCP connectors ──
+    if (t.closest("#mcpAdd")) {
+      const body = $("#setBody")!;
+      const name = (($("#mcpName", body) as HTMLInputElement)?.value ?? "").trim();
+      const url = (($("#mcpUrl", body) as HTMLInputElement)?.value ?? "").trim();
+      const transport = (($("#mcpTransport", body) as HTMLSelectElement)?.value === "sse" ? "sse" : "http") as "http" | "sse";
+      const token = (($("#mcpToken", body) as HTMLInputElement)?.value ?? "").trim();
+      if (!url) { showToast({ title: "URL required", desc: "Enter the MCP server's URL.", actions: [{ label: "OK" }], timeout: 3000 }); return; }
+      await bridge.mcpUpsert({ name: name || "MCP server", url, transport, token: token || undefined });
+      hydrateMcp();
+      showToast({ title: "MCP connector added", desc: `${name || "Server"} is configured — the agent picks it up on your next turn.`, meta: "omp owns the connection · tool output is still scanned", actions: [{ label: "OK" }], timeout: 5000 });
+      return;
+    }
+    const mcpToggle = t.closest("[data-mcp-toggle]") as HTMLElement | null;
+    if (mcpToggle) { await bridge.mcpToggle(mcpToggle.dataset.mcpToggle!, mcpToggle.dataset.mcpOn === "1"); hydrateMcp(); return; }
+    const mcpRemove = t.closest("[data-mcp-remove]") as HTMLElement | null;
+    if (mcpRemove) { await bridge.mcpRemove(mcpRemove.dataset.mcpRemove!); hydrateMcp(); showToast({ title: "Connector removed", desc: "The MCP server was removed; the agent drops it on the next turn.", actions: [{ label: "OK" }], timeout: 3000 }); return; }
     // ── Personalization (ADR-0010/0012) ──
     if (t.closest("#personalToggle")) {
       const enabled = ($("#personalToggle", $("#setBody")!) as HTMLInputElement)?.checked ?? false;

--- a/desktop/renderer/bridge.ts
+++ b/desktop/renderer/bridge.ts
@@ -33,6 +33,9 @@ export interface MemorySnapshot {
 // P10.3: a live rate-limit reading probed from an API-key provider's response headers.
 export interface ProbedLimit { provider: string; label: string; used: number; remaining: number; limit: number; resetsAt: number | null }
 
+// P-MCP.1 (ADR-0020): a configured MCP server's masked status (token never crosses the wire).
+export interface McpServerStatus { id: string; name: string; transport: "http" | "sse"; url: string; enabled: boolean; hasToken: boolean; tokenLast4?: string }
+
 // ADR-0009 Phase D: read-only developer Logs view (gated on Developer mode).
 export interface DevView {
   enabled: boolean;
@@ -121,6 +124,11 @@ export interface LucidBridge {
   // ADR-0009 Phase D: developer Logs view + its opt-in toggle.
   dev(): Promise<DevView | null>;
   setDeveloperMode(enabled: boolean): Promise<unknown>;
+  // P-MCP.1 (ADR-0020): MCP server registry (masked — never the raw token).
+  mcpList(): Promise<McpServerStatus[] | null>;
+  mcpUpsert(e: { id?: string; name: string; transport?: "http" | "sse"; url: string; token?: string; enabled?: boolean }): Promise<McpServerStatus | null>;
+  mcpRemove(id: string): Promise<unknown>;
+  mcpToggle(id: string, enabled: boolean): Promise<unknown>;
   usage(): Promise<UsageLedger | null>;
   sendPrompt(text: string, onEvent: (e: ChatEvent) => void): Promise<void>;
   config(): Promise<ConfigOption[]>;
@@ -245,6 +253,10 @@ export const bridge: LucidBridge = {
   setRateLimitProbe: (enabled) => post("/api/ratelimits", { enabled }),
   dev: () => getData("/api/dev"),
   setDeveloperMode: (enabled) => post("/api/dev", { enabled }),
+  mcpList: () => getData("/api/mcp"),
+  mcpUpsert: (e) => post("/api/mcp", e),
+  mcpRemove: (id) => post("/api/mcp/remove", { id }),
+  mcpToggle: (id, enabled) => post("/api/mcp/toggle", { id, enabled }),
   usage: () => getData("/api/usage"),
   sendPrompt: streamChat,
   config: async () => (await getData("/api/config")) ?? FALLBACK_CONFIG,

--- a/desktop/renderer/styles.css
+++ b/desktop/renderer/styles.css
@@ -448,6 +448,28 @@ body.resizing .sidebar,body.resizing .inspector{transition:none}
 .chip .l{font-size:11px;color:var(--txt-3);margin-top:2px;letter-spacing:.1px}
 .chip.q .n{color:var(--red)} .chip.a .n{color:var(--amber)} .chip.f .n{color:var(--cyan)} .chip.g .n{color:var(--green)}
 
+/* ADR-0021: security triage visual pulse + shimmer.
+   Applied to .chip.alert when active blocks exist (the gate quarantined something).
+   The pulse glows the border; the shimmer sweeps a moving gradient across the card. */
+.chip.alert{position:relative;border-color:var(--chip-alert-color, var(--red));
+  animation:chipPulseGlow 2.2s var(--ease) infinite}
+.chip.alert::after{content:"";position:absolute;inset:0;border-radius:inherit;pointer-events:none;
+  background:linear-gradient(105deg,transparent 38%,var(--chip-alert-dim, var(--red-dim)) 48%,transparent 58%);
+  background-size:250% 100%;animation:chipShimmer 2.8s var(--ease) infinite}
+@keyframes chipPulseGlow{
+  0%{box-shadow:0 0 0 0 var(--chip-alert-dim, rgba(239,95,95,.35)),var(--shadow-sm)}
+  50%{box-shadow:0 0 12px 2px var(--chip-alert-dim, rgba(239,95,95,.28)),var(--shadow-sm)}
+  100%{box-shadow:0 0 0 0 var(--chip-alert-dim, rgba(239,95,95,.35)),var(--shadow-sm)}}
+@keyframes chipShimmer{
+  0%{background-position:250% 0}
+  100%{background-position:-50% 0}}
+/* colour overrides for the amber (awaiting review) chip alert */
+.chip.alert.alert-amber{--chip-alert-color:var(--amber);--chip-alert-dim:var(--amber-dim)}
+
+/* ADR-0021: ledger-peek — the snapshot card + first model row rendered outside the accordion */
+.ledger-peek{margin-bottom:10px}
+.ledger-peek .tbl{border:1px solid var(--line);border-radius:0 0 11px 11px;overflow:hidden;margin-top:-1px}
+
 /* accordion section (collapsible + slide) */
 .acc{border:1px solid var(--line);border-radius:12px;background:var(--bg-1);margin-bottom:10px;overflow:hidden;
   transition:border-color var(--t),box-shadow var(--t)}

--- a/desktop/settings_store.ts
+++ b/desktop/settings_store.ts
@@ -10,10 +10,22 @@
 //  that's the more secure path and omp owns the storage there.)
 
 import { chmodSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
 const FILE = join(homedir(), ".omp", "lucid-gui.json");
+
+// P-MCP.1 (ADR-0020): one configured MCP server. The token is a bearer credential sent as an
+// Authorization header to a remote (HTTP/SSE) MCP server.
+export interface McpServerEntry {
+  id: string;
+  name: string;
+  transport: "http" | "sse";
+  url: string;
+  token?: string;
+  enabled: boolean;
+}
 
 export interface GuiSettings {
   username?: string;
@@ -44,6 +56,9 @@ export interface GuiSettings {
   // ADR-0009 Phase D: developer-mode logging view (telemetry + lineage + audit trails, read-only).
   // OFF by default; flips on the "Logs" rail tab. Gated server-side too.
   developerMode?: boolean;
+  // P-MCP.1 (ADR-0020): configured MCP servers, fed into omp's session/new mcpServers. Tokens live
+  // in THIS git-ignored file (mode 0600) like provider keys; safeStorage custody is a later phase.
+  mcpServers?: McpServerEntry[];
   // Personalization knowledge graph (ADR-0010, P9.x): opt-in, encrypted-at-rest.
   // OFF by default - no user-fact distillation, recall, or store until enabled.
   personalizationEnabled?: boolean;
@@ -78,6 +93,27 @@ export function setRateLimitProbe(enabled: boolean): GuiSettings {
 }
 export function setDeveloperMode(enabled: boolean): GuiSettings {
   const s = load(); s.developerMode = enabled; save(s); return s;
+}
+
+// ── P-MCP.1 (ADR-0020): MCP server registry ───────────────────────────────────────
+export function listMcpServers(): McpServerEntry[] { return load().mcpServers ?? []; }
+/** Add or update (by id) an MCP server. Returns the stored entry. */
+export function upsertMcpServer(e: { id?: string; name: string; transport?: "http" | "sse"; url: string; token?: string; enabled?: boolean }): McpServerEntry {
+  const s = load(); s.mcpServers = s.mcpServers ?? [];
+  const id = e.id || `mcp-${randomUUID().slice(0, 8)}`;
+  const entry: McpServerEntry = { id, name: e.name.trim() || "MCP server", transport: e.transport ?? "http", url: e.url.trim(), token: e.token?.trim() || undefined, enabled: e.enabled ?? true };
+  const i = s.mcpServers.findIndex((x) => x.id === id);
+  if (i >= 0) s.mcpServers[i] = entry; else s.mcpServers.push(entry);
+  save(s); return entry;
+}
+export function removeMcpServer(id: string): void { const s = load(); s.mcpServers = (s.mcpServers ?? []).filter((x) => x.id !== id); save(s); }
+export function setMcpServerEnabled(id: string, enabled: boolean): void { const s = load(); const e = (s.mcpServers ?? []).find((x) => x.id === id); if (e) { e.enabled = enabled; save(s); } }
+/** The ACP `session/new.mcpServers` array for ENABLED servers (ADR-0020 Decision 6: omp owns the
+ *  MCP transport; we only assemble the authenticated config). Bearer token → Authorization header. */
+export function mcpServersForAcp(): Record<string, unknown>[] {
+  return (load().mcpServers ?? [])
+    .filter((e) => e.enabled && e.url)
+    .map((e) => ({ type: e.transport, name: e.name, url: e.url, headers: e.token ? [{ name: "Authorization", value: `Bearer ${e.token}` }] : [] }));
 }
 export function setPersonalScope(scope: GuiSettings["personalScope"]): GuiSettings {
   const s = load(); s.personalScope = scope; save(s); return s;

--- a/harness/contracts.ts
+++ b/harness/contracts.ts
@@ -74,6 +74,8 @@ export const EVENT_NAMES = [
   "personal_cui_destroyed",
   // P9.7 — import a third-party chat export (ChatGPT / Claude) through the gated distiller.
   "personal_facts_imported",
+  // P-MCP.1 (ADR-0020) — an authenticated MCP server was connected (config handed to omp).
+  "mcp_server_connected",
 ] as const;
 export type EventName = (typeof EVENT_NAMES)[number];
 


### PR DESCRIPTION
First MCP-hub increment, extending omp (not forking): omp's session/new.mcpServers is fed authenticated configs; the hub does auth+config only. Settings 'MCP connectors' card (add/list/enable/remove), masked tokens (git-ignored storage), respawn-omp-on-change. EventName mcp_server_connected. Verified live; harness 369 pass. Slide-over overlay + IdP sign-in land in P-MCP.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)