### PR TITLE
feat(desktop): live-refresh the Knowledge graph after a turn (no close/reopen)

### DIFF
--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -648,6 +648,7 @@ async function send(): Promise<void> {
     (node as MsgNode)._md = buf;
     if (state.streaming) { streamEl.innerHTML = renderMarkdown(buf); enhanceCodeBlocks(streamEl); finishHud(); state.streaming = false; setSendEnabled(); } else { finishHud(); }
     void renderSessions(); void refreshBudget(false); void syncMode();
+    scheduleKnowledgeRefresh(); // #54 follow-up: new facts appear in the open KG without close/reopen
     // P-ACP.4: the turn ended — fire off any pre-staged prompt now (the composer is idle again).
     if (state.queued) { const q = state.queued; state.queued = null; renderQueued(); const ta2 = $("#input") as HTMLTextAreaElement; ta2.value = q; setSendEnabled(); void send(); }
   }
@@ -1238,6 +1239,33 @@ let kgData: PersonalGraphData | null = null;
 let kgLens: "kind" | "trust" = "kind";
 let kgOpen = false;
 let kgSelId: string | null = null;
+let kgSig = ""; // signature of the last-rendered graph, to skip no-op live refreshes
+
+/** Cheap change-signature for the graph (node/edge ids + counts + fact total). */
+function kgSignature(d: PersonalGraphData | null): string {
+  if (!d) return "";
+  return `${d.nodes.map((n) => `${n.id}:${n.count}`).join("|")}#${d.edges.map((e) => `${e.from}>${e.to}`).join("|")}#${d.facts?.length ?? 0}`;
+}
+
+/** Live-refresh the open KG without a full remount: merge new facts/edges into the running
+ *  simulation (positions preserved). No-op if the panel is closed or nothing changed. */
+async function refreshKnowledgeLive(): Promise<void> {
+  if (!kgOpen || !kgHandle) return;
+  const data = await bridge.personalGraph().catch(() => null);
+  if (!data || data.nodes.length === 0) return;
+  const sig = kgSignature(data);
+  if (sig === kgSig) return; // nothing new learned
+  kgSig = sig; kgData = data;
+  kgHandle.update(data);
+}
+
+/** After a chat turn, learning happens in the background (learnFromTurn, async + best-effort),
+ *  so poll a couple of times to catch both the fast heuristic and the slower model extractor. */
+function scheduleKnowledgeRefresh(): void {
+  if (!kgOpen) return;
+  setTimeout(() => void refreshKnowledgeLive(), 1500);
+  setTimeout(() => void refreshKnowledgeLive(), 4500);
+}
 function openKnowledge(): void {
   kgOpen = true;
   closeSettings();
@@ -1283,6 +1311,7 @@ async function renderKnowledge(): Promise<void> {
   (side as HTMLElement).hidden = true; side.innerHTML = ""; // appears only when a node is clicked
   kgHandle = mountGraph(canvas as HTMLElement, kgData, (id) => renderKgSide(id));
   kgHandle.setLens(kgLens);
+  kgSig = kgSignature(kgData); // baseline so live refreshes only fire on real changes
 }
 // Inline unlock for the Knowledge graph - enter the passphrase here instead of going to Settings.
 // Validates (non-empty), warns on Caps Lock, and has a show/hide toggle. On success the graph mounts.

--- a/desktop/renderer/graph.ts
+++ b/desktop/renderer/graph.ts
@@ -19,7 +19,7 @@ const TRUST_COLOR: Record<string, string> = { trusted: "#46d27e", untrusted: "#5
 export const kindLabel = (k: string): string => k.replace(/^user:/, "");
 
 interface SimNode extends GraphNode { x: number; y: number; vx: number; vy: number; r: number }
-export interface GraphHandle { destroy: () => void; setLens: (l: "kind" | "trust") => void; fit: () => void }
+export interface GraphHandle { destroy: () => void; setLens: (l: "kind" | "trust") => void; fit: () => void; update: (data: PersonalGraphData) => void }
 
 const NS = "http://www.w3.org/2000/svg";
 const make = <K extends keyof SVGElementTagNameMap>(t: K): SVGElementTagNameMap[K] => document.createElementNS(NS, t);
@@ -212,9 +212,55 @@ export function mountGraph(host: HTMLElement, data: PersonalGraphData, onSelect:
   ro.observe(host);
 
   paint();
+
+  // Position-preserving merge of fresh data into the LIVE simulation (issue #54 follow-up): keep
+  // existing nodes AND their x/y (so the layout doesn't jump), add new nodes near the centre so they
+  // animate in, drop removed ones, then rebuild the cheap edge layer. Reheats so new nodes settle.
+  const mkNodeEl = (n: SimNode) => {
+    const g = make("g"); g.setAttribute("class", "kg-node"); (g as SVGGElement & { dataset: DOMStringMap }).dataset.id = n.id;
+    const c = make("circle"); c.setAttribute("r", String(n.r));
+    const t = make("text"); t.setAttribute("class", "kg-label"); t.setAttribute("y", String(-n.r - 5));
+    t.textContent = n.name.length > 22 ? n.name.slice(0, 21) + "…" : n.name;
+    g.append(c, t); nodeG.append(g); elFor.set(n.id, { g, c });
+  };
+  const update = (next: PersonalGraphData) => {
+    const incoming = new Map(next.nodes.map((n) => [n.id, n]));
+    for (let i = nodes.length - 1; i >= 0; i--) { // drop removed nodes
+      const n = nodes[i]!;
+      if (!incoming.has(n.id)) { elFor.get(n.id)?.g.remove(); elFor.delete(n.id); byId.delete(n.id); nodes.splice(i, 1); }
+    }
+    for (const nd of next.nodes) { // add new + refresh existing (KEEP position)
+      const r = 7 + Math.min(15, nd.count * 2.5);
+      const ex = byId.get(nd.id);
+      if (ex) {
+        ex.name = nd.name; ex.kind = nd.kind; ex.trust = nd.trust; ex.count = nd.count; ex.r = r;
+        const el = elFor.get(nd.id);
+        if (el) {
+          el.c.setAttribute("r", String(r));
+          const lbl = el.g.querySelector(".kg-label") as SVGTextElement | null;
+          if (lbl) { lbl.textContent = nd.name.length > 22 ? nd.name.slice(0, 21) + "…" : nd.name; lbl.setAttribute("y", String(-r - 5)); }
+        }
+      } else {
+        const sn: SimNode = { ...nd, x: cx + (Math.random() - 0.5) * 60, y: cy + (Math.random() - 0.5) * 60, vx: 0, vy: 0, r };
+        nodes.push(sn); byId.set(sn.id, sn); mkNodeEl(sn);
+      }
+    }
+    for (const ed of edgeEls) { ed.path.remove(); for (const p of ed.parts) p.remove(); } // rebuild edges (cheap)
+    edgeEls.length = 0; edges.length = 0;
+    for (const e of next.edges.filter((e) => byId.has(e.from) && byId.has(e.to))) {
+      edges.push(e);
+      const path = make("path"); path.setAttribute("class", "kg-edge"); edgeG.append(path);
+      const parts: SVGCircleElement[] = [];
+      for (let i = 0; i < PPE; i++) { const c = make("circle"); c.setAttribute("class", "kg-part"); c.setAttribute("r", "1.7"); partG.append(c); parts.push(c); }
+      edgeEls.push({ e, path, parts });
+    }
+    reheat(); paint();
+  };
+
   return {
     destroy() { stopped = true; cancelAnimationFrame(raf); ro.disconnect(); window.removeEventListener("mousemove", onMove); window.removeEventListener("mouseup", onUp); host.innerHTML = ""; },
     setLens(l) { lens = l; paint(); },
     fit() { userMoved = true; computeFit(); },
+    update,
   };
 }


### PR DESCRIPTION
Closes the KG-refresh half of the #54 discussion.

## Problem
The Knowledge graph only re-rendered when you **opened** it (or after import/unlock). Facts learned during a chat (`learnFromTurn`, background) never showed until you **closed and reopened** the panel.

## Fix
- New **position-preserving `GraphHandle.update(data)`** that merges fresh data into the live force simulation: existing nodes keep their x/y (no jump), new nodes animate in, removed nodes drop, edges rebuild, sim reheats so new nodes settle.
- After each turn, if the KG is open, poll twice (1.5s + 4.5s — covers the fast heuristic and slower model extractor) and `update()` only when a cheap change-signature differs (unchanged graph = no-op, no flicker).

## Verified live (preview)
Sent `I prefer working in dark mode` with the KG open → graph went **4 → 5 nodes** (`working in dark mode` appeared) **without reopening**, all original nodes preserved, no console errors (screenshot in the session). 277 desktop tests green; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)