### PR TITLE
sec(P11.6/SEC): TOCTOU-safe import reader — fix js/file-system-race (CodeQL #15, ADR-0025)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1981,3 +1981,62 @@ doesn't re-open the plane.
   `dev.ts`; `x-lucid-token` on every `bridge.ts` fetch. Verified live: HTML carries the meta token;
   `/api/usage` and `/api/personal/unlock` 403 without it / 200 with it (the latter even with a valid
   Origin, proving independence); `/api/health` and static assets need none.
+
+-----
+
+## ADR-0025 — TOCTOU-safe import reader: read-and-handle, not stat-then-read
+
+**Date:** 2026-06-21
+**Status:** Built
+**Context increment:** P11.6/SEC
+
+### Context
+
+CodeQL alert #15 (`js/file-system-race`, High) flagged `desktop/personal.ts`'s `loadExportText`.
+It resolved a chat-export path by **checking then using**: `statSync(raw)` to branch on file vs
+directory, then a *separate* `readFileSync(raw)`. Between the stat and the read the path can be
+swapped (e.g. a symlink flip), so the bytes read need not be the bytes that were stat'd — a
+time-of-check/time-of-use race. The directory branch had the same shape: `existsSync(join(dir,c))`
+then `readFileSync(join(dir,c))` per candidate.
+
+### Decision
+
+Replace check-then-use with **use-and-handle**: perform the filesystem operation directly and let its
+error classify the path. `loadExportText` now reads `raw` straight away; an `EISDIR` error means it
+is a directory (fall through to the folder logic), `ENOENT` means it is gone. The directory branch
+reads the listing **once** with `readdirSync` and selects from the returned names (`names.includes`)
+instead of a per-file `existsSync` probe. No stat/exists precedes a read of the same path, so there
+is no check/use window. `statSync`/`existsSync` are dropped from the module's `node:fs` imports.
+
+Behavior and user-facing errors are preserved (missing → "That path doesn't exist."; unreadable file
+→ "Couldn't read that file."; unreadable/empty folder → the folder guidance). An ambiguous folder
+(multiple unnamed `.json`) is still rejected rather than guessed.
+
+### Why
+
+`use-and-handle` is the standard `js/file-system-race` remediation: collapsing the check and the use
+into one operation removes the swap window entirely, and is also fewer syscalls. The path is already
+confined to the home subtree (ADR-0023) and scanned fail-closed on import (keystone #2); this closes
+the remaining race on top of those.
+
+### Integration with the invariants
+
+- **Fail-closed is law (#3).** Every read is wrapped; any error yields a typed `{ ok:false }` with a
+  user-facing message — never an unguarded throw or a silent pass. The import scanner gate downstream
+  is unchanged.
+- **Extend omp; never fork (#1) / language boundary (#2).** TypeScript only, confined to `desktop/`.
+- **No new dependencies / frozen contracts untouched.** Pure `node:fs` refactor.
+
+### Honest residual
+
+- `loadExportText` is now `export`ed solely so the FS branching is unit-testable directly
+  (`desktop/export_loader.test.ts`); it remains an internal helper with no new caller.
+- A swap to a *different regular file* between `readdirSync` and the subsequent `readFileSync(join(dir,
+  name))` is still theoretically possible, but there is no longer a type-check being relied upon — the
+  read either succeeds on whatever is there or fails closed, which is the property CodeQL requires.
+
+### Phases — one increment each (session ritual)
+
+- **P11.6/SEC (this increment)** — rewrite `loadExportText` to read-and-handle (EISDIR/ENOENT branch),
+  read the directory listing once, drop `statSync`/`existsSync`, and add `desktop/export_loader.test.ts`
+  (6 tests: file, dir-with-conversations.json, lone-json, missing→ENOENT, empty folder, ambiguous folder).

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1019,3 +1019,16 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
   read it (already full renderer compromise; markdown is DOMPurify-sanitized) — it guards the
   network/CSRF boundary, not in-page injection.
 - **next:** optional token for tools/web; setWorkspace path containment; then back to ADR-0021 P11.2 UX.
+
+## P11.6/SEC: TOCTOU-safe import reader (ADR-0025 — CodeQL alert #15 js/file-system-race)
+- **shipped:** fixed the High file-system-race in desktop/personal.ts loadExportText. Was stat-then-
+  read (statSync to branch file/dir, separate readFileSync — swappable in between); now read-and-handle:
+  read raw directly and let EISDIR (→ folder) / ENOENT (→ missing) classify it, and read the directory
+  listing ONCE (names.includes) instead of per-file existsSync. Dropped statSync/existsSync imports.
+  User-facing errors + ambiguous-folder rejection preserved. loadExportText exported for direct FS
+  testing; new desktop/export_loader.test.ts (6 pass). desktop 33 pass (+6), harness 194 pass,
+  root+desktop tsc clean.
+- **stubbed:** readdir→readFileSync(join(dir,name)) still has a theoretical swap window, but no
+  type-check is relied upon (read succeeds on what's there or fails closed) — the property CodeQL wants.
+- **next:** sweep remaining CodeQL alerts (e.g. autofix #40 alert #2 string-escaping landed on master);
+  optional tools/web token + setWorkspace containment; then ADR-0021 P11.2 UX.

--- a/desktop/export_loader.test.ts
+++ b/desktop/export_loader.test.ts
@@ -1,0 +1,52 @@
+// Tests for loadExportText (ADR-0025): the TOCTOU-safe import-source reader. It must
+// classify file vs directory vs missing by performing the read directly and handling the
+// error (no stat-then-read race; js/file-system-race), and read the listing once for folders.
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadExportText } from "./personal.ts";
+
+const root = mkdtempSync(join(tmpdir(), "lucid-export-"));
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+const mk = (rel: string, body: string): string => { const p = join(root, rel); writeFileSync(p, body); return p; };
+
+describe("loadExportText", () => {
+  test("reads a .json file directly", () => {
+    const p = mk("conv.json", '{"a":1}');
+    expect(loadExportText(p)).toEqual({ ok: true, text: '{"a":1}' });
+  });
+
+  test("reads conversations.json from a directory (EISDIR fall-through, no stat)", () => {
+    const dir = join(root, "chatgpt"); mkdirSync(dir);
+    writeFileSync(join(dir, "conversations.json"), '{"v":"gpt"}');
+    expect(loadExportText(dir)).toEqual({ ok: true, text: '{"v":"gpt"}' });
+  });
+
+  test("reads the lone .json in a directory", () => {
+    const dir = join(root, "single"); mkdirSync(dir);
+    writeFileSync(join(dir, "whatever.json"), '{"v":"x"}');
+    expect(loadExportText(dir)).toEqual({ ok: true, text: '{"v":"x"}' });
+  });
+
+  test("a missing path reports doesn't-exist (ENOENT, not a crash)", () => {
+    const r = loadExportText(join(root, "nope.json"));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/doesn't exist/i);
+  });
+
+  test("a directory with nothing usable reports the folder guidance", () => {
+    const dir = join(root, "empty"); mkdirSync(dir);
+    writeFileSync(join(dir, "readme.txt"), "hi");
+    const r = loadExportText(dir);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/conversations\.json/i);
+  });
+
+  test("an ambiguous directory (multiple .json, none named) is rejected, not guessed", () => {
+    const dir = join(root, "ambig"); mkdirSync(dir);
+    writeFileSync(join(dir, "a.json"), "{}"); writeFileSync(join(dir, "b.json"), "{}");
+    const r = loadExportText(dir);
+    expect(r.ok).toBe(false);
+  });
+});

--- a/desktop/personal.ts
+++ b/desktop/personal.ts
@@ -5,7 +5,7 @@
 // for the moment of derivation; it is NEVER persisted and NEVER returned over the API.
 // Only booleans + compartment counts ever leave the server.
 
-import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, normalize, sep } from "node:path";
 import { homedir } from "node:os";
 import { pathWithin } from "./path_guard.ts";
@@ -354,30 +354,41 @@ const MODEL_IMPORT_CAP = 500;
 const EXPORT_FILES = ["conversations.json", "MyActivity.json"]; // ChatGPT/Claude, then Gemini Takeout
 
 /** Resolve the export's JSON text from a folder, a .json file, or a .zip (reads the entry
- *  in-memory — no extraction to disk). Returns a user-facing error when nothing usable is found. */
-function loadExportText(raw: string): { ok: true; text: string } | { ok: false; error: string } {
+ *  in-memory — no extraction to disk). Returns a user-facing error when nothing usable is found.
+ *  Exported for direct FS-branch testing (TOCTOU-safe read path). */
+export function loadExportText(raw: string): { ok: true; text: string } | { ok: false; error: string } {
   const fromZip = (buf: Buffer): { ok: true; text: string } | { ok: false; error: string } => {
     try {
       for (const c of EXPORT_FILES) { const e = readZipEntry(buf, c); if (e) return { ok: true, text: e.toString("utf8") }; }
       return { ok: false, error: "That .zip has no conversations.json / MyActivity.json inside." };
     } catch (e) { return { ok: false, error: `Couldn't read that .zip: ${String((e as Error)?.message ?? e)}` }; }
   };
-  let st: ReturnType<typeof statSync>;
-  try { st = statSync(raw); } catch { return { ok: false, error: "That path doesn't exist." }; }
-  if (st.isFile()) {
+  const errCode = (e: unknown): string => (e as { code?: string })?.code ?? "";
+
+  // js/file-system-race (TOCTOU): do NOT stat-then-read — the path could be swapped between the
+  // check and the use. Read `raw` directly and let the failure classify it: EISDIR means it's a
+  // folder (fall through), ENOENT means it's gone. One operation, no check/use gap.
+  try {
     if (raw.toLowerCase().endsWith(".zip")) return fromZip(readFileSync(raw));
-    try { return { ok: true, text: readFileSync(raw, "utf8") }; } catch { return { ok: false, error: "Couldn't read that file." }; }
+    return { ok: true, text: readFileSync(raw, "utf8") };
+  } catch (e) {
+    if (errCode(e) === "ENOENT") return { ok: false, error: "That path doesn't exist." };
+    if (errCode(e) !== "EISDIR") return { ok: false, error: "Couldn't read that file." };
+    // EISDIR → it's a directory; handle it below.
   }
-  if (st.isDirectory()) {
-    for (const c of EXPORT_FILES) { const p = join(raw, c); if (existsSync(p)) return { ok: true, text: readFileSync(p, "utf8") }; }
-    let names: string[]; try { names = readdirSync(raw); } catch { return { ok: false, error: "Couldn't read that folder." }; }
-    const zip = names.find((n) => n.toLowerCase().endsWith(".zip"));
-    if (zip) return fromZip(readFileSync(join(raw, zip)));
-    const jsons = names.filter((n) => n.toLowerCase().endsWith(".json"));
-    if (jsons.length === 1) { try { return { ok: true, text: readFileSync(join(raw, jsons[0]!), "utf8") }; } catch { /* fall through */ } }
-    return { ok: false, error: "No conversations.json / MyActivity.json (or an export .zip) found in that folder." };
-  }
-  return { ok: false, error: "Choose the export file or its folder." };
+
+  // Directory: read the listing ONCE, then pick from it — no per-file existsSync check-then-read.
+  let names: string[];
+  try { names = readdirSync(raw); } catch { return { ok: false, error: "Couldn't read that folder." }; }
+  const pick = (name: string): { ok: true; text: string } | null => {
+    try { return { ok: true, text: readFileSync(join(raw, name), "utf8") }; } catch { return null; }
+  };
+  for (const c of EXPORT_FILES) if (names.includes(c)) { const r = pick(c); if (r) return r; }
+  const zip = names.find((n) => n.toLowerCase().endsWith(".zip"));
+  if (zip) { try { return fromZip(readFileSync(join(raw, zip))); } catch (e) { return { ok: false, error: `Couldn't read that .zip: ${String((e as Error)?.message ?? e)}` }; } }
+  const jsons = names.filter((n) => n.toLowerCase().endsWith(".json"));
+  if (jsons.length === 1) { const r = pick(jsons[0]!); if (r) return r; }
+  return { ok: false, error: "No conversations.json / MyActivity.json (or an export .zip) found in that folder." };
 }
 
 /** Import a ChatGPT / Claude / Gemini data export into the active (unlocked) compartment.


### PR DESCRIPTION
## Summary

Fixes **CodeQL alert #15** — `js/file-system-race` (High) — at `desktop/personal.ts:369`.

`loadExportText` resolved a chat-export path by **check-then-use**: `statSync(raw)` to branch file-vs-directory, then a *separate* `readFileSync(raw)`. The path can be swapped between the two (e.g. a symlink flip), so the bytes read need not be the bytes that were stat'd — a TOCTOU race. The directory branch had the same `existsSync(p)` → `readFileSync(p)` shape.

## Fix

**Use-and-handle** instead of check-then-use:
- Read `raw` directly; let the error classify it — `EISDIR` → it's a folder (fall through), `ENOENT` → missing. One operation, no check/use window.
- The folder branch reads the listing **once** with `readdirSync` and selects from the returned names (`names.includes`) instead of a per-file `existsSync` probe.
- `statSync`/`existsSync` dropped from the `node:fs` imports.

Behavior and user-facing errors are preserved (missing → "That path doesn't exist."; unreadable file → "Couldn't read that file."; empty/unreadable folder → folder guidance; ambiguous folder with multiple unnamed `.json` → rejected, not guessed). This sits on top of the existing home-subtree confinement (ADR-0023) and the fail-closed import scanner (keystone #2).

## Invariants
- **Fail-closed (#3):** every read is wrapped → typed `{ ok:false }` with a message, never an unguarded throw or silent pass.
- **Extend omp / language boundary (#1, #2):** TypeScript, confined to `desktop/`. Pure `node:fs` refactor, no new dependency.

## Verification
- `loadExportText` exported solely for direct FS-branch testing. New `desktop/export_loader.test.ts` — **6 tests**: file, directory-with-`conversations.json` (exercises the EISDIR fall-through), lone-`.json`, missing→ENOENT, empty folder, ambiguous folder.
- `bun test` (desktop) → **33 pass** (+6); `bun test harness` → **194 pass**; `bun x tsc --noEmit` clean (root + desktop).

## Honest residual (in ADR-0025)
A swap between `readdirSync` and the subsequent `readFileSync(join(dir, name))` is still theoretically possible, but no type-check is relied upon — the read either succeeds on whatever is there or fails closed, which is the property the rule requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrTqRvkZBtq3NdEExxyCLG)_