### PR TITLE
fix(desktop): forgetting a fact updates the KG live

### DIFF
--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -2179,8 +2179,9 @@ function wire(): void {
     if (forget) {
       const fid = forget.dataset.forget!;
       await bridge.personalForget(fid);
-      if (kgData) kgData.facts = kgData.facts.filter((f) => f.id !== fid); // keep the graph layout; just drop the fact
+      if (kgData) kgData.facts = kgData.facts.filter((f) => f.id !== fid); // drop the fact from the side panel
       renderKgSide(kgSelId);
+      void refreshKnowledgeLive(); // also drop the node live if that was its last fact (no reopen needed)
       showToast({ title: "Forgotten", desc: "The agent will stop recalling that fact.", actions: [{ label: "OK" }], timeout: 2000 });
     }
   });


### PR DESCRIPTION
Follow-up to #63. The forget handler updated the facts side-panel but not the graph, so a node lingered until close/reopen. Now it calls `refreshKnowledgeLive()` (the same position-preserving merge) so the node drops immediately when its last fact is forgotten. tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)