### PR TITLE
feat(desktop): delete chats from the session menu (#53)

### DIFF
--- a/desktop/acp_backend.ts
+++ b/desktop/acp_backend.ts
@@ -294,6 +294,10 @@ class Backend {
     if (configId === "model") this.syncModelEnv(); // persist the new authoring model for AI-LOC (ADR-0031)
     return this.configOptions;
   }
+  /** The live ACP session id (matches the omp on-disk session id), or null when fresh.
+   *  Used by the delete route to close the session before removing its file (#53). */
+  currentSessionId(): string | null { return this.sessionId; }
+
   /** Resume a past session so the next prompt continues it. */
   async loadSession(id: string): Promise<void> {
     await this.start();

--- a/desktop/dev.ts
+++ b/desktop/dev.ts
@@ -14,7 +14,7 @@ import { approveBlock, liveBlocks } from "./security_log.ts";
 import { probeRateLimits } from "./ratelimit_probe.ts";
 import { OBS_DB_PATH, memorySnapshot, rateLimits, usageLedger } from "../tools/memory_data.ts";
 import { backend } from "./acp_backend.ts";
-import { listSessions, sessionMessages } from "./sessions.ts";
+import { deleteSession, listSessions, sessionMessages } from "./sessions.ts";
 import { providerAuth } from "./auth_status.ts";
 import { cloneRepo, setWorkspace, workspaceInfo } from "./workspace.ts";
 import { applyEnv, attribution, chinaModelsAcknowledged, listMcpServers, load as loadSettings, removeMcpServer, setAsksage, setAttributionSkip, setChinaModelsAcknowledged, setDeveloperMode, setKey, setMcpServerEnabled, setProfile, setRateLimitProbe, upsertMcpServer } from "./settings_store.ts";
@@ -241,6 +241,15 @@ const server = Bun.serve({
       if (p === "/api/sessions") return json({ ok: true, data: listSessions() });
       if (p === "/api/session" && url.searchParams.get("id")) return json({ ok: true, data: sessionMessages(url.searchParams.get("id")!) });
       if (p === "/api/session/load" && req.method === "POST") { const { id } = await readBody<{ id?: unknown }>(req); await backend.loadSession(String(id)); return json({ ok: true }); }
+      if (p === "/api/session/delete" && req.method === "POST") {
+        const { id } = await readBody<{ id?: unknown }>(req);
+        const sid = String(id);
+        // If it's the live session, close it first so omp releases the file handle (Windows
+        // locks open files), then start fresh. newSession() does session/close + ensureSession.
+        if (backend.currentSessionId() === sid) await backend.newSession().catch(() => {});
+        const res = deleteSession(sid);
+        return json({ ok: true, data: res });
+      }
 
       // workspace (the folder the agent works in; local or cloned remote)
       if (p === "/api/workspace") {

--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -230,6 +230,7 @@ async function renderSessions(): Promise<void> {
     <div class="sess ${i === 0 ? "active" : ""}" data-sid="${esc(s.id)}" data-tip="${esc(s.title)}|${esc(modelLabel(s.model))} · ${s.turns} turn${s.turns === 1 ? "" : "s"} · ${relTime(s.updatedAt)}" data-tip-side="right">
       <div class="t">${esc(s.title)}</div>
       <div class="m"><b>${esc(modelLabel(s.model))}</b> · ${s.turns} turn${s.turns === 1 ? "" : "s"} · ${relTime(s.updatedAt)}</div>
+      <button class="sess-del" data-del="${esc(s.id)}" data-tip="Delete session" aria-label="Delete session" tabindex="-1">${icon("trash", 13)}</button>
     </div>`).join("");
 }
 
@@ -1405,6 +1406,32 @@ async function resumeSession(id: string): Promise<void> {
   $("#input")?.focus();
 }
 
+/** Delete a session from history (with confirm). Backend closes the live session first if it's
+ *  the one being deleted (so omp releases the file), then removes the .jsonl; the append-only
+ *  audit trail is untouched. If the deleted session was the active one, reset to a fresh chat. */
+function confirmDeleteSession(id: string): void {
+  if (state.streaming) { showToast({ title: "Finish the current turn first", desc: "Stop or let the reply finish, then delete the session.", tone: "warn", actions: [{ label: "OK" }], timeout: 3000 }); return; }
+  const row = $$(".sess").find((s) => (s as HTMLElement).dataset.sid === id) as HTMLElement | undefined;
+  const wasActive = row?.classList.contains("active") ?? false;
+  const title = row?.querySelector(".t")?.textContent?.trim() || "this session";
+  showToast({
+    title: "Delete session?",
+    desc: `"${title}" will be removed from history. This can't be undone. (Audit/provenance records are kept.)`,
+    tone: "warn",
+    actions: [
+      { label: "Delete", kind: "danger", run: async () => {
+        const r = await bridge.deleteSession(id).catch(() => ({ ok: false, error: "request failed" }));
+        if (!r?.ok) { showToast({ title: "Couldn't delete", desc: r?.error || "Try again in a moment.", tone: "danger", actions: [{ label: "OK" }], timeout: 4000 }); return; }
+        if (wasActive) { seedThread(); state.liveUsage = null; renderStatus(); renderMetricsRail(); }
+        await renderSessions();
+        showToast({ title: "Session deleted", desc: "", timeout: 1600 });
+      } },
+      { label: "Cancel" },
+    ],
+    timeout: 8000,
+  });
+}
+
 async function applyWorkspace(path: string): Promise<void> {
   // #11 perceived-latency: setWorkspace() respawns the backend (2–5s). Reassure the user
   // up front that work is happening, then confirm when it's ready, and reflect the switch
@@ -2496,7 +2523,13 @@ function wire(): void {
   $("#sideToggle")!.addEventListener("click", () => toggleSidebar());
   $("#sideCollapse")!.addEventListener("click", () => toggleSidebar(true));
   $("#wsBar")!.addEventListener("click", () => openSettings());
-  $("#sessList")!.addEventListener("click", (e) => { const s = (e.target as HTMLElement).closest(".sess") as HTMLElement | null; if (s?.dataset.sid) void resumeSession(s.dataset.sid); });
+  $("#sessList")!.addEventListener("click", (e) => {
+    const t = e.target as HTMLElement;
+    const del = t.closest(".sess-del") as HTMLElement | null;
+    if (del?.dataset.del) { e.stopPropagation(); confirmDeleteSession(del.dataset.del); return; }
+    const s = t.closest(".sess") as HTMLElement | null;
+    if (s?.dataset.sid) void resumeSession(s.dataset.sid);
+  });
   $(".brand")!.addEventListener("click", () => toggleSidebar());
 
   // status bar: click the budget / gov chips to re-check usage now

--- a/desktop/renderer/bridge.ts
+++ b/desktop/renderer/bridge.ts
@@ -193,6 +193,7 @@ export interface LucidBridge {
   sessions(): Promise<SessionInfo[] | null>;
   sessionMessages(id: string): Promise<{ role: string; text: string }[] | null>;
   resumeSession(id: string): Promise<void>;
+  deleteSession(id: string): Promise<{ ok: boolean; error?: string }>;
   newSession(): Promise<void>;
   setZoom(factor: number): void;
   // settings + provider auth
@@ -357,6 +358,7 @@ export const bridge: LucidBridge = {
   },
   sessionMessages: (id) => getData(`/api/session?id=${encodeURIComponent(id)}`),
   resumeSession: async (id) => { await post("/api/session/load", { id }); },
+  deleteSession: async (id) => (await post("/api/session/delete", { id })) ?? { ok: false, error: "no response" },
   newSession: async () => { await post("/api/newSession", {}); },
   getSettings: () => getData("/api/settings"),
   saveUsername: (username) => post("/api/settings", { username }),

--- a/desktop/renderer/icons.ts
+++ b/desktop/renderer/icons.ts
@@ -34,6 +34,8 @@ const RAW: Record<string, string> = {
   bolt: P("M12 3 6 13h5l-1 8 6-11h-5z"),
   // close
   close: P("M6 6l12 12") + P("M18 6 6 18"),
+  // trash / delete
+  trash: P("M5 7h14") + P("M9 7V5.5A1.5 1.5 0 0 1 10.5 4h3A1.5 1.5 0 0 1 15 5.5V7") + P("M6.6 7l.8 11.1A1.6 1.6 0 0 0 9 19.6h6a1.6 1.6 0 0 0 1.6-1.5L17.4 7") + P("M10 11v5") + P("M14 11v5"),
   // minimise / maximise (window controls)
   minus: P("M6 12h12"),
   square: P("M6 6.5h12v11H6z"),

--- a/desktop/renderer/styles.css
+++ b/desktop/renderer/styles.css
@@ -240,6 +240,15 @@ body.resizing .sidebar,body.resizing .inspector{transition:none}
 .sess:hover .t,.sess.active .t{color:var(--txt)}
 .sess .m{font-size:11.5px;color:var(--txt-3);display:flex;gap:6px;align-items:center}
 .sess .m b{color:var(--cyan);font-weight:600}
+/* per-row delete: hidden until hover/focus, danger tint on hover; never shifts layout */
+.sess-del{position:absolute;top:7px;right:7px;display:grid;place-items:center;width:24px;height:24px;
+  border:0;border-radius:7px;background:transparent;color:var(--txt-3);cursor:pointer;opacity:0;
+  transition:opacity var(--t) var(--ease),background var(--t) var(--ease),color var(--t) var(--ease)}
+.sess-del svg{width:13px;height:13px}
+.sess:hover .sess-del,.sess:focus-within .sess-del{opacity:.85}
+.sess-del:hover{opacity:1;background:color-mix(in srgb,var(--danger,#e5484d) 16%,transparent);color:var(--danger,#e5484d)}
+.sess-del:focus-visible{opacity:1;outline:2px solid var(--accent);outline-offset:1px}
+.sess:hover .t{padding-right:24px}
 
 /* ───────────────────────── centre / chat ───────────────────────── */
 .center{display:flex;flex-direction:column;min-width:0;min-height:0;background:var(--bg-0)}

--- a/desktop/sessions.ts
+++ b/desktop/sessions.ts
@@ -5,7 +5,7 @@
 // and derive a title (first user message), model, turn count, and last-modified.
 // New GUI chats write new files here, so they appear on the next poll.
 
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, rmSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { currentWorkspace } from "./workspace.ts";
@@ -98,4 +98,39 @@ export function sessionMessages(id: string): { role: string; text: string }[] {
     } catch { /* skip */ }
   }
   return [];
+}
+
+/** Delete a session's omp `.jsonl` transcript from disk. Restricted to the CURRENT
+ *  workspace's sessions (defense in depth) and matched by session id (or filename).
+ *  Returns `{ ok }`; `ok:false` when the session is not found, belongs to another
+ *  workspace, or the file can't be removed (e.g. still open by omp on Windows — close
+ *  the live session first). The append-only DuckDB audit/provenance is a separate store
+ *  and is intentionally untouched (issue #53). */
+export function deleteSession(id: string, cwd: string = currentWorkspace(), root: string = join(homedir(), ".omp", "agent", "sessions")): { ok: boolean; error?: string } {
+  if (!existsSync(root)) return { ok: false, error: "no sessions directory" };
+  const want = norm(cwd);
+  for (const d of readdirSync(root)) {
+    const dir = join(root, d);
+    try {
+      if (!statSync(dir).isDirectory()) continue;
+      for (const f of readdirSync(dir)) {
+        if (!f.endsWith(".jsonl")) continue;
+        const p = join(dir, f);
+        // Resolve id + cwd from the session record (first matching line), like listSessions.
+        let sid = f, scwd = "";
+        try {
+          for (const ln of readFileSync(p, "utf8").split("\n")) {
+            if (!ln) continue;
+            let o: any; try { o = JSON.parse(ln); } catch { continue; }
+            if (o.type === "session") { sid = o.id ?? f; scwd = o.cwd ?? ""; break; }
+          }
+        } catch { /* keep filename fallback */ }
+        if (sid !== id && f !== id) continue;
+        if (scwd && norm(scwd) !== want) return { ok: false, error: "session belongs to another workspace" };
+        try { rmSync(p, { force: true }); return { ok: true }; }
+        catch (e) { return { ok: false, error: String((e as any)?.message ?? e) }; }
+      }
+    } catch { /* skip dir */ }
+  }
+  return { ok: false, error: "session not found" };
 }

--- a/desktop/sessions_delete.test.ts
+++ b/desktop/sessions_delete.test.ts
@@ -1,0 +1,63 @@
+// desktop/sessions_delete.test.ts
+//
+// Issue #53: deleting a chat from the session menu removes the omp .jsonl transcript
+// from disk. It is scoped to the current workspace (defense in depth) and matched by
+// session id; the append-only DuckDB audit/provenance is a separate store and untouched.
+
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { deleteSession } from "./sessions.ts";
+
+let root: string;
+const CWD = "C:/work/proj-a";
+
+// Write a minimal omp-style session .jsonl: a `session` record (id + cwd) then one message.
+function seedSession(id: string, cwd: string): string {
+  const dir = join(root, encodeURIComponent(cwd));
+  mkdirSync(dir, { recursive: true });
+  const p = join(dir, `${id}.jsonl`);
+  writeFileSync(
+    p,
+    `${JSON.stringify({ type: "session", id, cwd })}\n${JSON.stringify({ type: "message", message: { role: "user", content: "hi" } })}\n`,
+  );
+  return p;
+}
+
+beforeEach(() => { root = mkdtempSync(join(tmpdir(), "sess-del-")); });
+afterEach(() => { rmSync(root, { recursive: true, force: true }); });
+
+test("deletes the matching session file in the current workspace", () => {
+  const p = seedSession("sess-1", CWD);
+  expect(existsSync(p)).toBe(true);
+  const r = deleteSession("sess-1", CWD, root);
+  expect(r.ok).toBe(true);
+  expect(existsSync(p)).toBe(false);
+});
+
+test("refuses to delete a session that belongs to another workspace", () => {
+  const p = seedSession("sess-2", "C:/work/proj-b");
+  const r = deleteSession("sess-2", CWD, root); // ask as proj-a
+  expect(r.ok).toBe(false);
+  expect(r.error).toContain("another workspace");
+  expect(existsSync(p)).toBe(true); // untouched
+});
+
+test("returns not-found for an unknown id and leaves other sessions intact", () => {
+  const keep = seedSession("sess-keep", CWD);
+  const r = deleteSession("does-not-exist", CWD, root);
+  expect(r.ok).toBe(false);
+  expect(r.error).toContain("not found");
+  expect(existsSync(keep)).toBe(true);
+});
+
+test("matches by filename when the session record lacks an id", () => {
+  const dir = join(root, encodeURIComponent(CWD));
+  mkdirSync(dir, { recursive: true });
+  const p = join(dir, "raw-id.jsonl");
+  writeFileSync(p, `${JSON.stringify({ type: "session", cwd: CWD })}\n`);
+  const r = deleteSession("raw-id.jsonl", CWD, root);
+  expect(r.ok).toBe(true);
+  expect(existsSync(p)).toBe(false);
+});


### PR DESCRIPTION
Closes #53.

## What
A per-row **delete** control in the session menu. Hover a session to reveal a trash button (danger-tinted, keyboard-focusable, never shifts layout); click it for a confirm toast; on confirm the session is removed from history.

## How
- New `deleteSession()` in `desktop/sessions.ts` removes the omp `.jsonl` transcript, plus `POST /api/session/delete` and a `bridge.deleteSession()`.
- Renderer: delete button in `renderSessions`, a `#sessList` handler that routes the button (stopPropagation) vs. row-resume, and `confirmDeleteSession()` with the app's standard confirm toast.

## Safety
- **Workspace-scoped + id-matched** (defense in depth): refuses a session that belongs to another workspace.
- **Live session handled:** if you delete the session you're currently in, the backend closes it first (`session/close` via `newSession`) so omp releases the file handle (Windows locks open files), then the file is removed and the UI resets to a fresh chat. New `Backend.currentSessionId()` getter supports this.
- **Blocked while streaming** (finish or stop the turn first).
- **Audit/provenance untouched:** the append-only DuckDB store is separate; only the omp transcript file is deleted.

## Tests
- 4 new unit tests for `deleteSession` (temp root, no real `~/.omp` touched): deletes-in-workspace, refuses-other-workspace, not-found, filename-fallback.
- Full desktop suite: **265 pass**; `tsc` clean.
- Final visual click-through to be confirmed in the real Electron app (not auto-verified here, since exercising delete against the dev server would remove real `~/.omp` sessions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
