### PR TITLE
fix(build): macOS ships .zip app bundle, not .dmg — unblock the release

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -1,9 +1,13 @@
-# Build the LucidAgentIDE desktop installers (macOS .dmg/.zip + Windows .exe).
+# Build the LucidAgentIDE desktop installers (macOS .zip app bundle + Windows .exe).
 #
-# electron-builder can't cross-build/sign a mac .dmg from Windows, so this runs
-# the real packaging on native runners: macOS for the .dmg/.zip, Windows for the
+# electron-builder can't cross-build/sign a mac app from Windows, so this runs
+# the real packaging on native runners: macOS for the .zip bundle, Windows for the
 # NSIS installer + portable .exe. Both bundle the repo into the app
 # (extraResources) per desktop/package.json.
+#
+# (macOS ships .zip, not .dmg: the default DMG layout drives a Finder/AppleScript
+#  background pass that is fragile on headless Apple-Silicon runners. The .zip is a
+#  complete, auto-updatable app bundle — see desktop/README.md.)
 #
 # Triggers:
 #   - Manual:  Actions -> "Build desktop installers" -> Run workflow.
@@ -32,7 +36,7 @@ jobs:
       matrix:
         include:
           - os: macos-latest
-            label: macOS (.dmg/.zip, arm64+x64)
+            label: macOS (.zip, arm64+x64)
             script: dist:mac
           - os: windows-latest
             label: Windows (NSIS + portable, x64)

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
 <br/>
 
 <a href="https://github.com/mlcyclops/lucidagentide/releases/latest/download/LucidAgentIDE-Setup.exe"><img src="https://img.shields.io/badge/Download-Windows%20Installer-2ea44f?style=for-the-badge&logo=windows&logoColor=white" alt="Download Windows installer (latest release)" /></a>
-<a href="https://github.com/mlcyclops/lucidagentide/releases/latest/download/LucidAgentIDE-mac-arm64.dmg"><img src="https://img.shields.io/badge/Download-macOS%20Apple%20Silicon-000000?style=for-the-badge&logo=apple&logoColor=white" alt="Download macOS Apple Silicon (latest release)" /></a>
-<a href="https://github.com/mlcyclops/lucidagentide/releases/latest/download/LucidAgentIDE-mac-x64.dmg"><img src="https://img.shields.io/badge/macOS-Intel-555555?style=for-the-badge&logo=apple&logoColor=white" alt="Download macOS Intel (latest release)" /></a>
+<a href="https://github.com/mlcyclops/lucidagentide/releases/latest/download/LucidAgentIDE-mac-arm64.zip"><img src="https://img.shields.io/badge/Download-macOS%20Apple%20Silicon-000000?style=for-the-badge&logo=apple&logoColor=white" alt="Download macOS Apple Silicon (latest release)" /></a>
+<a href="https://github.com/mlcyclops/lucidagentide/releases/latest/download/LucidAgentIDE-mac-x64.zip"><img src="https://img.shields.io/badge/macOS-Intel-555555?style=for-the-badge&logo=apple&logoColor=white" alt="Download macOS Intel (latest release)" /></a>
 <a href="https://github.com/mlcyclops/lucidagentide/releases/latest"><img src="https://img.shields.io/github/v/release/mlcyclops/lucidagentide?label=latest&style=for-the-badge&color=c64bd6&sort=semver" alt="Latest release version" /></a>
 
 <sub>⬆ Always the most recent successful release — links auto-update each version (no release yet? they appear after the first tagged build).</sub>
