### PR TITLE
sec(P11.3/SEC): harden local control plane — loopback bind, origin/host gate, FS containment (ADR-0022)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1746,3 +1746,91 @@ The previous design hid the critical Cost & Savings snapshot inside a closed acc
 
 - **P11.2a/UX** — Implement the conditional default tab logic in `focusInspector()` and the conditional CSS class application for the `.pulse-glow` and `.shimmer-particle` animations in `securityHtml()`.
 - **P11.2b/UX** — Refactor `ledgerBody()` to separate the snapshot card and the first model row from the `accordion()` wrapper, preserving the "Prompt-cache savings" layout below it.
+
+-----
+
+## ADR-0022 — Local control-plane hardening: loopback bind, origin/host gate, path containment
+
+**Date:** 2026-06-21
+**Status:** Built
+**Context increment:** P11.3/SEC
+
+### Context
+
+CodeQL (`security-extended`, `.github/workflows/codeql.yml`) and a manual SAST pass
+over the same sink classes surfaced that the desktop data plane is the shipped app's
+real control plane, not just a dev convenience: `desktop/main.ts` spawns
+`desktop/dev.ts` and the Electron window loads it over `http://localhost:5319`. That
+server (and the read-only `tools/web/server.ts` dashboard) handled requests that set
+provider API keys, unlock the encrypted personal/CUI stores with a passphrase, clone
+repos, and browse the filesystem — with **no bind-address restriction, no
+origin/CSRF check, and an unconstrained path** into the folder browser.
+
+Three findings, by severity:
+
+- **H1 — binds to all interfaces.** `Bun.serve` defaults to `0.0.0.0`; neither server
+  passed `hostname`, so the secret-handling control plane was reachable from the LAN.
+- **H2 — no origin/CSRF protection.** Handlers acted on `req.json()` with no `Origin`
+  or `Host` check on a fixed, predictable port — so any web page the user visited (or a
+  DNS-rebinding attack) could drive-by POST to clone repos, set keys, or brute-force
+  the store passphrase.
+- **M1 — path injection (`js/path-injection`).** `/api/fs/list` passed the request's
+  `path` straight to `readdirSync`/`statSync`, an arbitrary directory-listing oracle.
+
+### Decision
+
+1. **Loopback bind (H1).** Both `Bun.serve` instances bind `hostname: "127.0.0.1"`.
+   The Electron window already loads `http://localhost:PORT`, so loopback is the
+   complete, correct surface; the LAN is removed entirely.
+2. **A single front gate (H2).** `desktop/origin_guard.ts` — a pure, unit-tested
+   `isAllowedRequest()` — runs before routing in both servers and 403s anything forged:
+   - **Host allowlist** on *every* method (`localhost|127.0.0.1|[::1]:PORT`) — defeats
+     DNS rebinding, where the socket is loopback but the `Host` is the attacker's domain.
+   - **Origin allowlist** on state-changing methods — blocks drive-by cross-site POSTs
+     (a null Origin is allowed for local non-browser tools; a browser attack always
+     carries a non-null foreign Origin, and is already past the Host gate regardless).
+   - **JSON content-type** on state-changing methods — blocks `<form>`/simple-request
+     CSRF, which cannot set `application/json` without a preflight we never grant.
+3. **Path containment (M1).** `desktop/path_guard.ts`'s `pathWithin()` canonicalizes
+   the requested path (collapsing `../`) and confirms it stays inside the user's home
+   subtree before `/api/fs/list` touches the FS; the returned `parent` is likewise
+   clamped so the browser never offers a path above home. Separator-aware prefix
+   matching avoids the `/home/user` vs `/home/user-evil` sibling-prefix bypass.
+
+### Why
+
+Defense in depth: loopback bind closes the LAN; the Host gate closes DNS rebinding;
+the Origin + content-type gate closes drive-by CSRF from a page the user is browsing;
+path containment turns the FS browser back into a folder picker. Each is independent,
+so no single bypass re-opens the control plane.
+
+### Integration with the invariants
+
+- **Fail-closed is law (invariant #3).** The guard is allow-listed: an unrecognized
+  Host/Origin or a missing JSON body is rejected, never waved through. The security
+  gate, scanner, and quarantine semantics are untouched — this hardens the *transport*
+  around them, not their logic.
+- **Extend omp; never fork it (invariant #1).** All changes live in the GUI shell
+  (`desktop/`, `tools/web/`). No omp or scanner-sidecar change.
+- **The language boundary is fixed (invariant #2).** New code is TypeScript; no new
+  Python surface.
+- **No new dependencies.** Pure standard-library (`node:path`, WHATWG `URL`, `Headers`).
+
+### Honest residual
+
+- **Import / vault `dest` paths** (`/api/personal/import`, `/api/personal/vault`,
+  `cui-archive`) still take an explicit user-supplied path. With H1+H2 the remote/CSRF
+  vector is closed, so the residual is "the local user reads/writes their own chosen
+  files" — the intended function. Tightening these to an allow-listed root is a
+  candidate follow-up, not part of this increment.
+- A **per-launch capability token** (minted in `main.ts`, required as a header) would
+  add a fourth, transport-independent layer. Deferred: the Host + Origin + bind trio
+  already defeats the realistic browser/LAN attacks without threading a secret through
+  the renderer. Tracked as future hardening.
+
+### Phases — one increment each (session ritual)
+
+- **P11.3/SEC (this increment)** — `origin_guard.ts` + `path_guard.ts` (+ unit tests),
+  loopback bind and the front gate wired into `desktop/dev.ts` and `tools/web/server.ts`,
+  and the `/api/fs/list` containment. Verified live: legit GET 200; forged Host 403;
+  cross-site JSON POST 403; `fs/list?path=/etc` returns home, not `/etc`.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -975,3 +975,17 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
   GUI-side telemetry persistence (two-process DuckDB); MCP tool output scanning relies on the
   existing gate (omp tool calls are already scanned) — confirm the path in P-MCP.2.
 - **next:** P-MCP.2 — Entra/Okta OIDC via ephemeral-localhost PKCE + safeStorage via Electron main.
+
+## P11.3/SEC: local control-plane hardening (ADR-0022 — SAST H1/H2/M1)
+- **shipped:** CodeQL/SAST fixes for the desktop control plane (desktop/dev.ts, spawned by main.ts as
+  the shipped app's data plane, + tools/web/server.ts). H1: both Bun.serve bind hostname 127.0.0.1
+  (was 0.0.0.0/LAN-exposed). H2: new pure, unit-tested desktop/origin_guard.ts front-gates both
+  servers — Host allowlist (defeats DNS rebinding) on every method + Origin allowlist & JSON
+  content-type on state-changing methods (defeats drive-by CSRF against keys/passphrase/clone). M1:
+  desktop/path_guard.ts pathWithin() confines /api/fs/list to the home subtree (was arbitrary
+  readdir/js/path-injection). Verified live: legit GET 200, forged Host 403, cross-site POST 403,
+  fs/list?path=/etc→home. harness 194 pass, desktop 17 pass (12 new), root+desktop tsc clean.
+- **stubbed:** per-launch capability token (transport-independent 4th layer) deferred; import/vault
+  `dest` paths remain user-scoped (remote/CSRF vector closed by H1/H2) — allow-list tightening is a
+  follow-up. CodeQL alert IDs not machine-fetchable in-session (no list_code_scanning_alerts tool).
+- **next:** optional per-launch token + import/vault `dest` containment; then back to ADR-0021 P11.2 UX.

--- a/desktop/dev.ts
+++ b/desktop/dev.ts
@@ -25,6 +25,8 @@ import { destroyCui, enablePersonal, exportCuiArchive, exportHistory, exportVaul
 import { homedir } from "node:os";
 import { existsSync, readdirSync, statSync } from "node:fs";
 import { dirname } from "node:path";
+import { isAllowedRequest, reqShape } from "./origin_guard.ts";
+import { pathWithin } from "./path_guard.ts";
 
 applyEnv(); // make stored API keys available to a spawned omp acp
 if (loadSettings().headroomEnabled) startHeadroom(); // resume the opt-in compression proxy
@@ -85,10 +87,14 @@ function startOauthBroker(oauthId: string): Promise<{ started: boolean; url: str
 
 const server = Bun.serve({
   port: PORT,
+  hostname: "127.0.0.1", // H1 (ADR-0022): loopback only — this control plane handles keys/passphrases.
   idleTimeout: 60,
   async fetch(req) {
     const url = new URL(req.url);
     const p = url.pathname;
+    // H2 (ADR-0022): reject anything a web page or DNS-rebind could forge against
+    // the fixed local port (foreign Host/Origin, or a non-JSON state-changing body).
+    if (!isAllowedRequest(reqShape(req), PORT)) return new Response("forbidden", { status: 403 });
     try {
       if (p === "/app.js") {
         const { js } = await bundleApp();
@@ -139,8 +145,12 @@ const server = Bun.serve({
       // In-app folder browser (works in the browser build AND Electron — the dev server
       // reads the local FS in both). Lists subdirectories + flags git repos, for Workspace.
       if (p === "/api/fs/list") {
+        // M1 (ADR-0022): the folder browser is confined to the user's home subtree.
+        // pathWithin canonicalizes (collapsing any ../) and rejects anything outside,
+        // so the request path can't turn this into an arbitrary directory-listing oracle.
         const want = url.searchParams.get("path");
-        const base = want && existsSync(want) ? want : homedir();
+        const safe = want ? pathWithin(homedir(), want) : null;
+        const base = safe && existsSync(safe) ? safe : homedir();
         const dirs: { name: string; path: string; isGit: boolean }[] = [];
         try {
           for (const name of readdirSync(base)) {
@@ -150,8 +160,9 @@ const server = Bun.serve({
           }
         } catch { /* unreadable dir */ }
         dirs.sort((a, b) => a.name.localeCompare(b.name));
-        const parent = dirname(base);
-        return json({ ok: true, data: { path: base, parent: parent !== base ? parent : null, home: homedir(), isGit: existsSync(join(base, ".git")), dirs } });
+        const parentDir = dirname(base);
+        const parent = parentDir !== base && pathWithin(homedir(), parentDir) ? parentDir : null; // never offer a parent above home
+        return json({ ok: true, data: { path: base, parent, home: homedir(), isGit: existsSync(join(base, ".git")), dirs } });
       }
 
       // real omp ACP backend (genuine model replies + live session config)

--- a/desktop/origin_guard.test.ts
+++ b/desktop/origin_guard.test.ts
@@ -1,0 +1,74 @@
+// Tests for the local control-plane request guard (H1/H2, ADR-0022).
+import { describe, expect, test } from "bun:test";
+import { hostAllowed, isAllowedRequest, reqShape, type ReqShape } from "./origin_guard.ts";
+
+const PORT = 5319;
+const base: ReqShape = { method: "GET", host: `localhost:${PORT}`, origin: null, contentType: null };
+
+describe("hostAllowed (DNS-rebind defense)", () => {
+  test("accepts loopback authorities on the right port", () => {
+    for (const h of [`localhost:${PORT}`, `127.0.0.1:${PORT}`, `[::1]:${PORT}`, `LOCALHOST:${PORT}`]) {
+      expect(hostAllowed(h, PORT)).toBe(true);
+    }
+  });
+  test("rejects a foreign Host (rebound attacker domain) and wrong port", () => {
+    expect(hostAllowed(`evil.example:${PORT}`, PORT)).toBe(false);
+    expect(hostAllowed(`localhost:${PORT + 1}`, PORT)).toBe(false);
+    expect(hostAllowed(null, PORT)).toBe(false);
+  });
+});
+
+describe("isAllowedRequest", () => {
+  test("same-origin GET passes", () => {
+    expect(isAllowedRequest(base, PORT)).toBe(true);
+  });
+  test("GET with a foreign Host is rejected (rebinding)", () => {
+    expect(isAllowedRequest({ ...base, host: `evil.example:${PORT}` }, PORT)).toBe(false);
+  });
+
+  test("same-origin JSON POST passes", () => {
+    expect(isAllowedRequest(
+      { method: "POST", host: `localhost:${PORT}`, origin: `http://localhost:${PORT}`, contentType: "application/json" },
+      PORT,
+    )).toBe(true);
+  });
+  test("cross-site POST is rejected even with a JSON body (drive-by CSRF)", () => {
+    expect(isAllowedRequest(
+      { method: "POST", host: `localhost:${PORT}`, origin: "https://evil.example", contentType: "application/json" },
+      PORT,
+    )).toBe(false);
+  });
+  test("same-origin POST without a JSON content-type is rejected (form CSRF)", () => {
+    expect(isAllowedRequest(
+      { method: "POST", host: `localhost:${PORT}`, origin: `http://localhost:${PORT}`, contentType: "application/x-www-form-urlencoded" },
+      PORT,
+    )).toBe(false);
+  });
+  test("local non-browser POST (no Origin) with JSON passes", () => {
+    expect(isAllowedRequest(
+      { method: "POST", host: `127.0.0.1:${PORT}`, origin: null, contentType: "application/json; charset=utf-8" },
+      PORT,
+    )).toBe(true);
+  });
+  test("a malformed Origin is rejected", () => {
+    expect(isAllowedRequest(
+      { method: "POST", host: `localhost:${PORT}`, origin: "::not a url::", contentType: "application/json" },
+      PORT,
+    )).toBe(false);
+  });
+});
+
+describe("reqShape", () => {
+  test("extracts the guard-relevant headers from a Request", () => {
+    const req = new Request(`http://localhost:${PORT}/api/auth/key`, {
+      method: "POST",
+      headers: { host: `localhost:${PORT}`, origin: `http://localhost:${PORT}`, "content-type": "application/json" },
+      body: "{}",
+    });
+    const s = reqShape(req);
+    expect(s.method).toBe("POST");
+    expect(s.origin).toBe(`http://localhost:${PORT}`);
+    expect(s.contentType).toContain("application/json");
+    expect(isAllowedRequest(s, PORT)).toBe(true);
+  });
+});

--- a/desktop/origin_guard.ts
+++ b/desktop/origin_guard.ts
@@ -1,0 +1,71 @@
+// desktop/origin_guard.ts — H1/H2 (ADR-0022): local control-plane request guard.
+//
+// The desktop data plane (desktop/dev.ts) and the read-only web dashboard
+// (tools/web/server.ts) listen on a FIXED loopback port and handle secrets:
+// they set provider API keys, unlock the encrypted personal/CUI stores with a
+// passphrase, clone repos, and browse the filesystem — all without per-request
+// auth. Binding to 127.0.0.1 (H1) keeps the LAN out, but a web page the user
+// happens to visit still runs on their machine and can reach loopback. This
+// guard is the second half of the defense:
+//
+//   - Host allowlist  → defeats DNS rebinding. A rebound request carries the
+//     attacker's Host (e.g. evil.example:PORT), never localhost / 127.0.0.1.
+//   - Origin allowlist on state-changing methods → blocks drive-by cross-site
+//     POSTs; the browser always stamps a foreign Origin on those.
+//   - JSON content-type on state-changing methods → blocks <form>/simple-request
+//     CSRF, which cannot set application/json without a preflight we never grant.
+//
+// Pure + side-effect free so it is unit-tested directly, no socket required.
+
+export interface ReqShape {
+  method: string;
+  host: string | null; // Host header
+  origin: string | null; // Origin header (browsers stamp it on all cross-origin + all POST)
+  contentType: string | null; // Content-Type header
+}
+
+const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
+/** Host/Origin authorities we accept for a loopback server on `port`. */
+function localAuthorities(port: number): Set<string> {
+  return new Set(["localhost", "127.0.0.1", "[::1]"].map((h) => `${h}:${port}`));
+}
+
+/** True iff the Host header names this loopback server (defeats DNS rebinding). */
+export function hostAllowed(host: string | null, port: number): boolean {
+  if (!host) return false; // HTTP/1.1 requires Host; a missing one is treated as hostile
+  return localAuthorities(port).has(host.toLowerCase());
+}
+
+/**
+ * The single front gate for both local servers. Reject anything a malicious web
+ * page or a DNS-rebinding attack against the fixed local port could forge.
+ */
+export function isAllowedRequest(r: ReqShape, port: number): boolean {
+  // EVERY request (GET included) must target a loopback Host — this is what
+  // defeats DNS rebinding, where the socket is loopback but the Host is foreign.
+  if (!hostAllowed(r.host, port)) return false;
+  if (SAFE_METHODS.has(r.method.toUpperCase())) return true;
+
+  // State-changing methods: require a same-origin Origin (when the client sends
+  // one) AND a JSON body. A null Origin is allowed for local non-browser tools
+  // (curl, scripts) — they are already past the loopback Host gate and a browser
+  // attack always carries a non-null, foreign Origin.
+  const authorities = localAuthorities(port);
+  let originOk = !r.origin;
+  if (r.origin) {
+    try { originOk = authorities.has(new URL(r.origin).host.toLowerCase()); } catch { originOk = false; }
+  }
+  const jsonBody = (r.contentType ?? "").toLowerCase().includes("application/json");
+  return originOk && jsonBody;
+}
+
+/** Convenience: extract the guard-relevant headers from a Request. */
+export function reqShape(req: Request): ReqShape {
+  return {
+    method: req.method,
+    host: req.headers.get("host"),
+    origin: req.headers.get("origin"),
+    contentType: req.headers.get("content-type"),
+  };
+}

--- a/desktop/path_guard.test.ts
+++ b/desktop/path_guard.test.ts
@@ -1,0 +1,23 @@
+// Tests for filesystem path containment (M1, ADR-0022).
+import { describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
+import { pathWithin } from "./path_guard.ts";
+
+const ROOT = resolve("/home/user");
+
+describe("pathWithin", () => {
+  test("accepts the root itself and descendants", () => {
+    expect(pathWithin(ROOT, ROOT)).toBe(ROOT);
+    expect(pathWithin(ROOT, `${ROOT}/projects`)).toBe(`${ROOT}/projects`);
+    expect(pathWithin(ROOT, "projects/app")).toBe(`${ROOT}/projects/app`);
+  });
+  test("rejects traversal that escapes the root", () => {
+    expect(pathWithin(ROOT, "../../etc/passwd")).toBeNull();
+    expect(pathWithin(ROOT, `${ROOT}/../secret`)).toBeNull();
+    expect(pathWithin(ROOT, "/etc/passwd")).toBeNull();
+  });
+  test("rejects the sibling-prefix bypass", () => {
+    // /home/user-evil shares the /home/user prefix but is NOT inside it.
+    expect(pathWithin(ROOT, "/home/user-evil")).toBeNull();
+  });
+});

--- a/desktop/path_guard.ts
+++ b/desktop/path_guard.ts
@@ -1,0 +1,21 @@
+// desktop/path_guard.ts — M1 (ADR-0022): filesystem path containment.
+//
+// The in-app folder browser (/api/fs/list) takes a directory path straight from
+// the request and hands it to readdirSync/statSync. Unconstrained, that is an
+// arbitrary directory-listing primitive (CodeQL js/path-injection). The browser
+// only ever needs to navigate the user's home subtree, so we canonicalize the
+// requested path and confirm it stays inside an allowed root before touching it.
+
+import { resolve, sep } from "node:path";
+
+/**
+ * Canonicalize `candidate` and return it only if it is `root` or a descendant of
+ * `root`; otherwise null. `resolve` collapses `..` and relative segments, so
+ * `root/../../etc` cannot escape. Comparison is prefix-on-separator to avoid the
+ * classic `/home/user` vs `/home/user-evil` sibling-prefix bypass.
+ */
+export function pathWithin(root: string, candidate: string): string | null {
+  const r = resolve(root);
+  const c = resolve(r, candidate);
+  return c === r || c.startsWith(r + sep) ? c : null;
+}

--- a/tools/web/server.ts
+++ b/tools/web/server.ts
@@ -14,6 +14,7 @@
 
 import { join } from "node:path";
 import { securitySnapshot, memorySnapshot } from "./data.ts";
+import { isAllowedRequest, reqShape } from "../../desktop/origin_guard.ts";
 
 const PORT = Number(process.env.PORT ?? 4317);
 const INDEX = join(import.meta.dir, "index.html");
@@ -26,8 +27,11 @@ function json(data: unknown): Response {
 
 const server = Bun.serve({
   port: PORT,
+  hostname: "127.0.0.1", // H1 (ADR-0022): loopback only.
   async fetch(req) {
     const url = new URL(req.url);
+    // H2 (ADR-0022): loopback-Host gate (defeats DNS rebinding) — read-only, but cheap and consistent.
+    if (!isAllowedRequest(reqShape(req), PORT)) return new Response("forbidden", { status: 403 });
     try {
       if (url.pathname === "/" || url.pathname === "/index.html") {
         return new Response(Bun.file(INDEX), { headers: { "content-type": "text/html; charset=utf-8" } });


### PR DESCRIPTION
## Summary

CodeQL (`security-extended`) + a manual SAST pass over the same sink classes surfaced that the desktop **data plane is the shipped app's control plane** — `desktop/main.ts` spawns `desktop/dev.ts` and the Electron window loads it over `http://localhost:5319`. That server (and the read-only `tools/web/server.ts` dashboard) set provider API keys, unlock the encrypted personal/CUI stores with a passphrase, clone repos, and browse the filesystem with **no bind restriction, no CSRF/origin check, and an unconstrained FS path**.

This PR fixes the three findings. Full rationale in **ADR-0022** (`DECISIONS.md`).

### Findings → fixes

| | Finding | Fix |
|---|---|---|
| **H1** | `Bun.serve` defaulted to `0.0.0.0` → secret-handling control plane reachable from the LAN | Bind `hostname: "127.0.0.1"` in both servers |
| **H2** | No `Origin`/`Host` check on a fixed port → drive-by CSRF / DNS-rebinding could clone repos, set keys, brute-force the store passphrase | New pure `desktop/origin_guard.ts` front-gate: **Host** allowlist on every method (defeats rebinding) + **Origin** allowlist & **JSON content-type** on state-changing methods (defeats CSRF) |
| **M1** | `/api/fs/list` passed request `path` → `readdirSync` (arbitrary directory listing; `js/path-injection`) | New `desktop/path_guard.ts` `pathWithin()` confines the browser to the home subtree; `parent` clamped too |

Defense-in-depth: loopback bind closes the LAN, the Host gate closes DNS rebinding, the Origin + content-type gate closes drive-by CSRF, and containment turns the FS browser back into a folder picker. Each layer is independent.

### Invariants
- **Fail-closed (#3):** allow-listed — unrecognized Host/Origin or missing JSON body is rejected, never waved through. Gate/scanner/quarantine logic untouched (transport hardening only).
- **Extend omp; never fork (#1):** changes confined to `desktop/` + `tools/web/`.
- **Language boundary (#2):** new code is TypeScript; no new Python.
- **No new dependencies:** pure stdlib (`node:path`, WHATWG `URL`, `Headers`).

### Verification
- **Live** against real `dev.ts`: legit GET `200`; forged `Host` `403`; cross-site JSON POST `403`; `fs/list?path=/etc` returns home, not `/etc`.
- `bun test harness` → **194 pass**; `bun test` (desktop) → **17 pass** (12 new across `origin_guard.test.ts` / `path_guard.test.ts`).
- `bun x tsc --noEmit` clean at root **and** desktop.

### Honest residual (documented in ADR-0022, not in this increment)
- Import/vault `dest` paths remain user-scoped — the remote/CSRF vector is closed by H1/H2; allow-list tightening is a follow-up.
- A per-launch capability token would add a 4th, transport-independent layer; deferred since Host + Origin + bind already defeat the realistic browser/LAN attacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrTqRvkZBtq3NdEExxyCLG)_