### PR TITLE
build(deps-dev): bump typescript to 6.0.3 (root) — supersedes #7

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@types/bun": "latest",
-        "typescript": "^5.6.0",
+        "typescript": "^6.0.3",
       },
     },
   },
@@ -589,7 +589,7 @@
 
     "typed-query-selector": ["typed-query-selector@2.12.2", "", {}, "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@types/bun": "latest",
-    "typescript": "^5.6.0"
+    "typescript": "^6.0.3"
   },
   "trustedDependencies": []
 }


### PR DESCRIPTION
Lands the root TypeScript 6.0.3 bump (the intent of dependabot #7) on a clean base. #7 branched from an ancient master (pre-#42), so its CI typechecked stale code and went red; this is verified on CURRENT master.

Verified: full bun run typecheck across all 3 tsconfig projects is clean under TypeScript 6.0.3 (desktop already on 6.0.3 via #9). Closes #7.

Generated with Claude Code