### PR TITLE
fix(desktop): persist persona/skill/profile across turns (#54)

### DIFF
--- a/desktop/acp_backend.ts
+++ b/desktop/acp_backend.ts
@@ -14,6 +14,7 @@ import { ACPClient } from "./acp.ts";
 import { BUILD_POLICY, DELEGATION_POLICY } from "../harness/prompt/assembler.ts";
 import { currentWorkspace } from "./workspace.ts";
 import { learnFromTurn, recallPreamble } from "./personal.ts";
+import { buildUserTurnPreamble } from "./preamble.ts";
 import { recordTurns } from "./turns_log.ts";
 import { recordBlock } from "./security_log.ts";
 import { attribution, lastModel, mcpServersForAcp, setLastModel } from "./settings_store.ts";
@@ -52,24 +53,21 @@ class Backend {
   private sessionId: string | null = null;
   private starting: Promise<void> | null = null;
   private listener: ((e: ChatEvent) => void) | null = null;
-  // Approved (scanned + delimited) AskSage persona, delivered once per session
-  // inside the first user turn - never the frozen prefix (ADR-0007 / invariant #5).
+  // Approved (scanned + delimited) AskSage persona. STANDING guidance: re-delivered EVERY turn in the
+  // user turn (never the frozen prefix; ADR-0007 / invariant #5) so it doesn't fade (issue #54).
   private persona: string | null = null;
-  private personaDelivered = false;
-  // Personalization recall (P9.2): a <user-profile> block delivered once per session in
-  // the user turn (never the frozen prefix). Off unless personalization is enabled+unlocked.
-  private recallDelivered = false;
-  // Cross-session memory recall (ADR-0009 Phase A): a <recalled-memory> block of facts
-  // distilled in EARLIER sessions, delivered once per session in the user turn — never the
-  // frozen prefix (invariant #5/#6). Distinct from the P9.2 personalization recall above.
+  // Personalization recall (P9.2): the live <user-profile> block, re-read and re-delivered every turn
+  // (never the frozen prefix). Off unless personalization is enabled+unlocked.
+  // Cross-session memory recall (ADR-0009 Phase A): a <recalled-memory> block of facts distilled in
+  // EARLIER sessions, delivered ONCE per session in the user turn (a session-start recall, not standing
+  // guidance) — never the frozen prefix (invariant #5/#6). Distinct from the P9.2 recall above.
   private memoryRecall: string | null = null;
   private memoryRecallDelivered = false;
-  // P-IDE.2 (ADR-0029): an active BUNDLED skill's trusted guidance, delivered once per session in the
-  // user turn (same path as persona/recall — never the frozen prefix, never --append-system-prompt).
-  // Already wrapped (`<active-skill name="…">…</active-skill>`). Persists until cleared/changed.
+  // P-IDE.2 (ADR-0029): an active BUNDLED skill's trusted guidance. STANDING guidance: re-delivered
+  // every turn (never the frozen prefix, never --append-system-prompt) so the skill keeps guiding the
+  // agent until cleared (issue #54). Already wrapped (`<active-skill name="…">…</active-skill>`).
   private skill: string | null = null;
   private skillName = "";
-  private skillDelivered = false;
   configOptions: any[] = [];
   commands: any[] = [];
   // P-ACP.2 (ADR-0027): ACP session modes (omp exposes [default, plan]). Plan is a read-only
@@ -90,7 +88,7 @@ class Backend {
   private static readonly PERM_MS = 300_000; // 5 min to decide, then fail-closed (deny)
 
   /** Set/clear the active persona. Pass the ALREADY-scanned, delimiter-wrapped text. */
-  setPersona(wrapped: string | null): void { this.persona = wrapped; this.personaDelivered = false; }
+  setPersona(wrapped: string | null): void { this.persona = wrapped; }
 
   /** Set/clear the cross-session recall block. Pass the ALREADY-escaped, delimiter-wrapped
    *  text from buildRecall(); re-delivered in the first user turn of each session. */
@@ -98,7 +96,7 @@ class Backend {
 
   /** P-IDE.2: set/clear the active bundled skill. `wrapped` is the trusted `<active-skill …>` block
    *  (or null to clear). Re-delivered on the next turn so a skill change takes effect immediately. */
-  setSkill(wrapped: string | null, name = ""): void { this.skill = wrapped; this.skillName = wrapped ? name : ""; this.skillDelivered = false; }
+  setSkill(wrapped: string | null, name = ""): void { this.skill = wrapped; this.skillName = wrapped ? name : ""; }
   activeSkillName(): string { return this.skillName; }
 
   private emit(e: ChatEvent): void { this.listener?.(e); }
@@ -309,10 +307,7 @@ class Backend {
     await this.start();
     if (this.sessionId) await this.acp!.request("session/close", { sessionId: this.sessionId }).catch(() => {});
     this.sessionId = null;
-    this.personaDelivered = false; // re-deliver the persona in the fresh session
-    this.recallDelivered = false;
-    this.memoryRecallDelivered = false; // re-deliver cross-session recall in the fresh session
-    this.skillDelivered = false; // re-deliver the active bundled skill in the fresh session
+    this.memoryRecallDelivered = false; // re-deliver the cross-session recall once in the fresh session
     await this.ensureSession();
   }
 
@@ -321,10 +316,7 @@ class Backend {
   restart(): void {
     try { this.acp?.stop(); } catch { /* ignore */ }
     this.acp = null; this.starting = null; this.sessionId = null; this.listener = null;
-    this.personaDelivered = false; // keep the chosen persona; re-deliver after respawn
-    this.recallDelivered = false;
-    this.memoryRecallDelivered = false;
-    this.skillDelivered = false; // keep the active skill; re-deliver after respawn
+    this.memoryRecallDelivered = false; // persona/skill/profile are re-delivered every turn anyway (#54)
     this.availableModes = []; this.currentModeId = "default"; // re-captured from the fresh session
     // Drop any parked permission (deny) but KEEP permissionMode — the user's Ask choice survives a respawn.
     for (const [, fn] of this.permPending) fn(null);
@@ -353,14 +345,18 @@ class Backend {
     this.askActive = true; // permission requests in THIS turn may be forwarded to the UI (Ask mode)
     try {
       await this.ensureSession();
-      // Deliver, once per session in the user turn (never the frozen prefix): the approved
-      // persona (delimited untrusted) + the personalization recall (<user-profile> guidance).
-      let preamble = "";
-      if (this.persona && !this.personaDelivered) { preamble += `${this.persona}\n\n`; this.personaDelivered = true; }
-      if (this.skill && !this.skillDelivered) { preamble += `${this.skill}\n\n`; this.skillDelivered = true; } // P-IDE.2 bundled skill
-      if (!this.recallDelivered) { const r = recallPreamble(); if (r) preamble += `${r}\n\n`; this.recallDelivered = true; }
-      if (this.memoryRecall && !this.memoryRecallDelivered) { preamble += `${this.memoryRecall}\n\n`; this.memoryRecallDelivered = true; }
-      const body = preamble + text;
+      // Assemble the user-turn preamble (never the frozen prefix; invariant #5/#6). Issue #54:
+      // persona + skill + the live <user-profile> profile are STANDING guidance re-delivered every
+      // turn; the cross-session <recalled-memory> is a one-time session-start recall. See preamble.ts.
+      const built = buildUserTurnPreamble({
+        persona: this.persona,
+        skill: this.skill,
+        profile: recallPreamble(), // P9.2: re-read each turn so newly-learned facts show up
+        memoryRecall: this.memoryRecall,
+        memoryRecallDelivered: this.memoryRecallDelivered,
+      });
+      this.memoryRecallDelivered = built.memoryRecallDelivered;
+      const body = built.preamble + text;
       arm(); // start the idle clock now (covers a stall BEFORE the first token)
       const stall = new Promise<never>((_, reject) => { onStall = reject; });
       await Promise.race([

--- a/desktop/preamble.test.ts
+++ b/desktop/preamble.test.ts
@@ -1,0 +1,62 @@
+// desktop/preamble.test.ts
+//
+// Issue #54: standing guidance (persona, skill, <user-profile> profile) must be re-delivered on
+// EVERY turn so it doesn't fade across a conversation; the cross-session <recalled-memory> recall
+// is delivered ONCE per session.
+
+import { expect, test } from "bun:test";
+import { buildUserTurnPreamble, type PreambleState } from "./preamble.ts";
+
+const persona = "UNTRUSTED_CONTENT_START\n[persona]\nBe terse.\nUNTRUSTED_CONTENT_END";
+const skill = `<active-skill name="reviewer">\nReview carefully.\n</active-skill>`;
+const profile = `<user-profile note="learned">\nLikes caramel custard.\n</user-profile>`;
+const memory = `<recalled-memory>\n- (trusted) build-system: builds with Bun.\n</recalled-memory>`;
+
+const base = (over: Partial<PreambleState> = {}): PreambleState => ({
+  persona: null, skill: null, profile: "", memoryRecall: null, memoryRecallDelivered: false, ...over,
+});
+
+test("empty state -> empty preamble", () => {
+  const r = buildUserTurnPreamble(base());
+  expect(r.preamble).toBe("");
+  expect(r.memoryRecallDelivered).toBe(false);
+});
+
+test("persona + skill + profile are all included on a turn", () => {
+  const r = buildUserTurnPreamble(base({ persona, skill, profile }));
+  expect(r.preamble).toContain("Be terse.");
+  expect(r.preamble).toContain("active-skill");
+  expect(r.preamble).toContain("Likes caramel custard.");
+});
+
+test("persona/skill/profile PERSIST across turns (re-delivered every turn) — issue #54", () => {
+  const state = base({ persona, skill, profile, memoryRecall: memory });
+  // turn 1
+  const t1 = buildUserTurnPreamble(state);
+  expect(t1.preamble).toContain("Be terse.");
+  expect(t1.preamble).toContain("active-skill");
+  expect(t1.preamble).toContain("Likes caramel custard.");
+  expect(t1.preamble).toContain("recalled-memory"); // memory delivered on turn 1
+
+  // turn 2 (carry forward the updated memoryRecallDelivered flag)
+  const t2 = buildUserTurnPreamble({ ...state, memoryRecallDelivered: t1.memoryRecallDelivered });
+  expect(t2.preamble).toContain("Be terse.");          // persona still here
+  expect(t2.preamble).toContain("active-skill");        // skill still here
+  expect(t2.preamble).toContain("Likes caramel custard."); // profile still here
+  expect(t2.preamble).not.toContain("recalled-memory"); // memory NOT re-sent (once per session)
+});
+
+test("cross-session memory recall is delivered exactly once and flips the flag", () => {
+  const first = buildUserTurnPreamble(base({ memoryRecall: memory }));
+  expect(first.preamble).toContain("recalled-memory");
+  expect(first.memoryRecallDelivered).toBe(true);
+  const second = buildUserTurnPreamble(base({ memoryRecall: memory, memoryRecallDelivered: true }));
+  expect(second.preamble).toBe("");
+});
+
+test("the live profile reflects the latest value each turn (re-read, not cached)", () => {
+  const t1 = buildUserTurnPreamble(base({ profile: "<user-profile note=\"learned\">\nA\n</user-profile>" }));
+  expect(t1.preamble).toContain("A");
+  const t2 = buildUserTurnPreamble(base({ profile: "<user-profile note=\"learned\">\nA\nB\n</user-profile>" }));
+  expect(t2.preamble).toContain("B"); // newly-learned fact shows up on the next turn
+});

--- a/desktop/preamble.ts
+++ b/desktop/preamble.ts
@@ -1,0 +1,45 @@
+// desktop/preamble.ts
+//
+// Builds the per-turn USER-TURN PREAMBLE that acp_backend prepends to the typed message
+// (never the frozen prefix; invariant #5/#6 — these live AFTER the cache breakpoint, so
+// re-sending them every turn does not bust the prefix KV cache).
+//
+// Issue #54: STANDING guidance (the active persona, the active bundled skill, and the live
+// <user-profile> personalization profile) is re-delivered EVERY turn so it does not fade across
+// a long conversation. The cross-session <recalled-memory> block is a one-time SESSION-START
+// recall of prior-session facts (not standing guidance), so it is delivered ONCE per session.
+
+export interface PreambleState {
+  /** Active AskSage persona, already scanned + delimiter-wrapped, or null. */
+  persona: string | null;
+  /** Active bundled skill, already `<active-skill …>`-wrapped, or null. */
+  skill: string | null;
+  /** Live <user-profile> personalization block (recallPreamble()), re-read each turn; "" when off. */
+  profile: string;
+  /** Cross-session <recalled-memory> block, or null. Delivered once per session. */
+  memoryRecall: string | null;
+  /** Whether the cross-session recall has already been delivered this session. */
+  memoryRecallDelivered: boolean;
+}
+
+export interface PreambleResult {
+  /** The assembled preamble to prepend to the user's typed text (may be ""). */
+  preamble: string;
+  /** Updated once-per-session flag for the cross-session recall. */
+  memoryRecallDelivered: boolean;
+}
+
+/** Assemble the user-turn preamble. Persona, skill, and profile are STANDING (every turn);
+ *  the cross-session memory recall is one-time per session. Pure + deterministic. */
+export function buildUserTurnPreamble(s: PreambleState): PreambleResult {
+  let preamble = "";
+  if (s.persona) preamble += `${s.persona}\n\n`;
+  if (s.skill) preamble += `${s.skill}\n\n`;
+  if (s.profile) preamble += `${s.profile}\n\n`;
+  let memoryRecallDelivered = s.memoryRecallDelivered;
+  if (s.memoryRecall && !memoryRecallDelivered) {
+    preamble += `${s.memoryRecall}\n\n`;
+    memoryRecallDelivered = true;
+  }
+  return { preamble, memoryRecallDelivered };
+}


### PR DESCRIPTION
Closes #54.

## Problem
Persona, bundled skill, and the `<user-profile>` personalization recall were delivered only on the **first** user turn of a session, then never re-sent. So in a multi-turn chat the standing guidance faded and the model 'forgot' the active skill/persona and the learned profile — e.g. it searched workspace files instead of using the knowledge-graph facts it had just learned.

## Fix
Re-deliver persona + skill + profile on **every** turn. They live **after the cache breakpoint** (invariant #5/#6), so re-sending does **not** bust the frozen-prefix KV cache — the only cost is a few input tokens per turn, which is the tradeoff that makes the guidance stick. The profile is re-read each turn so mid-session learning shows up next turn. The cross-session `<recalled-memory>` block stays **once** per session (a session-start recall, not standing guidance).

Supersedes the 'delivered once per session' model in ADR-0007/0029 for standing guidance (worth an ADR note if you want one).

## Verification
Extracted the assembly into a pure `buildUserTurnPreamble()` (`desktop/preamble.ts`) and removed the now-unused delivered flags. **5 new unit tests** prove persona/skill/profile persist across turns while memory-recall is delivered once; full desktop suite (277) green; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)