### PR TITLE
sec(P11.4/SEC): confine GUI import/export file paths to the home subtree (ADR-0023)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1834,3 +1834,77 @@ so no single bypass re-opens the control plane.
   loopback bind and the front gate wired into `desktop/dev.ts` and `tools/web/server.ts`,
   and the `/api/fs/list` containment. Verified live: legit GET 200; forged Host 403;
   cross-site JSON POST 403; `fs/list?path=/etc` returns home, not `/etc`.
+
+-----
+
+## ADR-0023 — GUI filesystem path containment: import sources & export destinations
+
+**Date:** 2026-06-21
+**Status:** Built
+**Context increment:** P11.4/SEC
+
+### Context
+
+ADR-0022 closed the network/CSRF vectors on the local control plane (loopback bind,
+Host/Origin gate) and confined the in-app folder browser (`/api/fs/list`) to the home
+subtree (M1). It explicitly left one residual: the personalization endpoints still took
+an unconstrained filesystem path —
+
+- `/api/personal/import` → `importChatExport(path)` reads an arbitrary file/folder/zip;
+- `/api/personal/vault` → `exportVault({ dest })` writes the Obsidian vault to an
+  arbitrary directory;
+- `/api/personal/cui-archive` → `exportCuiArchive({ dest })` writes the NARA-aligned CUI
+  archive to an arbitrary directory.
+
+`writeFiles()` already refused paths escaping the chosen `dest`, but the `dest` (and the
+import source) themselves were unbounded — an arbitrary-read primitive on import and an
+arbitrary-write location on export (CodeQL `js/path-injection`).
+
+### Decision
+
+Confine **every GUI-driven file path — import source and export destination — to the
+user's home subtree**, the same boundary M1 already applies to the folder browser.
+
+`desktop/personal.ts` gains `confineToHome(p)`, a one-liner over ADR-0022's
+`pathWithin(homedir(), p)` (canonicalizes, collapses `../`, separator-aware prefix match
+to avoid the `~user` vs `~user-evil` sibling bypass). It runs as **early input
+validation** — before the personalization/store-unlocked guards — in `exportVault`,
+`exportCuiArchive`, and `importChatExport`. An out-of-bounds path returns a plain
+"…inside your home folder" error; an in-bounds path yields the canonical path used for
+all subsequent FS work. Every default destination (`~/.omp/lucid-vault`,
+`~/.omp/lucid-cui-archive`) already lives under home, so defaults are unaffected.
+
+### Why
+
+The home subtree is exactly what the in-app folder browser can navigate (M1) and where
+every default already sits, so containment matches real usage while removing the
+arbitrary read/write. Validating up front (before stateful guards) keeps the check in
+one obvious place and makes it unit-testable without standing up an encrypted store.
+
+### Integration with the invariants
+
+- **Fail-closed is law (#3).** Allow-listed: a path that doesn't resolve inside home is
+  rejected, never written to or read from. The scanner gate that imported messages still
+  pass (keystone #2) is unchanged — this adds a path boundary *before* it.
+- **Extend omp; never fork (#1) / language boundary (#2).** TypeScript only, all in
+  `desktop/`. Reuses the ADR-0022 `path_guard.ts` helper; no new dependency.
+- **Frozen contracts.** No contract, schema, or prompt-prefix change.
+
+### Honest residual
+
+- **External drives / paths outside home** (e.g. exporting a vault to a mounted backup
+  volume) are now rejected. This is the deliberate tradeoff; a future increment can add an
+  explicit, user-confirmed allow-list entry for a chosen external root rather than
+  widening the default boundary.
+- `setWorkspace`/`cloneRepo` already write under `~/.omp/lucid-workspaces`; tightening the
+  local-folder `setWorkspace` path is a small follow-up, not bundled here.
+- The per-launch capability token (ADR-0022's deferred 4th layer) remains future work;
+  the chosen design is server-minted + HTML-injected so it covers both the Electron and
+  the plain-browser dev runtimes.
+
+### Phases — one increment each (session ritual)
+
+- **P11.4/SEC (this increment)** — `confineToHome()` + early-validation wiring in
+  `exportVault` / `exportCuiArchive` / `importChatExport`, with `desktop/personal_paths.test.ts`
+  (7 tests: outside-home rejected with the home-folder message, inside-home passes
+  containment, traversal-escape rejected).

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -989,3 +989,17 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
   `dest` paths remain user-scoped (remote/CSRF vector closed by H1/H2) — allow-list tightening is a
   follow-up. CodeQL alert IDs not machine-fetchable in-session (no list_code_scanning_alerts tool).
 - **next:** optional per-launch token + import/vault `dest` containment; then back to ADR-0021 P11.2 UX.
+
+## P11.4/SEC: GUI filesystem path containment (ADR-0023 — completes ADR-0022 M2 residual)
+- **shipped:** confined the personalization endpoints' file paths to the user's home subtree, the
+  same boundary M1 gave the folder browser. desktop/personal.ts gains confineToHome() (reuses
+  ADR-0022 path_guard.pathWithin) run as EARLY input validation in exportVault, exportCuiArchive,
+  and importChatExport — an out-of-home dest/source is rejected ("…inside your home folder") before
+  any FS read/write, closing the residual arbitrary-read (import) / arbitrary-write (export dest)
+  from ADR-0022 (CodeQL js/path-injection). Defaults (~/.omp/lucid-vault, lucid-cui-archive) are
+  under home, unaffected. New desktop/personal_paths.test.ts (7 pass). desktop 24 pass (+7), harness
+  194 pass, root+desktop tsc clean.
+- **stubbed:** external-drive exports are now rejected (deliberate tradeoff — future explicit
+  user-confirmed allow-list entry); setWorkspace local-folder path tightening not bundled here.
+- **next:** the per-launch capability token (server-minted + HTML-injected, both runtimes); optional
+  setWorkspace containment; then back to ADR-0021 P11.2 UX.

--- a/desktop/personal.ts
+++ b/desktop/personal.ts
@@ -7,6 +7,8 @@
 
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { dirname, join, normalize, sep } from "node:path";
+import { homedir } from "node:os";
+import { pathWithin } from "./path_guard.ts";
 import { CUI_STORE_VERSION, PersonalStore, type PersonalGraph, type PersonalScope, type ScopeView } from "../harness/personal/store.ts";
 import { load, personalAuditPath, personalCuiArchiveDir, personalCuiStorePath, personalStorePath, personalVaultDir, setPersonalization, setPersonalScope } from "./settings_store.ts";
 import { buildRecall, buildRecallFromGraph } from "../harness/personal/recall.ts";
@@ -164,6 +166,15 @@ export interface ExportSummary {
   scopes?: PersonalScope[]; includedCui?: boolean; payloadSha256?: string; manifestSha256?: string;
 }
 
+// M2 (ADR-0023): confine every GUI-driven file path — an import SOURCE or an export DESTINATION —
+// to the user's home subtree, the same boundary the in-app folder browser navigates (M1, ADR-0022).
+// writeFiles() already contains files WITHIN the chosen dir; this confines the dir/source ITSELF so
+// the GUI can't read an arbitrary file or write an export outside home. Canonicalizes (collapsing
+// any ../) and returns the safe absolute path, or null for the caller to turn into a user error.
+function confineToHome(p: string): string | null {
+  return pathWithin(homedir(), p);
+}
+
 /** Write the export's files under destDir, refusing any path that escapes it. Returns bytes. */
 function writeFiles(destDir: string, files: VaultFile[]): number {
   const root = normalize(destDir);
@@ -188,6 +199,8 @@ function auditExport(event: "personal_vault_exported" | "personal_cui_archived" 
  *  (ADR-0012). Decrypt→write→audit: writes files, records the action inside the
  *  encrypted store, and emits a metadata-only telemetry event. */
 export function exportVault(opts: { scopes?: PersonalScope[]; dest?: string; reviewer?: string } = {}): ExportSummary {
+  const dest = confineToHome(opts.dest?.trim() || personalVaultDir());
+  if (!dest) return { ok: false, error: "Export destination must be inside your home folder." };
   const s = load();
   if (!s.personalizationEnabled || !store) return { ok: false, error: "Personalization is off or locked." };
   // The portable vault reads the MAIN store only — CUI lives in its own isolated store and is
@@ -195,7 +208,6 @@ export function exportVault(opts: { scopes?: PersonalScope[]; dest?: string; rev
   const scopes = (opts.scopes && opts.scopes.length ? opts.scopes : (["personal", "work"] as PersonalScope[]))
     .filter((x): x is PersonalScope => x === "personal" || x === "work");
   if (!scopes.length) return { ok: false, error: "Select Personal and/or Work to export. CUI uses the CUI archive." };
-  const dest = opts.dest?.trim() || personalVaultDir();
   try {
     const build = buildVault(store.graph({ scope: "combined" }), { scopes, now: new Date().toISOString() });
     if (build.summary.entities === 0) return { ok: false, error: "Nothing to export in the selected compartment(s) yet." };
@@ -218,11 +230,12 @@ export function exportVault(opts: { scopes?: PersonalScope[]; dest?: string; rev
  *  Archives / NARA records management). Exports ONLY the cui scope into a CUI-marked,
  *  records-managed package with a SHA-256 manifest. Never bundled into the normal vault. */
 export function exportCuiArchive(opts: { dest?: string; designation?: CuiDesignation; reviewer?: string } = {}): ExportSummary {
+  const dest = confineToHome(opts.dest?.trim() || personalCuiArchiveDir());
+  if (!dest) return { ok: false, error: "Archive destination must be inside your home folder." };
   const s = load();
   if (!s.personalizationEnabled) return { ok: false, error: "Personalization is off." };
   if (!cuiStore) return { ok: false, error: "Unlock the CUI store first (select the CUI compartment and enter its passphrase)." };
   if (cuiStore.scopeCounts().cui === 0) return { ok: false, error: "No CUI-compartment facts to archive." };
-  const dest = opts.dest?.trim() || personalCuiArchiveDir();
   const designation = { ...opts.designation, reviewer: opts.reviewer ?? opts.designation?.reviewer };
   try {
     const build = buildCuiArchive(cuiStore.graph({ scope: "cui" }), { now: new Date().toISOString(), designation });
@@ -376,6 +389,13 @@ export async function importChatExport(
   pathArg: string,
   opts: { vendorHint?: ImportVendor; complete?: (system: string, user: string) => Promise<string> } = {},
 ): Promise<ImportResult> {
+  // Validate the untrusted source path up front (M2, ADR-0023): it must resolve inside home,
+  // so an import can't be pointed at an arbitrary file (e.g. /etc/passwd) to read it in.
+  const raw = String(pathArg ?? "").trim();
+  if (!raw) return { ok: false, error: "Choose your exported folder, .json, or .zip." };
+  const safe = confineToHome(raw);
+  if (!safe) return { ok: false, error: "Choose a file inside your home folder." };
+
   const s = load();
   if (!s.personalizationEnabled) return { ok: false, error: "Personalization is off." };
   const view = (s.personalScope ?? "personal") as ScopeView;
@@ -383,9 +403,7 @@ export async function importChatExport(
   const target = scope === "cui" ? cuiStore : store;
   if (!target) return { ok: false, error: scope === "cui" ? "Unlock the CUI store first (select CUI and enter its passphrase)." : "Unlock your store first." };
 
-  const raw = String(pathArg ?? "").trim();
-  if (!raw) return { ok: false, error: "Choose your exported folder, .json, or .zip." };
-  const loaded = loadExportText(raw);
+  const loaded = loadExportText(safe);
   if (!loaded.ok) return loaded;
   let data: unknown;
   try { data = JSON.parse(loaded.text); }

--- a/desktop/personal_paths.test.ts
+++ b/desktop/personal_paths.test.ts
@@ -1,0 +1,58 @@
+// Tests for GUI file-path containment (M2, ADR-0023): import sources and export
+// destinations must resolve inside the user's home subtree. The containment check
+// runs before the stateful (store-unlocked) guards, so these exercise it without
+// creating a real encrypted store: an outside-home path is rejected with the
+// "home folder" message; an inside-home path passes containment and falls through
+// to the next guard (a different message), proving the boundary is scoped, not blanket.
+import { describe, expect, test } from "bun:test";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { exportCuiArchive, exportVault, importChatExport } from "./personal.ts";
+
+const OUTSIDE = "/etc/lucid-escape"; // not under homedir()
+const INSIDE = join(homedir(), ".omp", "lucid-probe");
+const homeMsg = /home folder/i;
+
+describe("exportVault dest containment", () => {
+  test("rejects a destination outside home", () => {
+    const r = exportVault({ dest: OUTSIDE });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(homeMsg);
+  });
+  test("an inside-home destination passes containment (different guard fires)", () => {
+    const r = exportVault({ dest: INSIDE });
+    expect(r.ok).toBe(false);
+    expect(r.error ?? "").not.toMatch(homeMsg); // got past containment
+  });
+  test("traversal that escapes home is rejected", () => {
+    const r = exportVault({ dest: join(homedir(), "..", "..", "etc") });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(homeMsg);
+  });
+});
+
+describe("exportCuiArchive dest containment", () => {
+  test("rejects a destination outside home", () => {
+    const r = exportCuiArchive({ dest: OUTSIDE });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(homeMsg);
+  });
+  test("an inside-home destination passes containment", () => {
+    const r = exportCuiArchive({ dest: INSIDE });
+    expect(r.ok).toBe(false);
+    expect(r.error ?? "").not.toMatch(homeMsg);
+  });
+});
+
+describe("importChatExport source containment", () => {
+  test("rejects a source path outside home (e.g. /etc/passwd)", async () => {
+    const r = await importChatExport("/etc/passwd");
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(homeMsg);
+  });
+  test("an inside-home source passes containment (different guard fires)", async () => {
+    const r = await importChatExport(INSIDE);
+    expect(r.ok).toBe(false);
+    expect(r.error ?? "").not.toMatch(homeMsg);
+  });
+});


### PR DESCRIPTION
## Summary

Completes the path-injection residual ADR-0022 explicitly deferred. The personalization endpoints still took an **unconstrained filesystem path**:

- `/api/personal/import` → `importChatExport(path)` read an arbitrary file/folder/zip (arbitrary **read**)
- `/api/personal/vault` → `exportVault({ dest })` wrote to an arbitrary directory (arbitrary **write location**)
- `/api/personal/cui-archive` → `exportCuiArchive({ dest })` same

`writeFiles()` already contained files *within* the chosen dir, but the dir/source itself was unbounded (CodeQL `js/path-injection`).

## Fix

New `confineToHome(p)` in `desktop/personal.ts` — a one-liner over ADR-0022's `pathWithin(homedir(), p)` (canonicalizes, collapses `../`, separator-aware to avoid the `~user` vs `~user-evil` sibling bypass). It runs as **early input validation**, before the personalization/store-unlocked guards, in all three functions. A path that doesn't resolve inside the user's **home subtree** — the same boundary the M1 folder browser navigates — is rejected with a plain "…inside your home folder" error before any FS read/write.

Every default destination (`~/.omp/lucid-vault`, `~/.omp/lucid-cui-archive`) already lives under home, so defaults are unaffected.

## Invariants
- **Fail-closed (#3):** allow-listed — out-of-bounds paths are rejected, never read/written. The import scanner gate (keystone #2) is unchanged; this adds a path boundary *before* it.
- **Extend omp / language boundary (#1, #2):** TypeScript only, all in `desktop/`; reuses `path_guard.ts`, no new dependency.
- No frozen-contract, schema, or prompt-prefix change.

## Verification
- `desktop/personal_paths.test.ts` — **7 new tests**: outside-home rejected with the home-folder message; inside-home passes containment (a *different* guard fires, proving the boundary is scoped, not blanket); traversal-escape rejected.
- `bun test` (desktop) → **24 pass** (+7); `bun test harness` → **194 pass**; `bun x tsc --noEmit` clean at root **and** desktop.

## Honest residual (in ADR-0023)
- **External-drive exports** (outside home) are now rejected — the deliberate tradeoff; a future increment can add an explicit, user-confirmed allow-list entry for a chosen external root.
- `setWorkspace` local-folder path tightening is a small follow-up, not bundled here.
- The per-launch capability token (ADR-0022's deferred 4th layer) remains future work; chosen design is **server-minted + HTML-injected** so it covers both the Electron and plain-browser runtimes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrTqRvkZBtq3NdEExxyCLG)_