@@ -301,10 +301,13 @@ CI builds desktop installers for **both platforms** on every tag push:
 | Platform | Artifact | Status | Download (latest release) |
 |:--|:--|:--|:--|
 | **Windows** | NSIS installer + portable `.exe` (x64) | [![Windows Build](https://img.shields.io/github/actions/workflow/status/mlcyclops/lucidagentide/build-desktop.yml?label=passing&logo=windows&logoColor=white&style=flat-square)](https://github.com/mlcyclops/lucidagentide/actions/workflows/build-desktop.yml) | [**Installer**](https://github.com/mlcyclops/lucidagentide/releases/latest/download/LucidAgentIDE-Setup.exe) · [Portable](https://github.com/mlcyclops/lucidagentide/releases/latest/download/LucidAgentIDE-portable.exe) |
-| **macOS** | `.dmg` (arm64 + x64) | [![macOS Build](https://img.shields.io/github/actions/workflow/status/mlcyclops/lucidagentide/build-desktop.yml?label=passing&logo=apple&logoColor=white&style=flat-square)](https://github.com/mlcyclops/lucidagentide/actions/workflows/build-desktop.yml) | [**Apple Silicon**](https://github.com/mlcyclops/lucidagentide/releases/latest/download/LucidAgentIDE-mac-arm64.dmg) · [Intel](https://github.com/mlcyclops/lucidagentide/releases/latest/download/LucidAgentIDE-mac-x64.dmg) |
+| **macOS** | `.zip` app bundle (arm64 + x64) | [![macOS Build](https://img.shields.io/github/actions/workflow/status/mlcyclops/lucidagentide/build-desktop.yml?label=passing&logo=apple&logoColor=white&style=flat-square)](https://github.com/mlcyclops/lucidagentide/actions/workflows/build-desktop.yml) | [**Apple Silicon**](https://github.com/mlcyclops/lucidagentide/releases/latest/download/LucidAgentIDE-mac-arm64.zip) · [Intel](https://github.com/mlcyclops/lucidagentide/releases/latest/download/LucidAgentIDE-mac-x64.zip) |
 
 Both builds bundle [Bun](https://bun.sh) and [uv](https://docs.astral.sh/uv/) runtimes so the installed app
 needs **zero prerequisites**. Code-signing and notarization are supported when certs are configured.
+
+> **macOS:** the download is a zipped `LucidAgentIDE.app` — unzip it and drag the app into **Applications**.
+> (Builds ship as `.zip` rather than `.dmg`; in-app auto-update uses the same zip feed.)
 
 ## <img src=".github/assets/icons/roadmap.svg" width="28" align="top" alt=""> Roadmap
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -108,16 +108,24 @@ Optional: route turns through the **AskSage** accredited government AI gateway
 See [`../DECISIONS.md`](../DECISIONS.md) ADR-0006 for why the gate stays
 in-process and the GUI is a front end only.
 
-## Installers (.dmg / .exe) and the app icon
+## Installers (.zip / .exe) and the app icon
 
 The app is packaged with **electron-builder** (config in `package.json` → `build`,
 mac entitlements in `build/entitlements.mac.plist`).
 
 | Platform | Targets | Arch |
 | --- | --- | --- |
-| macOS | `.dmg` + `.zip` | `arm64`, `x64` |
+| macOS | `.zip` app bundle | `arm64`, `x64` |
 | Windows | NSIS `…-Setup.exe` + `…-portable.exe` | `x64` |
 | Linux | `.AppImage` | `x64` |
+
+> **Why mac ships `.zip`, not `.dmg`:** electron-builder's default DMG layout
+> mounts the image read-write and drives a Finder/AppleScript background pass,
+> which is fragile on headless GitHub Apple-Silicon runners (`hdiutil attach
+> failed - no mountable file systems` → missing `background.tiff`). The `.zip`
+> bundle is a complete, auto-updatable distribution; users unzip and drag
+> `LucidAgentIDE.app` to **Applications**. A signed/notarized `.dmg` can be
+> reintroduced later once it can be iterated on a real Mac.
 
 ### The icon
 
@@ -131,8 +139,8 @@ git-ignored — only the SVG is committed.
 ### Recommended: build via GitHub Actions (no Mac/Windows box needed)
 
 [`.github/workflows/build-desktop.yml`](../.github/workflows/build-desktop.yml)
-builds **both** installers on native runners (macOS for the `.dmg`, Windows for
-the `.exe`) — the only way to produce a mac `.dmg` without a Mac.
+builds **both** installers on native runners (macOS for the `.zip` app bundle,
+Windows for the `.exe`) — the only way to produce a signed mac build without a Mac.
 
 - **Manual:** GitHub → **Actions → "Build desktop installers" → Run workflow**.
   Installers download as run **artifacts**.
@@ -149,12 +157,12 @@ workflow.
 ```bash
 cd desktop
 bun install            # pulls electron + electron-builder
-bun run dist:mac       # → release/LucidAgentIDE-<ver>-{arm64,x64}.dmg (+ .zip)   (on macOS)
+bun run dist:mac       # → release/LucidAgentIDE-mac-{arm64,x64}.zip   (on macOS)
 bun run dist:win       # → release/LucidAgentIDE-<ver>-Setup.exe (+ portable.exe) (on Windows)
 ```
 
-> **A mac `.dmg` must be built on macOS** — electron-builder can't produce/sign
-> one from Windows or Linux. Use the workflow above, or a Mac.
+> **A mac build must be produced on macOS** — electron-builder can't package/sign
+> a mac app from Windows or Linux. Use the workflow above, or a Mac.
 >
 > **Building the Windows installer locally needs Developer Mode** (or an elevated
 > shell): electron-builder extracts a signing toolchain that contains symlinks,
@@ -221,8 +229,8 @@ Full secret list and setup: [`SIGNING.md`](SIGNING.md).
 - **Unsigned Windows:** SmartScreen — **More info → Run anyway**. Windows
   auto-updates fine while unsigned.
 
-> Status: the **macOS** `.dmg`/`.zip` (arm64 + x64) build locally on macOS via
-> `bun run dist:mac` — both DMGs pass `hdiutil verify`; the brand icon is
+> Status: the **macOS** `.zip` app bundle (arm64 + x64) builds on macOS via
+> `bun run dist:mac`; the brand icon is
 > embedded; the repo, in-process gate, and the static `bun`/`uv` runtimes are
 > bundled. Verified self-contained: the app's bundled dev server boots under a
 > Finder-style minimal `PATH` (`/usr/bin:/bin`) and serves `/api/health` — i.e.

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -56,11 +56,8 @@
       "category": "public.app-category.developer-tools",
       "icon": "build/icon.png",
       "identity": null,
+      "artifactName": "${productName}-mac-${arch}.${ext}",
       "target": [
-        {
-          "target": "dmg",
-          "arch": ["arm64", "x64"]
-        },
         {
           "target": "zip",
           "arch": ["arm64", "x64"]
@@ -70,10 +67,6 @@
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist",
       "gatekeeperAssess": false
-    },
-    "dmg": {
-      "title": "LucidAgentIDE ${version}",
-      "artifactName": "${productName}-mac-${arch}.${ext}"
     },
     "win": {
       "icon": "build/icon.ico",


### PR DESCRIPTION
**Problem.** The macOS CI build failed in DMG creation. electron-builder's default DMG layout mounts the image read-write and runs a Finder/AppleScript background pass — fragile on headless GitHub Apple-Silicon runners: `hdiutil attach failed - no mountable file systems`, then dmgbuild crashing on a missing `.background/background.tiff`. Both `.zip` artifacts built fine, but `dist:mac` exits 1 on the DMG error, failing the whole job (and the rolling `latest` release, since `publish-latest` has `needs: build`).

**Fix.** Drop the `dmg` target; ship mac as `.zip` (arm64 + x64) with a stable, versionless `artifactName` (`LucidAgentIDE-mac-arm64.zip` / `-mac-x64.zip`) so the README latest/download links stay valid. The `.zip` is a complete, auto-updatable app bundle (electron-updater uses the same zip feed); users unzip and drag `LucidAgentIDE.app` to Applications.

**Scope.** Build config + docs only — no app code or contract change. Windows build untouched. A signed/notarized `.dmg` can return later once it can be iterated on a real Mac.

_Verification note:_ the proof is a green re-run of the macOS job (cannot be reproduced from Windows). package.json validated as parseable with `mac.target = [zip]`, no `dmg` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)