### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete string escaping or encoding

### DIFF
--- a/harness/export/vault_export.ts
+++ b/harness/export/vault_export.ts
@@ -81,7 +81,10 @@ function mdLink(display: string, url: string): string {
 
 /** YAML scalar: quote + escape so no value can break the frontmatter or smuggle a codepoint. */
 function yamlScalar(s: string): string {
-  return `"${escapeMarkdown(s).replace(/"/g, '\\"')}"`;
+  const escaped = escapeMarkdown(s)
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"');
+  return `"${escaped}"`;
 }
 
 /** Stable, filesystem-safe basename for an entity; the Obsidian wikilink target. */


### PR DESCRIPTION
Potential fix for [https://github.com/mlcyclops/lucidagentide/security/code-scanning/2](https://github.com/mlcyclops/lucidagentide/security/code-scanning/2)

General fix: when producing escaped output with a custom `replace`, escape the escape character first (backslash), then escape delimiter characters (double quote), both globally.

Best fix here (minimal behavioral change): update `yamlScalar` in `harness/export/vault_export.ts` so it:
1. computes `escaped = escapeMarkdown(s).replace(/\\/g, "\\\\").replace(/"/g, '\\"')`
2. returns `"${escaped}"`

This keeps existing functionality (still uses `escapeMarkdown`, still outputs double-quoted YAML scalar) while correctly handling backslashes and all quotes globally.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
