### PR TITLE
ci(release): clear stale assets from the rolling "latest" release before publishing

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -166,6 +166,20 @@ jobs:
       - name: List artifacts
         run: ls -la dist
 
+      # softprops/action-gh-release replaces same-named assets but never deletes ones whose
+      # names changed (e.g. an old *.dmg or a versioned *-mac.zip from a prior build). Clear
+      # ALL existing assets on the rolling "latest" release first so it only ever holds the
+      # current build's artifacts. No-op if the release doesn't exist yet.
+      - name: Clear stale assets from the "latest" release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ids=$(gh api "repos/${{ github.repository }}/releases/tags/latest" --jq '.assets[].id' 2>/dev/null || true)
+          for id in $ids; do
+            echo "deleting stale asset $id"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/$id" || true
+          done
+
       - name: Publish / update the "latest" release
         uses: softprops/action-gh-release@v3
         with:


### PR DESCRIPTION
`softprops/action-gh-release` replaces same-named assets but never deletes ones whose names changed across builds (old `*.dmg`, versioned `*-mac.zip`), so the rolling **latest** release accumulated orphaned, misleading downloads.

Adds a step that deletes ALL existing assets on the `latest` release before the fresh upload, so it only ever holds the current build's artifacts. No-op on the first run (the release doesn't exist yet). The existing stale assets were already pruned manually via the API.

Workflow-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)