### PR TITLE
fix(desktop): toasts green by default + top-right (was red, bottom)

### DIFF
--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -279,7 +279,7 @@ const fmtDur = (s: number): string => (s < 90 ? `~${s}s` : s < 3600 ? `~${Math.r
 async function runPersonalImport(folder: string, useModel: boolean): Promise<void> {
   showToast({ title: useModel ? "Importing with AI extraction…" : "Importing chat history…", desc: useModel ? "Scanning each message, then extracting facts with the model. This can take a while." : "Scanning every message through the security gate before learning.", timeout: useModel ? 4000 : 2000 });
   const r = await bridge.personalImport(folder, useModel);
-  if (!r?.ok) { showToast({ title: "Import failed", desc: r?.error ?? "Personalization is off or locked.", actions: [{ label: "OK" }], timeout: 6000 }); return; }
+  if (!r?.ok) { showToast({ tone: "danger", title: "Import failed", desc: r?.error ?? "Personalization is off or locked.", actions: [{ label: "OK" }], timeout: 6000 }); return; }
   const vendor = r.vendor === "openai" ? "ChatGPT" : r.vendor === "anthropic" ? "Claude" : r.vendor === "gemini" ? "Gemini" : "export";
   const notes = [
     r.extractor === "model" ? "AI extraction" : "quick extraction",
@@ -1885,7 +1885,7 @@ async function applyPersona(id: string | null): Promise<void> {
     showToast({ title: `Persona "${id}" applied`, desc: "Scanned clean - added as delimited role guidance on your next turn.", actions: [{ label: "OK" }], timeout: 3200 });
   } else {
     state.persona = null; updateComposerTools();
-    showToast({ title: "Persona blocked", desc: `The scanner flagged this persona (${r?.scan?.findings ?? 0} finding(s)); it was not applied.`, meta: "fail-closed - untrusted content can't enter the prompt", actions: [{ label: "OK" }], timeout: 6000 });
+    showToast({ tone: "danger", title: "Persona blocked", desc: `The scanner flagged this persona (${r?.scan?.findings ?? 0} finding(s)); it was not applied.`, meta: "fail-closed - untrusted content can't enter the prompt", actions: [{ label: "OK" }], timeout: 6000 });
   }
 }
 
@@ -2061,7 +2061,7 @@ function wire(): void {
     if (!folder) return;
     // Read-only pre-import estimate → warn about AI-mode token cost + runtime before the paid run.
     const est = await bridge.personalImportEstimate(folder);
-    if (!est?.ok) { showToast({ title: "Couldn't read that export", desc: est?.error ?? "No conversations found in that export.", actions: [{ label: "OK" }], timeout: 6000 }); return; }
+    if (!est?.ok) { showToast({ tone: "danger", title: "Couldn't read that export", desc: est?.error ?? "No conversations found in that export.", actions: [{ label: "OK" }], timeout: 6000 }); return; }
     // First import (empty graph) defaults to AI extraction (best quality); after that, honor the box.
     const status = await bridge.personal();
     const totalFacts = status?.counts ? status.counts.work + status.counts.personal + status.counts.cui : 0;
@@ -2083,7 +2083,7 @@ function wire(): void {
   $("#kgExport")!.addEventListener("click", async () => {
     showToast({ title: "Exporting vault…", desc: "Decrypting and writing your Obsidian notes.", timeout: 1400 });
     const r = await bridge.personalExportVault({});
-    if (!r?.ok) showToast({ title: "Vault not exported", desc: r?.error ?? "Personalization is off or locked.", actions: [{ label: "OK" }], timeout: 5000 });
+    if (!r?.ok) showToast({ tone: "danger", title: "Vault not exported", desc: r?.error ?? "Personalization is off or locked.", actions: [{ label: "OK" }], timeout: 5000 });
     else showToast({ title: "Vault exported", desc: `${r.files} files · ${r.entities} notes · ${r.facts} facts → ${r.dest}`, meta: "Personal + Work · CUI excluded by design · audited", actions: [{ label: "OK" }], timeout: 7000 });
   });
   $("#kgCui")!.addEventListener("click", () => {
@@ -2095,7 +2095,7 @@ function wire(): void {
         { label: "Cancel" },
         { label: "Export CUI archive", kind: "danger", run: async () => {
           const r = await bridge.personalCuiArchive({});
-          if (!r?.ok) showToast({ title: "CUI archive not written", desc: r?.error ?? "Personalization is off or locked.", actions: [{ label: "OK" }], timeout: 6000 });
+          if (!r?.ok) showToast({ tone: "danger", title: "CUI archive not written", desc: r?.error ?? "Personalization is off or locked.", actions: [{ label: "OK" }], timeout: 6000 });
           else showToast({ title: "CUI archive written", desc: `${r.files} files · ${r.facts} facts → ${r.dest}`, meta: `manifest sha256 ${(r.manifestSha256 ?? "").slice(0, 12)}… · complete the designation before transfer`, actions: [{ label: "OK" }], timeout: 9000 });
         } },
       ],
@@ -2124,13 +2124,13 @@ function wire(): void {
     const saveBtn = t.closest("[data-msg-save]") as HTMLElement | null;
     if (!copyBtn && !saveBtn) return;
     const md = ((t.closest(".msg") as MsgNode | null)?._md ?? "").trim();
-    if (!md) { showToast({ title: "Nothing to copy yet", desc: "Wait for the reply to finish.", actions: [{ label: "OK" }], timeout: 2000 }); return; }
+    if (!md) { showToast({ tone: "warn", title: "Nothing to copy yet", desc: "Wait for the reply to finish.", actions: [{ label: "OK" }], timeout: 2000 }); return; }
     if (copyBtn) {
       try {
         await navigator.clipboard.writeText(md);
         copyBtn.classList.add("ok"); copyBtn.innerHTML = icon("check", 13);
         setTimeout(() => { copyBtn.classList.remove("ok"); copyBtn.innerHTML = icon("copy", 13); }, 1200);
-      } catch { showToast({ title: "Copy failed", desc: "Clipboard unavailable in this view.", actions: [{ label: "OK" }], timeout: 2800 }); }
+      } catch { showToast({ tone: "danger", title: "Copy failed", desc: "Clipboard unavailable in this view.", actions: [{ label: "OK" }], timeout: 2800 }); }
     } else if (saveBtn) {
       const blob = new Blob([md], { type: "text/markdown;charset=utf-8" });
       const url = URL.createObjectURL(blob);
@@ -2197,7 +2197,7 @@ function wire(): void {
       showToast({ title: "Cloning…", desc: "Fetching the repo - this can take a moment.", timeout: 2500 });
       const info = await bridge.cloneWorkspace(url);
       if (info?.cloned) { state.workspace = info; renderWorkspaceBar(); seedThread(); void renderSessions(); void renderSettings(); showToast({ title: "Cloned & opened", desc: `Agent now works in ${info.name}.`, actions: [{ label: "OK" }], timeout: 3000 }); }
-      else showToast({ title: "Clone failed", desc: (info?.error ?? "Check the URL and your git access.").slice(0, 180), actions: [{ label: "OK" }], timeout: 6000 });
+      else showToast({ tone: "danger", title: "Clone failed", desc: (info?.error ?? "Check the URL and your git access.").slice(0, 180), actions: [{ label: "OK" }], timeout: 6000 });
       return;
     }
     const wsr = t.closest("[data-ws]") as HTMLElement | null;
@@ -2222,7 +2222,7 @@ function wire(): void {
       const env = save.dataset.savekey!;
       const inp = $(`.prov-key[data-env="${env}"]`, $("#setBody")!) as HTMLInputElement | null;
       const val = inp?.value.trim() ?? "";
-      if (!val) { showToast({ title: "Nothing to save", desc: "Paste a key first.", actions: [{ label: "OK" }], timeout: 2000 }); return; }
+      if (!val) { showToast({ tone: "warn", title: "Nothing to save", desc: "Paste a key first.", actions: [{ label: "OK" }], timeout: 2000 }); return; }
       await bridge.saveKey(env, val);
       showToast({ title: `${env} saved`, desc: "Stored on this machine and passed to omp. New turns use it.", actions: [{ label: "OK" }], timeout: 2800 });
       void renderSettings();

--- a/desktop/renderer/styles.css
+++ b/desktop/renderer/styles.css
@@ -820,9 +820,10 @@ body.resizing .sidebar,body.resizing .inspector{transition:none}
 .seg button.on.acc{color:var(--accent-2)}
 
 /* ───────────────────────── toast / popover ───────────────────────── */
-#toasts{position:fixed;right:18px;bottom:42px;z-index:120;display:flex;flex-direction:column;gap:10px;align-items:flex-end}
-/* --tone: the toast's accent colour; defaults to danger so existing (classless) toasts are unchanged. */
-.toast{--tone:var(--red);--tone-tint:rgba(239,95,95,.14);--tone-h:#ffd0d0;
+#toasts{position:fixed;right:18px;top:52px;z-index:120;display:flex;flex-direction:column;gap:10px;align-items:flex-end}
+/* --tone: the toast's accent colour; defaults to the positive (green) look — most toasts are
+   confirmations. Error/failure callers opt into tone:"danger" (red); warnings into tone:"warn". */
+.toast{--tone:var(--green);--tone-tint:var(--green-dim);--tone-h:#c6f3d6;
   width:340px;background:var(--bg-1);background-image:var(--emboss,none);
   border:1px solid color-mix(in srgb,var(--tone) 42%,transparent);border-radius:13px;
   box-shadow:var(--shadow-lg,var(--shadow)),0 0 0 1px rgba(255,255,255,.02) inset;overflow:hidden;

--- a/desktop/renderer/ui.ts
+++ b/desktop/renderer/ui.ts
@@ -183,15 +183,15 @@ export interface ToastAction { label: string; kind?: "ok" | "danger"; run?: () =
 export type ToastTone = "ok" | "info" | "warn" | "danger";
 export interface ToastOpts { title: string; desc: string; meta?: string; actions?: ToastAction[]; timeout?: number; tone?: ToastTone }
 
-// Per-tone icon. Defaults to the danger look ("shield") when tone is omitted, so
-// existing callers are unchanged — they just lose the aggressive red via CSS only
-// when they opt into a tone.
+// Per-tone icon. Defaults to the positive look ("check") when tone is omitted, matching
+// the green default in CSS — most toasts are confirmations. Failure callers opt into
+// tone:"danger" (shield + red), warnings into tone:"warn".
 const TONE_ICON: Record<ToastTone, string> = { ok: "check", info: "info", warn: "bolt", danger: "shield" };
 
 export function showToast(o: ToastOpts): void {
   const host = $("#toasts")!;
   const toneClass = o.tone ? ` ${o.tone}` : "";
-  const ico = o.tone ? (TONE_ICON[o.tone] ?? "shield") : "shield";
+  const ico = o.tone ? (TONE_ICON[o.tone] ?? "shield") : "check";
   const node = el(`<div class="toast${toneClass}" role="alert">
     <div class="bar"></div>
     <div class="in">${icon(ico, 18)}


### PR DESCRIPTION
Two toast fixes requested: success toasts should be a **green box**, and the stack should sit **top-right** (was bottom-right).

## Root cause
The toast CSS defaulted to the danger look (`--tone: var(--red)` + shield icon) for any caller that didn't pass a `tone`. Most toasts are confirmations ("Session deleted", "Workspace set", "Skill on", "Email saved", …), so they all rendered red.

## Fix
- **Default → green/positive** (`--tone: var(--green)`, default icon `check`).
- **Host moved to top-right** (`top:52px; right:18px`, clearing the 40px titlebar).
- **Failures stay red:** the genuine error toasts now opt into `tone:"danger"` (Import failed, Persona blocked, Couldn't read that export, Copy failed, Vault not exported, CUI archive not written, Clone failed); the two soft "Nothing to …" notices use `tone:"warn"`.

## Verified in the dev preview
Injected a default and a danger toast: host computed `top:52px / right:18px`, success `--tone:#46d27e` (green). Screenshot confirms a green "Session deleted" box and a red "Import failed" box, both top-right. `tsc` clean; no console errors.
