### PR TITLE
sec(P11.5/SEC): per-launch capability token on the local control plane (ADR-0024)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1908,3 +1908,76 @@ one obvious place and makes it unit-testable without standing up an encrypted st
   `exportVault` / `exportCuiArchive` / `importChatExport`, with `desktop/personal_paths.test.ts`
   (7 tests: outside-home rejected with the home-folder message, inside-home passes
   containment, traversal-escape rejected).
+
+-----
+
+## ADR-0024 — Per-launch capability token: a transport-independent gate on the local control plane
+
+**Date:** 2026-06-21
+**Status:** Built
+**Context increment:** P11.5/SEC
+
+### Context
+
+ADR-0022 hardened the desktop control plane (`desktop/dev.ts`, spawned by `main.ts` and loaded by
+the Electron window over `http://localhost:PORT`) with three network-shaped layers: a loopback bind,
+a Host allowlist (DNS-rebind defense), and an Origin + JSON-content-type gate (CSRF defense). Those
+defeat the realistic browser/LAN attacks, but every one keys off request *headers* the browser
+populates — so they share a failure mode: a future gap in that header logic, or any local process
+that can forge a same-origin-looking request, would be through. ADR-0022 explicitly deferred a 4th,
+*transport-independent* layer that doesn't rely on header heuristics.
+
+### Decision
+
+Mint a **per-launch capability token** and require it on the sensitive API surface.
+
+1. **Mint.** `dev.ts` generates `randomBytes(32).toString("hex")` once per process. A fresh value
+   each launch means a captured token never outlives the server that issued it.
+2. **Deliver.** When serving `index.html`, the server injects `<meta name="lucid-token" content="…">`
+   into `<head>`. The same-origin policy prevents a cross-origin page from reading this response
+   body, so only the genuine renderer — which actually loaded our HTML — learns the token.
+3. **Echo.** `bridge.ts` reads the meta once at load and sends it as `x-lucid-token` on every
+   `/api` call (the two fetch wrappers plus the chat-stream and sessions fetches).
+4. **Verify.** After the ADR-0022 Host/Origin gate, `dev.ts` requires `tokenValid(header, TOKEN)`
+   on `p.startsWith("/api/")`. `tokenValid` (in `origin_guard.ts`) is a pure, constant-time-ish
+   compare that fails closed on an empty/missing/wrong token.
+
+**Exemptions:** `/api/health` (polled by `main.ts` *before* the page — and thus the token — exists;
+returns no data) and all non-`/api` paths (HTML, `/app.js`, CSS, fonts — loaded before any JS could
+carry a token, and free of secrets).
+
+### Why this design (server-minted + HTML-injected)
+
+It covers **both** runtimes with no `main.ts` change: the Electron window and the plain-browser dev
+workflow (`bun run desktop:web`) both load the injected HTML and get a working token. A
+`main.ts`-minted/env-passed token would have to be threaded into the renderer separately and would
+break the browser-only dev/screenshot path. The token is a *defense-in-depth* layer, not the only
+one — it sits behind the loopback bind and the Host/Origin gate, so a single bypass of any one layer
+doesn't re-open the plane.
+
+### Integration with the invariants
+
+- **Fail-closed is law (#3).** `tokenValid` returns false for an empty configured token, a missing
+  header, or any mismatch — never waves through. Health/asset exemptions carry no secrets and mutate
+  nothing.
+- **Extend omp; never fork (#1) / language boundary (#2).** TypeScript only, confined to `desktop/`.
+- **Prompt prefix / frozen contracts.** Untouched — this is transport, not prompt or schema.
+- **No new dependencies.** `node:crypto` (stdlib) for the mint; a `<meta>` tag for delivery.
+
+### Honest residual
+
+- **`tools/web/server.ts`** (the separate read-only dashboard on its own port) keeps only the
+  ADR-0022 Host/Origin gate — it serves no `bridge.ts`/`app.js` to carry a token and exposes only
+  read-only snapshots (no keys, passphrases, clone, or FS). Adding a token there is a low-value
+  follow-up, not bundled.
+- The token lives in the DOM of a trusted, same-origin page; a successful **XSS in the renderer**
+  could read it. That is already a full compromise of the renderer (the markdown path is
+  DOMPurify-sanitized, ADR-0016), so the token doesn't widen that blast radius — but it does mean
+  the token defends the *network/CSRF* boundary, not an in-page script-injection one.
+
+### Phases — one increment each (session ritual)
+
+- **P11.5/SEC (this increment)** — `tokenValid` + tests in `origin_guard.ts`; mint/inject/verify in
+  `dev.ts`; `x-lucid-token` on every `bridge.ts` fetch. Verified live: HTML carries the meta token;
+  `/api/usage` and `/api/personal/unlock` 403 without it / 200 with it (the latter even with a valid
+  Origin, proving independence); `/api/health` and static assets need none.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1003,3 +1003,19 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
   user-confirmed allow-list entry); setWorkspace local-folder path tightening not bundled here.
 - **next:** the per-launch capability token (server-minted + HTML-injected, both runtimes); optional
   setWorkspace containment; then back to ADR-0021 P11.2 UX.
+
+## P11.5/SEC: per-launch capability token (ADR-0024 — ADR-0022's deferred 4th layer)
+- **shipped:** a transport-independent gate on the desktop control plane (desktop/dev.ts). dev.ts
+  mints randomBytes(32) hex once per launch, injects it as <meta name="lucid-token"> into served
+  index.html (SOP keeps cross-origin pages from reading it), and requires it via tokenValid() (new
+  pure, constant-time-ish fn in origin_guard.ts) on every /api/* call except /api/health. bridge.ts
+  reads the meta once and echoes x-lucid-token on all four fetch sites. Static assets/HTML need no
+  token. Sits BEHIND the ADR-0022 loopback bind + Host/Origin gate (defense-in-depth). Verified live:
+  HTML carries the token; /api/usage + /api/personal/unlock 403 without it, 200 with it (latter even
+  with a valid Origin → independent layer); health + styles.css need none. desktop 27 pass (+3),
+  harness 194 pass, root+desktop tsc clean, renderer bundles.
+- **stubbed:** tools/web read-only dashboard keeps only the Host/Origin gate (serves no bridge/app.js
+  to carry a token; no secrets) — low-value follow-up. Token is DOM-readable, so a renderer XSS could
+  read it (already full renderer compromise; markdown is DOMPurify-sanitized) — it guards the
+  network/CSRF boundary, not in-page injection.
+- **next:** optional token for tools/web; setWorkspace path containment; then back to ADR-0021 P11.2 UX.

--- a/desktop/dev.ts
+++ b/desktop/dev.ts
@@ -25,8 +25,9 @@ import { destroyCui, enablePersonal, exportCuiArchive, exportHistory, exportVaul
 import { homedir } from "node:os";
 import { existsSync, readdirSync, statSync } from "node:fs";
 import { dirname } from "node:path";
-import { isAllowedRequest, reqShape } from "./origin_guard.ts";
+import { isAllowedRequest, reqShape, tokenValid } from "./origin_guard.ts";
 import { pathWithin } from "./path_guard.ts";
+import { randomBytes } from "node:crypto";
 
 applyEnv(); // make stored API keys available to a spawned omp acp
 if (loadSettings().headroomEnabled) startHeadroom(); // resume the opt-in compression proxy
@@ -38,6 +39,10 @@ function ompBin(): string {
 
 const ROOT = join(import.meta.dir, "renderer");
 const PORT = Number(process.env.PORT ?? 5319);
+// ADR-0024: per-launch capability token. Minted once per server process, injected into the served
+// HTML (only a same-origin document can read it), and required on every sensitive /api call. A new
+// random value each launch means a token never outlives the process that issued it.
+const TOKEN = randomBytes(32).toString("hex");
 const CT: Record<string, string> = { ".html": "text/html", ".css": "text/css", ".js": "text/javascript", ".svg": "image/svg+xml", ".woff2": "font/woff2", ".woff": "font/woff", ".ttf": "font/ttf" };
 
 async function bundleApp(): Promise<{ js: string; ok: boolean }> {
@@ -95,6 +100,11 @@ const server = Bun.serve({
     // H2 (ADR-0022): reject anything a web page or DNS-rebind could forge against
     // the fixed local port (foreign Host/Origin, or a non-JSON state-changing body).
     if (!isAllowedRequest(reqShape(req), PORT)) return new Response("forbidden", { status: 403 });
+    // ADR-0024: the sensitive /api surface additionally requires the per-launch token (carried by
+    // the renderer from the injected HTML). /api/health is exempt — main.ts polls it before the
+    // page (and thus the token) exists, and it returns no data. Static assets/HTML aren't /api/*.
+    if (p.startsWith("/api/") && p !== "/api/health" && !tokenValid(req.headers.get("x-lucid-token"), TOKEN))
+      return new Response("forbidden", { status: 403 });
     try {
       if (p === "/app.js") {
         const { js } = await bundleApp();
@@ -300,6 +310,14 @@ const server = Bun.serve({
       }
 
       const rel = p === "/" ? "index.html" : p.replace(/^\/+/, "");
+      // ADR-0024: serve the HTML with the per-launch token injected as a meta tag. Same-origin
+      // policy keeps a cross-origin page from reading this response body, so the token stays secret
+      // to the real renderer; no-store so it's never cached across launches.
+      if (rel === "index.html") {
+        const html = (await Bun.file(join(ROOT, "index.html")).text())
+          .replace("</head>", `  <meta name="lucid-token" content="${TOKEN}">\n</head>`);
+        return new Response(html, { headers: { "content-type": "text/html; charset=utf-8", "cache-control": "no-store" } });
+      }
       const file = Bun.file(join(ROOT, rel));
       if (await file.exists()) {
         const ext = rel.slice(rel.lastIndexOf("."));

--- a/desktop/origin_guard.test.ts
+++ b/desktop/origin_guard.test.ts
@@ -1,6 +1,6 @@
 // Tests for the local control-plane request guard (H1/H2, ADR-0022).
 import { describe, expect, test } from "bun:test";
-import { hostAllowed, isAllowedRequest, reqShape, type ReqShape } from "./origin_guard.ts";
+import { hostAllowed, isAllowedRequest, reqShape, tokenValid, type ReqShape } from "./origin_guard.ts";
 
 const PORT = 5319;
 const base: ReqShape = { method: "GET", host: `localhost:${PORT}`, origin: null, contentType: null };
@@ -55,6 +55,23 @@ describe("isAllowedRequest", () => {
       { method: "POST", host: `localhost:${PORT}`, origin: "::not a url::", contentType: "application/json" },
       PORT,
     )).toBe(false);
+  });
+});
+
+describe("tokenValid (capability token)", () => {
+  const TOKEN = "a".repeat(64);
+  test("accepts the exact token", () => {
+    expect(tokenValid(TOKEN, TOKEN)).toBe(true);
+  });
+  test("rejects a wrong, short, or missing token", () => {
+    expect(tokenValid("b".repeat(64), TOKEN)).toBe(false);
+    expect(tokenValid("a".repeat(63), TOKEN)).toBe(false);
+    expect(tokenValid(null, TOKEN)).toBe(false);
+    expect(tokenValid("", TOKEN)).toBe(false);
+  });
+  test("fails closed when no token is configured", () => {
+    expect(tokenValid("anything", "")).toBe(false);
+    expect(tokenValid("", "")).toBe(false);
   });
 });
 

--- a/desktop/origin_guard.ts
+++ b/desktop/origin_guard.ts
@@ -69,3 +69,21 @@ export function reqShape(req: Request): ReqShape {
     contentType: req.headers.get("content-type"),
   };
 }
+
+// ── Per-launch capability token (ADR-0024) ───────────────────────────────────
+// A 4th, transport-independent layer: dev.ts mints a random token at boot and
+// injects it into the served HTML, which only a same-origin document can read
+// (SOP blocks a cross-origin page from reading the response body). The renderer
+// echoes it back as `x-lucid-token` on every sensitive /api call. This holds even
+// if the Host/Origin checks ever had a gap, and even against a same-origin-looking
+// request that never loaded our HTML (it can't know the token).
+//
+// Constant-time-ish compare: the length check leaks only the (fixed, public) token
+// length; the byte loop does not early-exit on the first mismatch.
+export function tokenValid(provided: string | null, expected: string): boolean {
+  if (!expected) return false; // no token configured → fail closed, never wave through
+  if (!provided || provided.length !== expected.length) return false;
+  let diff = 0;
+  for (let i = 0; i < expected.length; i++) diff |= provided.charCodeAt(i) ^ expected.charCodeAt(i);
+  return diff === 0;
+}

--- a/desktop/renderer/bridge.ts
+++ b/desktop/renderer/bridge.ts
@@ -200,11 +200,20 @@ interface NativeShell {
 declare global { interface Window { lucid?: NativeShell } }
 const shell: NativeShell | undefined = typeof window !== "undefined" ? window.lucid : undefined;
 
+// ADR-0024: the per-launch capability token, injected into the served HTML by dev.ts. We echo it
+// on every /api call so the server can tell the real renderer from a forged request. Read once at
+// load; absent in a stray non-injected page (then calls are simply rejected, fail-closed).
+const TOKEN = typeof document !== "undefined"
+  ? (document.querySelector('meta[name="lucid-token"]') as HTMLMetaElement | null)?.content ?? ""
+  : "";
+const authHeaders = (extra?: Record<string, string>): Record<string, string> =>
+  ({ ...(TOKEN ? { "x-lucid-token": TOKEN } : {}), ...extra });
+
 async function getData(path: string): Promise<any> {
-  try { return (await (await fetch(path, { cache: "no-store" })).json())?.data ?? null; } catch { return null; }
+  try { return (await (await fetch(path, { cache: "no-store", headers: authHeaders() })).json())?.data ?? null; } catch { return null; }
 }
 async function post(path: string, body: unknown): Promise<any> {
-  try { return (await (await fetch(path, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) })).json())?.data ?? null; } catch { return null; }
+  try { return (await (await fetch(path, { method: "POST", headers: authHeaders({ "content-type": "application/json" }), body: JSON.stringify(body) })).json())?.data ?? null; } catch { return null; }
 }
 
 // Mock config only as a last resort if the backend can't be reached (no omp).
@@ -221,7 +230,7 @@ const FALLBACK_CONFIG: ConfigOption[] = [
 async function streamChat(text: string, onEvent: (e: ChatEvent) => void): Promise<void> {
   let res: Response;
   try {
-    res = await fetch("/api/chat", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ text }) });
+    res = await fetch("/api/chat", { method: "POST", headers: authHeaders({ "content-type": "application/json" }), body: JSON.stringify({ text }) });
   } catch {
     onEvent({ type: "token", text: "[chat backend unreachable - is the GUI server running?]" });
     onEvent({ type: "done" });
@@ -266,7 +275,7 @@ export const bridge: LucidBridge = {
   skills: () => getData("/api/skills"),
   sessions: async () => {
     try {
-      const r = await fetch("/api/sessions", { cache: "no-store" });
+      const r = await fetch("/api/sessions", { cache: "no-store", headers: authHeaders() });
       if (r.status === 404) return null; // server predates the sessions route → out of date
       return (await r.json())?.data ?? [];
     } catch { return null; }


### PR DESCRIPTION
## Summary

Adds the **4th, transport-independent** layer ADR-0022 deferred. Its three existing layers — loopback bind, Host allowlist (DNS-rebind), Origin + content-type gate (CSRF) — all key off browser-populated *headers*, so they share a failure mode. A per-launch capability token closes it.

## How it works

1. **Mint** — `dev.ts` generates `randomBytes(32).toString("hex")` once per process (fresh each launch).
2. **Deliver** — when serving `index.html`, the server injects `<meta name="lucid-token" content="…">`. The same-origin policy stops a cross-origin page from reading the response body, so only the genuine renderer (which actually loaded our HTML) learns the token.
3. **Echo** — `bridge.ts` reads the meta once and sends `x-lucid-token` on every `/api` call (both fetch wrappers + chat-stream + sessions).
4. **Verify** — after the ADR-0022 Host/Origin gate, `dev.ts` requires `tokenValid(header, TOKEN)` on `/api/*`. `tokenValid` (in `origin_guard.ts`) is a pure, constant-time-ish, fail-closed compare.

**Exempt:** `/api/health` (polled by `main.ts` before the page/token exists; returns no data) and all non-`/api` paths (HTML, `/app.js`, CSS, fonts — loaded before any JS could carry a token; no secrets).

This is **defense in depth** — it sits *behind* the loopback bind and Host/Origin gate, so a single bypass of any one layer doesn't re-open the plane.

### Why server-minted + HTML-injected
Covers **both** runtimes with no `main.ts` change: the Electron window and the plain-browser dev workflow (`bun run desktop:web`) both load the injected HTML. A `main.ts`-minted/env token would need separate renderer threading and would break the browser-only dev/screenshot path.

## Invariants
- **Fail-closed (#3):** `tokenValid` rejects empty/missing/wrong tokens; exemptions carry no secrets and mutate nothing.
- **Extend omp / language boundary (#1, #2):** TypeScript, confined to `desktop/`.
- **No new dependencies:** `node:crypto` (stdlib) + a `<meta>` tag. No prompt-prefix/schema/contract change.

## Verification
- **Live** against real `dev.ts`: HTML carries the meta token; `/api/usage` and `/api/personal/unlock` → **403** without it, **200** with it (the latter *even with a valid Origin*, proving the layer is independent); `/api/health` and `styles.css` need none.
- `bun test` (desktop) → **27 pass** (+3 `tokenValid` tests); `bun test harness` → **194 pass**; `bun x tsc --noEmit` clean (root + desktop); renderer bundles.

## Honest residual (in ADR-0024)
- `tools/web/server.ts` (separate read-only dashboard) keeps only the ADR-0022 Host/Origin gate — it serves no `bridge.ts` to carry a token and exposes only read-only snapshots. Low-value follow-up.
- The token lives in the trusted same-origin DOM, so a **renderer XSS** could read it — but that's already a full renderer compromise (markdown is DOMPurify-sanitized, ADR-0016). The token defends the network/CSRF boundary, not in-page script injection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrTqRvkZBtq3NdEExxyCLG)_