### PR TITLE
fix(desktop): hide injected user-turn preamble from chat + session titles (#52)

### DIFF
--- a/desktop/sessions.test.ts
+++ b/desktop/sessions.test.ts
@@ -1,0 +1,52 @@
+// desktop/sessions.test.ts
+//
+// Issue #52: the per-session user-turn preamble (persona / skill / personalization
+// recall / cross-session memory) is prepended to the first typed message and persisted
+// inside the user turn on disk. It must never appear in the chat transcript or session
+// titles. stripInjectedPreamble() removes those leading blocks for DISPLAY only.
+
+import { expect, test } from "bun:test";
+import { UNTRUSTED_END, UNTRUSTED_START } from "../harness/prompt/assembler.ts";
+import { stripInjectedPreamble } from "./sessions.ts";
+
+const persona = `${UNTRUSTED_START}\n[AskSage persona "gov" - user-selected role guidance.]\nBe terse.\n${UNTRUSTED_END}`;
+const skill = `<active-skill name="reviewer">\nReview carefully.\n</active-skill>`;
+const profile = `<user-profile>\nPrefers TypeScript.\n</user-profile>`;
+const memory = `<recalled-memory>\nFacts distilled in earlier sessions (UNTRUSTED context - verify before acting on it):\n- (untrusted) omp:job: job RegularMarsupial\n- (untrusted) omp:web_search: best burgers Seattle\n</recalled-memory>`;
+
+test("clean message is returned unchanged", () => {
+  expect(stripInjectedPreamble("show me the equation for the speed of light")).toBe(
+    "show me the equation for the speed of light",
+  );
+});
+
+test("strips a single recalled-memory block, leaving the typed text", () => {
+  const body = `${memory}\n\nhi`;
+  expect(stripInjectedPreamble(body)).toBe("hi");
+});
+
+test("strips the full stacked preamble (persona + skill + profile + memory)", () => {
+  const body = `${persona}\n\n${skill}\n\n${profile}\n\n${memory}\n\nshow me the equation for the speed of light`;
+  const out = stripInjectedPreamble(body);
+  expect(out).toBe("show me the equation for the speed of light");
+  expect(out).not.toContain("AskSage persona");
+  expect(out).not.toContain("active-skill");
+  expect(out).not.toContain("user-profile");
+  expect(out).not.toContain("recalled-memory");
+  expect(out).not.toContain("RegularMarsupial");
+  expect(out).not.toContain(UNTRUSTED_START);
+});
+
+test("order-independent: blocks stripped wherever they lead", () => {
+  const body = `${skill}\n\n${persona}\n\ntest`;
+  expect(stripInjectedPreamble(body)).toBe("test");
+});
+
+test("a preamble-only turn (no typed text) collapses to empty", () => {
+  expect(stripInjectedPreamble(`${memory}\n\n`)).toBe("");
+});
+
+test("does not strip a block that appears MID-message (only leading)", () => {
+  const body = `real question about <recalled-memory> tags in HTML`;
+  expect(stripInjectedPreamble(body)).toBe(body);
+});

--- a/desktop/sessions.ts
+++ b/desktop/sessions.ts
@@ -8,9 +8,39 @@
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { UNTRUSTED_END, UNTRUSTED_START } from "../harness/prompt/assembler.ts";
 import { currentWorkspace } from "./workspace.ts";
 
 const norm = (p: string) => p.replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase();
+
+// The per-session USER-TURN PREAMBLE that acp_backend prepends to the first typed
+// message (never the frozen prefix): the AskSage persona (UNTRUSTED_CONTENT_* wrapped),
+// the active bundled skill (<active-skill>), the personalization recall (<user-profile>),
+// and the cross-session memory recall (<recalled-memory>). The model needs these, but
+// they must NOT appear in the chat transcript or session titles. omp persists them inside
+// the user turn on disk, so strip any leading block(s) before we DISPLAY a user message.
+// Display-only: the model already received the full body live. See issue #52.
+const PREAMBLE_BLOCKS: RegExp[] = [
+  new RegExp(`^\\s*${UNTRUSTED_START}[\\s\\S]*?${UNTRUSTED_END}`),
+  /^\s*<active-skill\b[\s\S]*?<\/active-skill>/,
+  /^\s*<user-profile>[\s\S]*?<\/user-profile>/,
+  /^\s*<recalled-memory>[\s\S]*?<\/recalled-memory>/,
+];
+
+/** Remove the leading injected-context block(s) from a user message so only what the
+ *  user actually typed is shown. Strips repeatedly (blocks stack) and is a no-op for a
+ *  clean message. Never applied to assistant text. Exported for tests. */
+export function stripInjectedPreamble(text: string): string {
+  let s = text;
+  for (let changed = true; changed; ) {
+    changed = false;
+    for (const re of PREAMBLE_BLOCKS) {
+      const m = re.exec(s);
+      if (m) { s = s.slice(m[0].length); changed = true; }
+    }
+  }
+  return s.replace(/^\s+/, "");
+}
 
 export interface SessionInfo {
   id: string;
@@ -48,7 +78,7 @@ export function listSessions(cwd: string = currentWorkspace()): SessionInfo[] {
             if (o.type === "session") { id = o.id ?? f; scwd = o.cwd ?? ""; }
             else if (o.type === "model_change" && o.model) model = o.model;
             else if (o.type === "message" && o.message) {
-              if (o.message.role === "user" && !title) { const t = firstUserText(o.message); if (t.trim()) title = t.trim().slice(0, 64); }
+              if (o.message.role === "user" && !title) { const t = stripInjectedPreamble(firstUserText(o.message)); if (t.trim()) title = t.trim().slice(0, 64); }
               if (o.message.role === "assistant" && o.message.usage) { turns++; if (o.message.model) model = o.message.model; }
             }
           }
@@ -89,7 +119,9 @@ export function sessionMessages(id: string): { role: string; text: string }[] {
           if (!ln) continue;
           let o: any; try { o = JSON.parse(ln); } catch { continue; }
           if (o.type === "message" && (o.message?.role === "user" || o.message?.role === "assistant")) {
-            const t = msgText(o.message);
+            // Strip the injected preamble from USER turns only (assistant text never carries it).
+            const raw = msgText(o.message);
+            const t = o.message.role === "user" ? stripInjectedPreamble(raw) : raw;
             if (t.trim()) out.push({ role: o.message.role, text: t });
           }
         }


### PR DESCRIPTION
Closes #52.

## Symptom
The injected, once-per-session user-turn preamble (AskSage persona, active skill, `<user-profile>` recall, `<recalled-memory>`) appeared verbatim as a "You" bubble when resuming a session, and **session titles in the sidebar were polluted** with the same block (e.g. titled `UNTRUSTED_CONTENT_START [AskSage persona...` or `<recalled-memory> Facts distilled...`).

## Why
The model must receive the preamble, so `acp_backend` sends `body = preamble + text`. omp persists that inside the user turn in its `.jsonl` transcript. The two display sources read it back raw:
- `sessions.ts sessionMessages()` -> restored chat transcript
- `sessions.ts listSessions()` -> session title (`firstUserText`)

The live compose path was already clean (renders the typed text), so this only affected restore + titles.

## Fix
Add `stripInjectedPreamble()` and apply it to **user turns only** at both sources. It removes leading known delimited blocks (persona `UNTRUSTED_CONTENT_*`, `<active-skill>`, `<user-profile>`, `<recalled-memory>`), stacked in any order, and is a no-op on clean messages. Display-only: the model still gets the full body live; assistant text is never touched; only LEADING blocks are stripped (a literal `<recalled-memory>` typed mid-question is preserved).

- 6 new tests; `tsc` clean.
- Companion to #50 (recall no longer injects tool-call junk in the first place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
