### PR TITLE
feat(personal): opt-in model extraction for the KG (#1, part 2)

### DIFF
--- a/desktop/acp_backend.ts
+++ b/desktop/acp_backend.ts
@@ -374,7 +374,7 @@ class Backend {
     }
     this.listener = null;
     onEvent({ type: "done" });
-    void learnFromTurn(text, assistant); // best-effort, after the turn — fail-closed inside
+    void learnFromTurn(text, assistant, (sys, usr) => this.complete(sys, usr)); // best-effort; the model extractor (opt-in) uses complete()
     // ADR-0009 Phase B (issue #12): capture the turn for traceability. Sanitized + sha only,
     // GUI-side (can't co-write DuckDB); fully guarded so it never affects the chat.
     recordTurns({ sessionId: this.sessionId ?? "", userText: text, assistantText: assistant });

--- a/desktop/dev.ts
+++ b/desktop/dev.ts
@@ -17,7 +17,7 @@ import { backend } from "./acp_backend.ts";
 import { deleteSession, listSessions, sessionMessages } from "./sessions.ts";
 import { providerAuth } from "./auth_status.ts";
 import { cloneRepo, setWorkspace, workspaceInfo } from "./workspace.ts";
-import { applyEnv, attribution, chinaModelsAcknowledged, listMcpServers, load as loadSettings, removeMcpServer, setAsksage, setAttributionSkip, setChinaModelsAcknowledged, setDeveloperMode, setKey, setMcpServerEnabled, setProfile, setRateLimitProbe, upsertMcpServer } from "./settings_store.ts";
+import { applyEnv, attribution, chinaModelsAcknowledged, listMcpServers, load as loadSettings, removeMcpServer, setAsksage, setAttributionSkip, setChinaModelsAcknowledged, setDeveloperMode, setKey, setMcpServerEnabled, setPersonalAiExtract, setProfile, setRateLimitProbe, upsertMcpServer } from "./settings_store.ts";
 import { emailDomainAllowed, managedConfig, skipAllowed } from "./managed_config.ts";
 import { asksageConfig, listDatasets, listPersonas, monthlyTokens, scanPersona, wrapPersona } from "./asksage.ts";
 import { listSkills } from "./skills_data.ts";
@@ -355,6 +355,7 @@ const server = Bun.serve({
       // the passphrase never leaves this handler and is never persisted.
       if (p === "/api/personal") return json({ ok: true, data: personalStatus() });
       if (p === "/api/personal/enable" && req.method === "POST") { const b = await readBody<{ enabled?: unknown }>(req); return json({ ok: true, data: enablePersonal(!!b.enabled) }); }
+      if (p === "/api/personal/ai-extract" && req.method === "POST") { const b = await readBody<{ enabled?: unknown }>(req); setPersonalAiExtract(!!b.enabled); return json({ ok: true, data: personalStatus() }); }
       if (p === "/api/personal/setup" && req.method === "POST") { const b = await readBody<{ passphrase?: unknown }>(req); return json({ ok: true, data: setupPersonal(String(b.passphrase ?? "")) }); }
       if (p === "/api/personal/unlock" && req.method === "POST") { const b = await readBody<{ passphrase?: unknown }>(req); return json({ ok: true, data: unlockPersonal(String(b.passphrase ?? "")) }); }
       if (p === "/api/personal/lock" && req.method === "POST") return json({ ok: true, data: lockPersonal() });

--- a/desktop/personal.ts
+++ b/desktop/personal.ts
@@ -47,6 +47,7 @@ export function personalStatus(): PersonalStatus {
   const cuiUnlocked = !!cuiStore;
   return {
     enabled: !!s.personalizationEnabled,
+    aiExtract: !!s.personalAiExtract,
     configured: PersonalStore.exists(personalStorePath()),
     unlocked: !!store,
     scope: (s.personalScope ?? "personal") as ScopeView,
@@ -328,7 +329,11 @@ export function recallPreamble(): string {
  *  Uses the offline heuristic extractor (no per-turn model cost); the model extractor is
  *  available in the harness for an opt-in upgrade. New facts join the active compartment
  *  (Combined view defaults them to Personal). */
-export async function learnFromTurn(userText: string, assistantText: string): Promise<void> {
+export async function learnFromTurn(
+  userText: string,
+  assistantText: string,
+  complete?: (system: string, user: string) => Promise<string>,
+): Promise<void> {
   const s = load();
   if (!s.personalizationEnabled || !userText.trim()) return; // off or empty
   const view = (s.personalScope ?? "personal") as ScopeView;
@@ -337,7 +342,10 @@ export async function learnFromTurn(userText: string, assistantText: string): Pr
   const scope: PersonalScope = view === "combined" ? "personal" : view;
   const target = scope === "cui" ? cuiStore : store;
   if (!target) return; // main locked, or cui selected but its store is locked
-  try { await distillTurn(target, getScanner(), { userText, assistantText, scope, extract: heuristicExtractor }); }
+  // Opt-in (Settings): the MODEL extractor pulls richer facts + relations but costs one extra model
+  // call per turn. Off by default → the offline heuristic. Falls back to heuristic if no model fn.
+  const extract = s.personalAiExtract && complete ? modelExtractor(complete) : heuristicExtractor;
+  try { await distillTurn(target, getScanner(), { userText, assistantText, scope, extract }); }
   catch { /* best-effort; the turn already happened */ }
 }
 

--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -1152,6 +1152,8 @@ function secPersonal(p: import("./bridge.ts").PersonalStatus | null): string {
         <div class="psc"><b class="psc-cui">${p.cuiUnlocked ? c.cui : "-"}</b><span>cui${p.cuiUnlocked ? "" : " (locked)"}</span></div></div>
       ${cur === "cui" ? secCui(p) : ""}
       ${p.legacyCuiInMain > 0 ? `<div class="set-note warn">${icon("info", 12)} <span>${p.legacyCuiInMain} legacy CUI fact(s) sit in the main store from before isolation - not recalled or exported. ${p.cuiUnlocked ? `<button class="btn-mini" id="cuiMigrate" data-tip="Move into the isolated store|Relocates these cui facts (ids + timestamps preserved) into the separate CUI store, then removes them from the main store. Audited.">${icon("shield", 11)} Move into the CUI store</button>` : "Select CUI and unlock its store to move them into isolation."}</span></div>` : ""}
+      <label class="set-toggle" style="margin-top:10px;border-top:1px solid var(--line-soft);padding-top:10px"><input type="checkbox" id="personalAiToggle" ${p.aiExtract ? "checked" : ""}/>
+        <span><b>Richer graph (uses the model)</b> - extract semantic facts &amp; relationships with the model instead of offline patterns, so related ideas connect across turns. Costs one extra model call per turn. Off by default.</span></label>
       <button class="btn-mini pscope-lock" id="personalLock" data-tip="Lock everything|Wipes BOTH in-memory keys (main + CUI). You'll re-enter your passphrase to use personalization again this session - nothing is learned or recalled while locked." data-tip-side="top">${icon("shield", 12)} Lock</button>`;
   }
   return card(toggle + inner);
@@ -2361,6 +2363,12 @@ function wire(): void {
       await bridge.personalEnable(enabled);
       showToast({ title: enabled ? "Personalization on" : "Personalization off", desc: enabled ? "Set a passphrase to create your encrypted store." : "Locked and disabled - nothing is learned or recalled.", actions: [{ label: "OK" }], timeout: 2800 });
       void hydratePersonal();
+      return;
+    }
+    if (t.closest("#personalAiToggle")) {
+      const on = ($("#personalAiToggle", $("#setBody")!) as HTMLInputElement)?.checked ?? false;
+      await bridge.personalAiExtract(on);
+      showToast({ title: on ? "Richer graph on" : "Richer graph off", desc: on ? "New turns use the model to extract semantic facts + relationships (one extra call per turn)." : "Back to offline pattern extraction (no model cost).", actions: [{ label: "OK" }], timeout: 3200 });
       return;
     }
     if (t.closest("#personalSetup") || t.closest("#personalUnlock")) {

--- a/desktop/renderer/bridge.ts
+++ b/desktop/renderer/bridge.ts
@@ -90,7 +90,7 @@ export interface HeadroomStatus {
 }
 export type PersonalScopeView = "work" | "personal" | "cui" | "combined";
 export interface PersonalStatus {
-  enabled: boolean; configured: boolean; unlocked: boolean;
+  enabled: boolean; aiExtract: boolean; configured: boolean; unlocked: boolean;
   scope: PersonalScopeView; counts: { work: number; personal: number; cui: number } | null;
   // P9.5a hard CUI isolation: the CUI store is a separate file with its own passphrase.
   cuiConfigured: boolean; cuiUnlocked: boolean; legacyCuiInMain: number;
@@ -225,6 +225,7 @@ export interface LucidBridge {
   // personalization knowledge graph (opt-in, encrypted - ADR-0010/0012)
   personal(): Promise<PersonalStatus | null>;
   personalEnable(enabled: boolean): Promise<PersonalStatus | null>;
+  personalAiExtract(enabled: boolean): Promise<PersonalStatus | null>;
   personalSetup(passphrase: string): Promise<{ ok: boolean; error?: string } | null>;
   personalUnlock(passphrase: string): Promise<{ ok: boolean; error?: string } | null>;
   personalLock(): Promise<PersonalStatus | null>;
@@ -381,6 +382,7 @@ export const bridge: LucidBridge = {
   setHeadroom: (enabled) => post("/api/headroom", { enabled }),
   personal: () => getData("/api/personal"),
   personalEnable: (enabled) => post("/api/personal/enable", { enabled }),
+  personalAiExtract: (enabled) => post("/api/personal/ai-extract", { enabled }),
   personalSetup: (passphrase) => post("/api/personal/setup", { passphrase }),
   personalUnlock: (passphrase) => post("/api/personal/unlock", { passphrase }),
   personalLock: () => post("/api/personal/lock", {}),

--- a/desktop/settings_store.ts
+++ b/desktop/settings_store.ts
@@ -70,6 +70,9 @@ export interface GuiSettings {
   // Personalization knowledge graph (ADR-0010, P9.x): opt-in, encrypted-at-rest.
   // OFF by default - no user-fact distillation, recall, or store until enabled.
   personalizationEnabled?: boolean;
+  // OFF by default - opt-in richer learning: use the MODEL extractor (one extra model call per
+  // turn) instead of the offline heuristic, for semantic facts + relations. Cost vs quality.
+  personalAiExtract?: boolean;
   // Active compartment (ADR-0012): work | personal | cui | combined (view). Default personal.
   personalScope?: "work" | "personal" | "cui" | "combined";
   // P-LOC.1 (ADR-0031): the last model omp reported active, persisted so the AI-LOC gate can tag
@@ -108,6 +111,9 @@ export function personalVaultDir(): string { return join(personalBaseDir(), "luc
 export function personalCuiArchiveDir(): string { return join(personalBaseDir(), "lucid-cui-archive"); }
 export function setPersonalization(enabled: boolean): GuiSettings {
   const s = load(); s.personalizationEnabled = enabled; save(s); return s;
+}
+export function setPersonalAiExtract(enabled: boolean): GuiSettings {
+  const s = load(); s.personalAiExtract = enabled; save(s); return s;
 }
 export function setRateLimitProbe(enabled: boolean): GuiSettings {
   const s = load(); s.rateLimitProbe = enabled; save(s); return s;


### PR DESCRIPTION
Part 2 of the 'Both' approach. Adds a Settings toggle **'Richer graph (uses the model)'** (default OFF) under Personalization.

When **on**, live learning uses the **model extractor** instead of the offline heuristic, pulling semantic facts + relationships so related ideas connect across turns (custard~caramel) — at the cost of **one extra model call per turn**. Off by default → zero cost; the always-on offline cross-turn linker from #65 still runs underneath either way.

Wiring: `personalAiExtract` setting + setter; `learnFromTurn` takes an optional model-call and uses `modelExtractor` when the flag is on; `acp_backend` passes its existing `complete()` util (same one import uses); `personalStatus` exposes `aiExtract`; bridge + `/api/personal/ai-extract` route + UI toggle (shown only when the store is unlocked).

Verified: API round-trips the flag false→true→false; tsc clean; **332 desktop + personal tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)