### PR TITLE
fix(memory): recall excludes mechanical tool-activity facts (stops junk in chat)

### DIFF
--- a/harness/memory/recall.test.ts
+++ b/harness/memory/recall.test.ts
@@ -44,6 +44,30 @@ test("keystone #2: only trusted/untrusted facts are recallable; suspicious/quara
   expect(out.block).not.toContain("QUARANTINED payload");
 });
 
+test("mechanical tool-activity facts (omp:* / subagent:*) are never recalled", async () => {
+  // rememberActivity promotes a fact per tool call; these are activity, not durable
+  // knowledge, and must not be injected into a later session's user turn.
+  await seed("omp:web_search", "web_search best burgers Seattle 2025", "untrusted");
+  await seed("omp:job", "job RegularMarsupial", "untrusted");
+  await seed("subagent:explore", "explore list top-level files", "untrusted");
+  await seed("build-system", "The project builds with Bun.", "trusted");
+
+  const out = await buildRecall(db, { limit: 50 });
+  expect(out.count).toBe(1); // only the genuine knowledge fact
+  expect(out.block).toContain("The project builds with Bun.");
+  expect(out.block).not.toContain("best burgers");
+  expect(out.block).not.toContain("RegularMarsupial");
+  expect(out.block).not.toContain("explore list top-level");
+});
+
+test("recall is empty (null block) when only tool-activity facts exist", async () => {
+  await seed("omp:read", "read README.md", "untrusted");
+  await seed("omp:task", "task explore the repo", "untrusted");
+  const out = await buildRecall(db, { limit: 50 });
+  expect(out.count).toBe(0);
+  expect(out.block).toBeNull();
+});
+
 test("every statement + entity is markdown/codepoint escaped (defense in depth)", async () => {
   // zero-width space (invisible) + markdown metachars in the statement.
   await seed("ent*x", "danger\u200Bzone *bold* [link](x)", "untrusted");

--- a/harness/memory/recall.ts
+++ b/harness/memory/recall.ts
@@ -24,6 +24,18 @@ import type { Db } from "./db.ts";
  *  suspicious, quarantined — are deliberately excluded (keystone #2). */
 const RECALLABLE_TRUST = ["trusted", "untrusted"] as const;
 
+/** Entity-name prefixes for MECHANICAL TOOL ACTIVITY, not durable knowledge.
+ *  `rememberActivity` (omp/security_extension.ts) promotes a fact for every tool
+ *  call with entity `omp:<tool>` (and task subagents land as `subagent:<name>`).
+ *  Those are activity, not knowledge — recalling "omp:web_search: best burgers
+ *  Seattle" or "omp:job: job RegularMarsupial" into a later, unrelated session
+ *  only confuses the model and clutters the user turn. They are excluded from
+ *  recall here (defense in depth: even if such facts exist in the store, they are
+ *  never surfaced). Genuine, durable facts use semantic entity names (e.g.
+ *  "build-system", "user-pref") and are unaffected. See also: stop promoting them
+ *  at the source (tracked separately). */
+const ACTIVITY_ENTITY_PREFIXES = ["omp:", "subagent:"] as const;
+
 export interface RecallOptions {
   /** Session the facts are being recalled INTO. When set, the recall is logged
    *  to fact_sessions and a memory_recalled event is emitted. */
@@ -56,15 +68,23 @@ export async function buildRecall(db: Db, opts: RecallOptions = {}): Promise<Rec
   const limit = Math.max(0, Math.trunc(opts.limit ?? 20));
   if (limit === 0) return { block: null, factIds: [], count: 0 };
 
-  const placeholders = RECALLABLE_TRUST.map((_, i) => `$${i + 1}`).join(", ");
+  const trustPlaceholders = RECALLABLE_TRUST.map((_, i) => `$${i + 1}`).join(", ");
+  // Exclude mechanical tool-activity entities (omp:* / subagent:*) so only durable
+  // knowledge is recalled. Patterns are bound parameters, after the trust params.
+  const activityPatterns = ACTIVITY_ENTITY_PREFIXES.map((p) => `${p}%`);
+  const activityClause = activityPatterns
+    .map((_, i) => `e.name NOT LIKE $${RECALLABLE_TRUST.length + 1 + i}`)
+    .join(" AND ");
+  const limitParam = RECALLABLE_TRUST.length + ACTIVITY_ENTITY_PREFIXES.length + 1;
   const rows = await db.all(
     `SELECT f.fact_id AS fact_id, f.statement AS statement, f.trust_label AS trust_label, e.name AS entity
        FROM semantic_facts f
        JOIN semantic_entities e ON e.entity_id = f.entity_id
-      WHERE f.trust_label IN (${placeholders})
+      WHERE f.trust_label IN (${trustPlaceholders})
+        AND ${activityClause}
       ORDER BY f.promoted_at DESC, f.fact_id DESC
-      LIMIT $${RECALLABLE_TRUST.length + 1}`,
-    [...RECALLABLE_TRUST, limit],
+      LIMIT $${limitParam}`,
+    [...RECALLABLE_TRUST, ...activityPatterns, limit],
   );
   if (rows.length === 0) return { block: null, factIds: [], count: 0 };
 


### PR DESCRIPTION
## Symptom
Every new chat showed a large "Facts distilled in earlier sessions (UNTRUSTED context...)" block in the chat window, full of noise like `omp:job: job RegularMarsupial`, `omp:read: read README.md`, and `omp:web_search: best burgers Seattle 2025`. It confused the model and cluttered the transcript.

## Root cause
`rememberActivity` (`harness/omp/security_extension.ts:101`) promotes a semantic fact for **every** tool call with entity `omp:<tool>` (task subagents land as `subagent:<name>`). `buildRecall` then injects up to 20 of these into each session's first user turn (`desktop/acp_backend.ts:358`), where they are sent to the model and rendered. A query of the live DB confirmed all 17 stored facts were mechanical tool activity, zero genuine knowledge.

## Fix (this PR)
`buildRecall` now excludes `omp:*` / `subagent:*` entities via parameterized `NOT LIKE`, so only durable knowledge (e.g. `build-system`, `user-pref`) is ever recalled. Non-destructive (no data deleted), defense-in-depth at the read side.

- 93 memory tests pass (2 new regression tests); `demo17_recall` (ADR-0009 Phase A) still recalls the genuine facts; `tsc` clean.

## Follow-ups (separate issues)
- Stop promoting mechanical tool activity at the source (`rememberActivity`).
- Do not render the injected user-turn preamble (persona / skill / recall / profile) in the chat window.
- Delete chats from the session menu.
- Skills/personas effectiveness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
