### PR TITLE
fix(memory): stop promoting raw tool I/O as semantic facts (root cause, #51)

### DIFF
--- a/harness/omp/security_extension.ts
+++ b/harness/omp/security_extension.ts
@@ -85,21 +85,22 @@ function collectStrings(value: unknown, skip: ReadonlySet<string> = new Set(["ty
   return parts.join("\n");
 }
 
-/** Persist a tool call to the project DB (provenance + scan) and gate-promote a
- *  fact from it — so memory fills from ORDINARY turns, with provenance, across
- *  sessions. Suspicious/quarantined sources are blocked from promotion (keystone
- *  #2). Best-effort and fire-and-forget: it never affects the security decision. */
+/** Persist a tool call to the project DB as a scanned, trust-labelled artifact for
+ *  PROVENANCE (and to keep the security/audit trail complete). It intentionally does
+ *  NOT promote a semantic fact: raw tool I/O (bash/read/find/web_search/job/yield,
+ *  keyed `omp:<tool>`) is mechanical activity, not durable knowledge. Promoting it
+ *  filled cross-session recall with noise that confused the model and cluttered the
+ *  user turn (issue #51; recall already excludes `omp:*` on the read side). Genuine
+ *  learning lives in the personalization graph (learnFromTurn); a subagent's
+ *  SUMMARIZED result still promotes through the keystone-#2 gate
+ *  (runs/task_gate.ts gateSubagentResult). Best-effort and fire-and-forget: it never
+ *  affects the security decision. */
 async function rememberActivity(toolName: string, text: string): Promise<void> {
   try {
     const db = await getDb();
     if (!db) return;
     const { ingestArtifact } = await import("../memory/ingest.ts");
-    const { promoteFactGated } = await import("../memory/promotion_gate.ts");
-    const art = await ingestArtifact(db, scanner, { runId: LIVE_RUN, sourceType: `omp:${toolName}`, rawContent: text }, {});
-    const statement = text.replace(/\s+/g, " ").trim().slice(0, 160);
-    if (statement.length >= 12) {
-      await promoteFactGated(db, { entityName: `omp:${toolName}`, statement, trustLabel: art.trustLabel, sourceArtifactId: art.artifactId }, {}).catch(() => {});
-    }
+    await ingestArtifact(db, scanner, { runId: LIVE_RUN, sourceType: `omp:${toolName}`, rawContent: text }, {});
   } catch {
     /* best-effort; the security decision already stands */
   }

--- a/harness/scripts/demo17_recall.ts
+++ b/harness/scripts/demo17_recall.ts
@@ -1,10 +1,11 @@
 // harness/scripts/demo17_recall.ts
 //
-// ADR-0009 Phase A — cross-session memory recall. The persist half already runs
-// live (rememberActivity -> ingestArtifact -> promoteFactGated on allowed tool
-// calls); this demo proves the RECALL half: facts distilled in one session are
-// recalled into a LATER session as a delimited, untrusted, post-cache block —
-// and suspicious/quarantined facts are NEVER recallable (keystone #2, read side).
+// ADR-0009 Phase A — cross-session memory recall. The persist half runs live when a
+// subagent RESULT is gated (runs/task_gate.ts gateSubagentResult -> promoteFactGated);
+// raw tool I/O is recorded for provenance only and is NOT promoted (issue #51). This
+// demo proves the RECALL half: facts distilled in one session are recalled into a
+// LATER session as a delimited, untrusted, post-cache block — and suspicious/
+// quarantined facts are NEVER recallable (keystone #2, read side).
 
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";


### PR DESCRIPTION
Closes #51. Root-cause (write-side) companion to #50 (read-side).

## Problem
`rememberActivity` (`harness/omp/security_extension.ts`) promoted a semantic fact for **every** allowed tool call (`entity omp:<tool>`, statement = the tool I/O). That filled `semantic_facts` with mechanical activity (`omp:bash`, `omp:read`, `omp:find`, `omp:web_search`, `omp:job`, `omp:yield`) — exactly the junk that #50 had to exclude from recall. A live DB query confirmed 17/17 stored facts were tool/subagent activity, zero genuine knowledge.

## Fix
Raw tool I/O is **provenance, not durable knowledge**. Keep `ingestArtifact` (scan + trust-label + raw content, so the security/audit trail stays complete) and **drop the fact promotion**.

What is intentionally unchanged:
- Genuine learning still flows through the **personalization graph** (`learnFromTurn`).
- A subagent's **summarized result** still promotes through the **keystone-#2 gate** (`runs/task_gate.ts gateSubagentResult`); its tests still assert clean-promotes and poisoned-blocked.

So keystone #2 (suspicious-source content never auto-promotes) is fully preserved; we just stop treating raw tool mechanics as knowledge.

## Verification
- `task_gate.test.ts` (6, keystone #2) pass; `harness/memory` (91) pass; quarantine gate (6) pass.
- `demo09_promotion_gate` (keystone #2) and `demo17_recall` pass; `tsc` clean.
- Stale comment in `demo17_recall.ts` updated to match.

Together with #50 and #52, the tool-activity noise is now neither generated, recalled, nor displayed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
