### PR TITLE
sec(P11.7/SEC): CodeQL alert sweep — stack-trace, fs-race, store perms, dashboard escaping (ADR-0026)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -2040,3 +2040,71 @@ the remaining race on top of those.
 - **P11.6/SEC (this increment)** — rewrite `loadExportText` to read-and-handle (EISDIR/ENOENT branch),
   read the directory listing once, drop `statSync`/`existsSync`, and add `desktop/export_loader.test.ts`
   (6 tests: file, dir-with-conversations.json, lone-json, missing→ENOENT, empty folder, ambiguous folder).
+
+-----
+
+## ADR-0026 — CodeQL alert sweep: stack-trace exposure, FS-race, store perms, dashboard attr escaping
+
+**Date:** 2026-06-21
+**Status:** Built
+**Context increment:** P11.7/SEC
+
+### Context
+
+A pass over the open CodeQL code-scanning alerts on `master` (15 total) resolved into three buckets.
+Two High alerts (#14/#15, `js/file-system-race` in `personal.ts`) were already fixed by ADR-0025
+(#41) and auto-close on the next scan. Eight Medium alerts (#7–#12, #16, #17, "File data in outbound
+network request" in `asksage.ts` and `ratelimit_probe.ts`) are **by design** — the data is the user's
+API key flowing to its *own* configured provider endpoint (`api.anthropic.com`, `api.openai.com`, or
+the user-set AskSage gateway); the key must reach the provider to authenticate, and the destinations
+are not attacker-controlled. Those are dispositioned as dismiss-as-intended on the Security tab, not a
+code change. This ADR covers the **five remaining real findings**.
+
+### Decision
+
+1. **Stack-trace exposure (#3 `desktop/dev.ts`, #4 `tools/web/server.ts`, `js/stack-trace-exposure`).**
+   Both Bun servers caught `err` and returned `String(err)` to the client. Now the catch logs the
+   detail server-side (`console.error`) and returns a generic `{ ok:false, error:"internal error" }`,
+   so an internal error/stack never reaches the renderer or a forged caller.
+2. **File-system race (#5 `harness/memory/state.ts`, `js/file-system-race`).** Seeding state headers
+   was `if (!existsSync(p)) writeFileSync(p, …)` — a check/use gap. Now a single
+   `writeFileSync(p, …, { flag: "wx" })` (create-or-fail) wrapped to swallow `EEXIST`: atomic, an
+   existing file is preserved, no TOCTOU. `existsSync` dropped from the imports.
+3. **Insecure temporary file (#6 `harness/personal/store.ts`, `js/insecure-temporary-file`).** The
+   encrypted store was `writeFileSync(path, …)` then `chmodSync(0o600)` — a window where the blob is
+   the default 0644. Now it is created owner-only at write time via `{ mode: 0o600 }`; the `chmod`
+   stays to tighten an already-existing file on overwrite.
+4. **Incomplete HTML-attribute sanitization (#1 `tools/web/index.html`,
+   `js/incomplete-html-attribute-sanitization`).** The dashboard's `esc()` escaped only `& < >`, but
+   its output lands inside double-quoted attributes (`class="pill ${esc(k)}"`), so a `"` could break
+   out — attribute-injection XSS. `esc()` now also escapes `"`→`&quot;` and `'`→`&#39;`, matching the
+   desktop renderer's `esc` (which already did and was therefore not flagged).
+
+### Why
+
+Each is the standard remediation for its rule: generic client errors + server-side logging for
+information exposure; atomic `wx` create for the FS race; mode-at-creation for the perms window; and
+quote-escaping for attribute-context output. All are pure hardening with behavior preserved (state
+files still seed once and survive reopen; the store still round-trips; the dashboard renders the same
+content, just correctly escaped).
+
+### Integration with the invariants
+
+- **Fail-closed is law (#3).** The error handlers still return a typed `{ ok:false }`; the FS-race
+  and perms fixes only *narrow* what can go wrong. No path now treats an error as success.
+- **Extend omp; never fork (#1) / language boundary (#2).** TypeScript/HTML only, in existing files.
+- **Frozen contracts / no new dependencies.** Pure `node:fs`/string changes; the store envelope format
+  and the prompt prefix are untouched.
+
+### Honest disposition of the by-design alerts
+
+The eight "File data in outbound network request" alerts are intentional credential transmission to a
+configured provider; dismissing them as "won't fix (by design)" on the Security tab is the correct
+disposition (chosen this session). They are recorded here so a future reader doesn't re-litigate them.
+
+### Phases — one increment each (session ritual)
+
+- **P11.7/SEC (this increment)** — the five fixes above + tests: a store-perms assertion
+  (`personal.test.ts`, 0600) and reliance on the existing `state.test.ts` reopen/no-clobber coverage.
+  Verified live: a forced handler error returns `{ok:false,error:"internal error"}` with the real
+  `SyntaxError` only in the server log.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1032,3 +1032,19 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
   type-check is relied upon (read succeeds on what's there or fails closed) — the property CodeQL wants.
 - **next:** sweep remaining CodeQL alerts (e.g. autofix #40 alert #2 string-escaping landed on master);
   optional tools/web token + setWorkspace containment; then ADR-0021 P11.2 UX.
+
+## P11.7/SEC: CodeQL alert sweep (ADR-0026 — alerts #1,#3,#4,#5,#6; #7-12/#16/#17 dismissed by-design)
+- **shipped:** five real CodeQL fixes. #3/#4 stack-trace-exposure (desktop/dev.ts + tools/web/server.ts):
+  catch logs server-side, returns generic {error:"internal error"} (was String(err)). #5 file-system-race
+  (harness/memory/state.ts): existsSync-then-write → atomic writeFileSync flag:"wx" (EEXIST-safe), dropped
+  existsSync import. #6 insecure-temporary-file (harness/personal/store.ts): encrypted store created
+  owner-only via {mode:0o600} (no 0644 window before chmod). #1 incomplete-html-attribute-sanitization
+  (tools/web/index.html): dashboard esc() now escapes " and ' too (matches desktop esc) — was attribute
+  XSS. Added store-perms test (0600); state reopen/no-clobber already covered. Verified live: forced
+  handler error → generic body, real SyntaxError only in server log. harness 195 pass (+1), desktop 33,
+  root+desktop tsc clean.
+- **stubbed:** 8 "file data outbound" alerts (asksage ×6, ratelimit_probe ×2) are API keys to their own
+  configured provider endpoints — intended; dispositioned dismiss-as-by-design in the UI (no code change).
+  #14/#15 (personal.ts fs-race) already fixed by #41 — auto-close on next scan.
+- **next:** confirm the next CodeQL run auto-closes #14/#15; optional tools/web token + setWorkspace
+  containment; then back to ADR-0021 P11.2 UX.

--- a/desktop/dev.ts
+++ b/desktop/dev.ts
@@ -324,7 +324,10 @@ const server = Bun.serve({
         return new Response(file, { headers: { "content-type": (CT[ext] ?? "application/octet-stream") + "; charset=utf-8" } });
       }
     } catch (err) {
-      return json({ ok: false, error: String(err) });
+      // js/stack-trace-exposure: log the detail server-side, return a generic message to the client
+      // so an internal error/stack never reaches the renderer (or a forged caller).
+      console.error(`[dev] ${p}:`, err);
+      return json({ ok: false, error: "internal error" });
     }
     return new Response("not found", { status: 404 });
   },

--- a/harness/memory/state.ts
+++ b/harness/memory/state.ts
@@ -5,7 +5,7 @@
 // (append-only logs). These are the file-backed face of working/episodic memory
 // — local-first and replayable.
 
-import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 export const STATE_FILES = ["NOW.md", "PROGRESS.md", "DECISIONS.md", "FAILURES.md"] as const;
@@ -32,8 +32,10 @@ export class StateArtifacts {
     this.#now = opts.now ?? (() => new Date().toISOString());
     mkdirSync(dir, { recursive: true });
     for (const f of STATE_FILES) {
-      const p = join(dir, f);
-      if (!existsSync(p)) writeFileSync(p, HEADERS[f], "utf8");
+      // js/file-system-race: seed the header only if the file doesn't exist, atomically.
+      // `wx` creates-or-fails (no existsSync-then-write TOCTOU); an existing file is preserved.
+      try { writeFileSync(join(dir, f), HEADERS[f], { encoding: "utf8", flag: "wx" }); }
+      catch (e) { if ((e as { code?: string })?.code !== "EEXIST") throw e; }
     }
   }
 

--- a/harness/personal/personal.test.ts
+++ b/harness/personal/personal.test.ts
@@ -3,7 +3,7 @@
 // holds the user's private personalization graph. Wrong key / tampering MUST fail.
 
 import { afterAll, expect, test } from "bun:test";
-import { existsSync, rmSync } from "node:fs";
+import { existsSync, rmSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { Telemetry, type TelemetryEvent } from "../telemetry/events.ts";
@@ -58,6 +58,13 @@ test("store: create → mutate → reopen with passphrase round-trips the graph"
   expect(g.facts[0]!.statement).toBe("Prefers Vim keybindings");
   expect(g.links.length).toBe(1);
   expect(g.links[0]!.relation).toBe("uses-with");
+});
+
+test("store: save() writes the encrypted file owner-only (0600, no world-readable window)", () => {
+  const path = tmp();
+  PersonalStore.createWithPassphrase(path, "pw").save();
+  // POSIX perms only; Windows ACLs don't map to a mode bitmask (CI is ubuntu).
+  if (process.platform !== "win32") expect(statSync(path).mode & 0o777).toBe(0o600);
 });
 
 test("store: wrong passphrase fails closed (throws, no graph leaks)", () => {

--- a/harness/personal/store.ts
+++ b/harness/personal/store.ts
@@ -224,7 +224,10 @@ export class PersonalStore {
       v: this.#version, custody: this.#custody, kdf: this.#kdf, wrappedDek: this.#wrappedDek,
       data: encrypt(JSON.stringify(this.#graph), this.#dek),
     };
-    writeFileSync(this.#path, JSON.stringify(env), "utf8");
+    // js/insecure-temporary-file: create owner-only at write time so the encrypted blob is never
+    // briefly world-readable (the default 0644 window between create and chmod). `mode` applies on
+    // creation; the chmod stays to also tighten an already-existing file on overwrite.
+    writeFileSync(this.#path, JSON.stringify(env), { encoding: "utf8", mode: 0o600 });
     try { chmodSync(this.#path, 0o600); } catch { /* best-effort on Windows */ }
   }
   /** Zero the in-memory key (call when locking the store). */

--- a/tools/web/index.html
+++ b/tools/web/index.html
@@ -120,7 +120,9 @@
 
 <script>
 const $ = (id) => document.getElementById(id);
-const esc = (s) => String(s ?? "").replace(/[&<>]/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;"}[c]));
+// Escapes for BOTH text and double-quoted attribute contexts (js/incomplete-html-attribute-sanitization):
+// quotes must be escaped too, since esc() output lands inside class="..."/style="..." attributes.
+const esc = (s) => String(s ?? "").replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c]));
 const fmtNum = (n) => { n=Number(n); if(!isFinite(n)) return "?"; const a=Math.abs(n);
   return a>=1e6?(n/1e6).toFixed(2)+"M":a>=1e3?(n/1e3).toFixed(1)+"k":String(Math.round(n)); };
 const fmtUSD = (n) => "$"+(Number(n)||0).toFixed(Number(n)<1?4:2);

--- a/tools/web/server.ts
+++ b/tools/web/server.ts
@@ -40,7 +40,9 @@ const server = Bun.serve({
       if (url.pathname === "/api/memory") return json({ ok: true, data: await memorySnapshot() });
       if (url.pathname === "/api/health") return json({ ok: true, ts: new Date().toISOString() });
     } catch (err) {
-      return json({ ok: false, error: String(err) });
+      // js/stack-trace-exposure: keep the detail in the server log, not the HTTP response.
+      console.error(`[dashboard] ${url.pathname}:`, err);
+      return json({ ok: false, error: "internal error" });
     }
     return new Response("not found", { status: 404 });
   },


### PR DESCRIPTION
## Summary

Sweep of the open CodeQL code-scanning alerts on `master`. The 15 alerts resolved into three buckets; this PR lands the **5 real fixes**.

### Fixed here

| # | Rule | Location | Fix |
|---|------|----------|-----|
| #3, #4 | `js/stack-trace-exposure` | `desktop/dev.ts`, `tools/web/server.ts` | catch returned `String(err)` to the client → now logs detail server-side, returns generic `{ ok:false, error:"internal error" }` |
| #5 | `js/file-system-race` | `harness/memory/state.ts` | `existsSync`-then-`writeFileSync` (TOCTOU) → atomic `writeFileSync(…, { flag:"wx" })`, `EEXIST`-safe, existing files preserved |
| #6 | `js/insecure-temporary-file` | `harness/personal/store.ts` | encrypted store written then `chmod`'d (0644 window) → created owner-only via `{ mode: 0o600 }` |
| #1 | `js/incomplete-html-attribute-sanitization` | `tools/web/index.html` | dashboard `esc()` escaped only `&<>` but output lands in `class="…"` attributes (a `"` could break out → attribute XSS) → now escapes `"`/`'` too, matching the desktop `esc` |

### Already fixed (auto-close on next scan)
- **#14, #15** (`js/file-system-race`, `personal.ts`) — resolved by the merged #41 (`loadExportText` rewrite removed both `statSync` sites).

### Dismissed as by-design (your call, this session)
- **#7–#12, #16, #17** — "File data in outbound network request" in `asksage.ts` (×6) and `ratelimit_probe.ts` (×2): the "file data" is the user's **API key** flowing to its *own configured provider endpoint* (`api.anthropic.com`, `api.openai.com`, the user's AskSage gateway). The key must reach the provider to authenticate; destinations aren't attacker-controlled. To be dismissed as "won't fix (by design)" on the Security tab — no code change.

## Invariants
- **Fail-closed (#3):** handlers still return typed `{ ok:false }`; the FS-race/perms fixes only narrow failure modes. No error is treated as success.
- **Extend omp / language boundary (#1, #2):** TypeScript/HTML only, in existing files. Pure `node:fs`/string changes — no new dependency, store envelope format and prompt prefix untouched.

## Verification
- New store-perms test (`personal.test.ts`, asserts `0600` on POSIX); existing `state.test.ts` reopen/no-clobber coverage guards the `wx` change.
- **Live:** a forced handler error returns `{"ok":false,"error":"internal error"}` with the real `SyntaxError` only in the server log.
- `bun test harness` → **195 pass** (+1); `bun test` (desktop) → **33 pass**; `bun x tsc --noEmit` clean (root + desktop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrTqRvkZBtq3NdEExxyCLG)_