### PR TITLE
feat(metrics): ADR-0030 P-CODE.1 — git workspace code-activity (/api/code-activity)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,10 @@ demo-P-LOC.1: ## P-LOC.1: AI-LOC attribution — count AI-authored lines per mod
 demo-ADR9A: ## ADR-0009 Phase A: recall prior-session facts into a new session (suspicious never recalled)
 	$(BUN) run harness/scripts/demo17_recall.ts
 
+.PHONY: demo-P-CODE.1
+demo-P-CODE.1: ## P-CODE.1 (ADR-0030): git workspace diffstat this month + fail-closed omit of non-git dirs
+	$(BUN) run harness/scripts/demo_pcode1.ts
+
 .PHONY: dashboards
 dashboards: ## Materialize dashboard CSVs from a DuckDB into observable/docs/data (DB=path)
 	$(BUN) run harness/scripts/materialize_dashboards.ts $(DB) observable/docs/data

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1824,3 +1824,20 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
 - **stubbed:** none — both decisions were already built/merged; these ADRs formalize them.
 - **next:** nothing pending. Use the omp compatibility probe (Actions) to adopt omp fixes; flip "Richer
   graph (uses the model)" in Settings if you want model-based learning.
+
+-----
+
+## P-CODE.1: git workspace code-activity metric (ADR-0030)
+- **shipped:** `codeActivity()` + pure `parseNumstat`/`renamedPath` in `tools/memory_data.ts` (git
+  `--numstat` for the calendar month; args-array spawn, `pathWithin` home-subtree confinement, 15s timeout,
+  vendored-churn pathspec excludes, rename + binary handling, fail-closed omit of non-git/out-of-home/failed
+  dirs); `GET /api/code-activity` in `dev.ts` (30s cache, `?force=1` bypass); `CodeActivity` bridge type +
+  accessor; ledger-card "workspace activity" row + green/red `.loc-add`/`.loc-del` CSS + a "lines" rail tile
+  (honest label — repo activity, NOT AI authorship; AGENTS.md #10). New `harness/code_activity.test.ts` (12
+  tests, parser keystone) + `demo-P-CODE.1`. Verified: 456/456 harness green; demo OK; live endpoint 403
+  w/o token, real data with (+39,271/-2,801, 302 files this month); UI rendered + screenshot, no console errors.
+- **stubbed:** per-workspace **spend** attribution (session `cwd` → ledger) deferred to P-CODE.2 (`spend:0`
+  for now); P-CODE.2 monthly workspace accordion/table and P-CODE.3 polish (no-changes/detached-HEAD edges)
+  not started. Pre-existing typecheck error `desktop/personal.ts:50` (ADR-0042 `aiExtract`) left as-is — out of scope.
+- **next:** P-CODE.2 — monthly workspace activity section (summary card + per-workspace table) + spend
+  attribution; then the add-on can re-pin its data contract and flip drift D-4 (code-activity) to ✅.

--- a/desktop/dev.ts
+++ b/desktop/dev.ts
@@ -12,7 +12,7 @@ import { join } from "node:path";
 import { devSnapshot, securitySnapshot } from "../tools/web/data.ts";
 import { approveBlock, liveBlocks } from "./security_log.ts";
 import { probeRateLimits } from "./ratelimit_probe.ts";
-import { OBS_DB_PATH, memorySnapshot, rateLimits, usageLedger } from "../tools/memory_data.ts";
+import { OBS_DB_PATH, codeActivity, memorySnapshot, rateLimits, usageLedger } from "../tools/memory_data.ts";
 import { backend } from "./acp_backend.ts";
 import { deleteSession, listSessions, sessionMessages } from "./sessions.ts";
 import { providerAuth } from "./auth_status.ts";
@@ -39,6 +39,9 @@ import type { CuiDesignation } from "../harness/export/vault_export.ts";
 
 applyEnv(); // make stored API keys available to a spawned omp acp
 if (loadSettings().headroomEnabled) startHeadroom(); // resume the opt-in compression proxy
+
+// 30s memo for /api/code-activity — each rebuild spawns `git log` per workspace (ADR-0030 P-CODE.1).
+let codeActivityCache: { at: number; data: ReturnType<typeof codeActivity> } | null = null;
 
 function ompBin(): string {
   for (const c of [join(homedir(), ".bun", "bin", "omp.exe"), join(homedir(), ".bun", "bin", "omp")]) if (existsSync(c)) return c;
@@ -213,6 +216,16 @@ const server = Bun.serve({
       }
       // P10.2: cross-model usage & cost ledger (per-model totals + estimated cache savings).
       if (p === "/api/usage") return json({ ok: true, data: usageLedger() });
+      // ADR-0030 P-CODE.1: per-workspace git diffstat for the current month (repo
+      // activity, not AI authorship). Read-only, metadata-only, fail-closed per workspace.
+      // Cached 30s — each call spawns `git log` per workspace, so don't re-run it on
+      // every dashboard poll. `?force=1` bypasses the cache (manual refresh).
+      if (p === "/api/code-activity") {
+        const now = Date.now();
+        if (!codeActivityCache || now - codeActivityCache.at > 30_000 || url.searchParams.get("force") === "1")
+          codeActivityCache = { at: now, data: codeActivity() };
+        return json({ ok: true, data: codeActivityCache.data });
+      }
       if (p === "/api/health") return json({ ok: true });
       // In-app folder browser (works in the browser build AND Electron — the dev server
       // reads the local FS in both). Lists subdirectories + flags git repos, for Workspace.

--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -26,6 +26,7 @@ const state = {
   security: null as SecuritySnapshot | null,
   memory: null as MemorySnapshot | null,
   ledger: null as import("./bridge.ts").UsageLedger | null, // P10.2 cross-model usage ledger
+  codeActivity: null as import("./bridge.ts").CodeActivity | null, // ADR-0030 P-CODE.1 git workspace diffstat
   config: [] as ConfigOption[],
   configCached: false, // P-IDE.1d: current config came from the local cache; live refresh pending
   uiMode: "agent" as "agent" | "ask" | "plan", // P-ACP.2/3: composer Plan/Ask/Agent (derived from backend)
@@ -796,6 +797,7 @@ function renderMetricsRail(): void {
   const avg = turns ? Math.round(cur / turns) : 0;
   const findings = sec ? sec.findings.reduce((a, r) => a + Number(r.n || 0), 0) : 0;
   const quar = sec ? sec.quarantine.length : 0;
+  const ca = state.codeActivity; // ADR-0030 P-CODE.1: this month's repo activity
   const tile = (n: string, label: string, cls: string, tip: string) =>
     `<div class="tile ${cls}" data-tip="${esc(label)}|${esc(tip)}" data-tip-side="left"><div class="n">${esc(n)}</div><div class="l">${esc(label)}</div></div>`;
   tiles.innerHTML =
@@ -803,6 +805,7 @@ function renderMetricsRail(): void {
     tile(fmtNum(avg), "avg/turn", "c", "Average tokens per turn") +
     tile(fmtNum(cur), "context", "b", "Context tokens in use this turn") +
     tile(String(turns), "turns", "b2", "Agent turns in this session") +
+    (ca && ca.totals.files > 0 ? tile(`+${fmtNum(ca.totals.added)}`, "lines", "g", `Workspace activity this month (${ca.month}): ${fmtNum(ca.totals.added)} lines added, ${fmtNum(ca.totals.deleted)} deleted across ${fmtNum(ca.totals.files)} files. This is REPO activity (all commits), not AI-authored lines.`) : "") +
     tile(String(findings), "findings", "m", "Scanner findings so far") +
     tile(String(quar), "quarantd", "r", "Artifacts currently quarantined");
 }
@@ -1668,6 +1671,16 @@ function ledgerBody(led: import("./bridge.ts").UsageLedger): string {
   const { peek, rest } = ledgerSplit(led);
   return peek + (rest ?? "");
 }
+// ADR-0030 P-CODE.1: one ledger-card row for this month's git workspace activity.
+// Honest label — this is REPO activity (all commits), NOT AI authorship (AGENTS.md #10).
+function codeActivityRow(): string {
+  const ca = state.codeActivity;
+  if (!ca || ca.totals.files === 0) return ""; // fail-closed: no live git data → render nothing
+  const { added, deleted, files } = ca.totals;
+  return `<div class="lc-row"><span class="lc-k">workspace activity · ${esc(ca.month)}</span>`
+    + `<b class="lc-loc"><span class="loc-add">+${fmtNum(added)}</span> / <span class="loc-del">-${fmtNum(deleted)}</span>`
+    + ` <span class="lc-pct">${fmtNum(files)} file${files === 1 ? "" : "s"}</span></b></div>`;
+}
 // ADR-0021: split the ledger into a "peek" (always visible: snapshot card + first model row)
 // and "rest" (the remaining model rows, rendered inside an accordion by the caller).
 function ledgerSplit(led: import("./bridge.ts").UsageLedger): { peek: string; rest: string | null } {
@@ -1678,6 +1691,7 @@ function ledgerSplit(led: import("./bridge.ts").UsageLedger): { peek: string; re
     <div class="lc-row"><span class="lc-k">spend · all models</span><b>${fmtUSD(t.cost)}</b></div>
     <div class="lc-row ok"><span class="lc-k">est. cache savings</span><b>${fmtUSD(t.savings)} <span class="lc-pct">${Math.round(savedPct * 100)}% off full price</span></b></div>
     <div class="lc-row"><span class="lc-k">cache hit-rate</span><b style="color:${goodColor(t.cacheHitRate)}">${Math.round(t.cacheHitRate * 100)}%</b></div>
+    ${codeActivityRow()}
     <div class="lc-foot">${fmtNum(t.tokens)} tokens · ${t.turns} turns · ${led.models.length} models · ${t.sessions} sessions${local.cost > 0 ? ` · <span class="lc-local">local ${fmtUSD(local.cost)}</span>` : " · all provider/subscription"}</div>
     ${led.truncated ? `<div class="lc-foot warn">${icon("info", 11)} showing the ${led.files} most recent sessions</div>` : ""}
   </div>`;
@@ -1778,8 +1792,8 @@ function renderStatus(): void {
 // ───────────────────────── data polling ─────────────────────────
 async function refresh(): Promise<void> {
   try {
-    const [sec, mem, led] = await Promise.all([bridge.security(), bridge.memory(), bridge.usage()]);
-    state.security = sec; state.memory = mem; state.ledger = led;
+    const [sec, mem, led, code] = await Promise.all([bridge.security(), bridge.memory(), bridge.usage(), bridge.codeActivity()]);
+    state.security = sec; state.memory = mem; state.ledger = led; state.codeActivity = code;
     checkBudgetWarning(mem?.budgets); // early heads-up before a provider budget runs out
     // the badge reflects the live session CONFIG model (loadConfig), not the
     // historical snapshot - so it shows what the next turn will actually use.

--- a/desktop/renderer/bridge.ts
+++ b/desktop/renderer/bridge.ts
@@ -71,6 +71,12 @@ export interface UsageLedger {
   bySource: { subscription: { cost: number; tokens: number }; local: { cost: number; tokens: number } };
   files: number; truncated: boolean; generatedAt: string;
 }
+// ADR-0030 P-CODE.1: git workspace diffstat this month (repo activity, not AI authorship).
+export interface CodeActivity {
+  workspaces: { name: string; path: string; added: number; deleted: number; files: number; spend: number }[];
+  totals: { added: number; deleted: number; files: number };
+  month: string; daysInMonth: number;
+}
 export interface ConfigOption {
   id: string; name: string; category: string; type: string;
   currentValue: string; options: { value: string; name: string }[];
@@ -170,6 +176,7 @@ export interface LucidBridge {
   mcpRemove(id: string): Promise<unknown>;
   mcpToggle(id: string, enabled: boolean): Promise<unknown>;
   usage(): Promise<UsageLedger | null>;
+  codeActivity(): Promise<CodeActivity | null>;
   sendPrompt(text: string, onEvent: (e: ChatEvent) => void): Promise<void>;
   config(): Promise<ConfigOption[]>;
   /** Respawn omp + re-read its model list (after connecting a provider via OAuth or key). */
@@ -336,6 +343,7 @@ export const bridge: LucidBridge = {
   mcpRemove: (id) => post("/api/mcp/remove", { id }),
   mcpToggle: (id, enabled) => post("/api/mcp/toggle", { id, enabled }),
   usage: () => getData("/api/usage"),
+  codeActivity: () => getData("/api/code-activity"),
   sendPrompt: streamChat,
   config: async () => (await getData("/api/config")) ?? FALLBACK_CONFIG,
   refreshConfig: async () => (await post("/api/config/refresh", {})) ?? FALLBACK_CONFIG,

--- a/desktop/renderer/styles.css
+++ b/desktop/renderer/styles.css
@@ -306,6 +306,10 @@ body.resizing .sidebar,body.resizing .inspector{transition:none}
 .lc-foot{margin-top:8px;padding-top:8px;border-top:1px solid var(--line-soft);font-size:10.5px;color:var(--txt-3);display:flex;align-items:center;gap:5px;flex-wrap:wrap}
 .lc-foot.warn{color:var(--amber);border-top:0;padding-top:2px;margin-top:3px}
 .lc-local{color:var(--cyan)}
+/* ADR-0030 P-CODE.1: git diffstat line counts in the ledger card (+added / -deleted) */
+.lc-loc{font-weight:700;font-variant-numeric:tabular-nums}
+.loc-add{color:var(--green)}
+.loc-del{color:var(--red)}
 /* reading column: a comfortable measure keeps long prose calm and scannable */
 .msg .text p,.msg .text ul,.msg .text ol,.msg .text blockquote{max-width:72ch}
 .msg .text p{margin:0 0 12px}

--- a/harness/code_activity.test.ts
+++ b/harness/code_activity.test.ts
@@ -1,0 +1,136 @@
+// harness/code_activity.test.ts — ADR-0030 P-CODE.1: git workspace diffstat.
+//
+// The numstat PARSER is the keystone (over-tested): renames, binary files, dedup,
+// blank separators, CRLF. The codeActivity() integration is exercised against a real
+// throwaway git repo created UNDER homedir() — because codeActivity confines every
+// workspace to the home subtree (pathWithin, ADR-0022/0023), and on Linux CI the
+// system tmpdir (/tmp) is OUTSIDE home and would be (correctly) omitted.
+
+import { afterAll, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join, parse } from "node:path";
+import { homedir } from "node:os";
+import { codeActivity, parseNumstat, renamedPath } from "../tools/memory_data.ts";
+
+const cleanup: string[] = [];
+afterAll(() => { for (const d of cleanup) try { rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ } });
+
+const git = (cwd: string, ...args: string[]) =>
+  Bun.spawnSync(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe", env: { ...process.env, GIT_CONFIG_NOSYSTEM: "1" } });
+const gitAvailable = Bun.spawnSync(["git", "--version"], { stdout: "pipe", stderr: "pipe" }).success;
+
+/** A throwaway git repo UNDER home (so pathWithin admits it on every platform). */
+function tmpRepoUnderHome(): string {
+  const dir = mkdtempSync(join(homedir(), ".lucid-codeact-test-"));
+  cleanup.push(dir);
+  git(dir, "init", "-q", "-b", "main");
+  git(dir, "config", "user.email", "t@t.test");
+  git(dir, "config", "user.name", "Test");
+  git(dir, "config", "commit.gpgsign", "false");
+  return dir;
+}
+
+// ── pure parser (keystone) ────────────────────────────────────────────────────
+
+test("parseNumstat: sums adds/deletes and collects the file set", () => {
+  const out = "12\t3\tsrc/a.ts\n\n4\t0\tsrc/b.ts\n";
+  const r = parseNumstat(out);
+  expect(r.added).toBe(16);
+  expect(r.deleted).toBe(3);
+  expect(r.files).toEqual(["src/a.ts", "src/b.ts"]);
+});
+
+test("parseNumstat: binary files (- -) count as touched but add no lines", () => {
+  const r = parseNumstat("-\t-\tlogo.png\n5\t2\tsrc/a.ts\n");
+  expect(r.added).toBe(5);
+  expect(r.deleted).toBe(2);
+  expect(r.files).toContain("logo.png");
+  expect(r.files.length).toBe(2);
+});
+
+test("parseNumstat: dedups a file touched across multiple commits", () => {
+  const r = parseNumstat("10\t0\tsrc/a.ts\n\n5\t3\tsrc/a.ts\n");
+  expect(r.added).toBe(15);
+  expect(r.deleted).toBe(3);
+  expect(r.files).toEqual(["src/a.ts"]); // one distinct file
+});
+
+test("parseNumstat: rename rows normalize to the final path (no double count)", () => {
+  const r = parseNumstat("1\t1\tsrc/old.ts => src/new.ts\n2\t0\tsrc/{a => b}/x.ts\n");
+  expect(r.files).toEqual(["src/b/x.ts", "src/new.ts"]);
+});
+
+test("parseNumstat: ignores blank lines and stray non-numstat rows", () => {
+  const r = parseNumstat("\n\nnot a row\n3\t1\tf.ts\r\n");
+  expect(r.added).toBe(3);
+  expect(r.deleted).toBe(1);
+  expect(r.files).toEqual(["f.ts"]); // CRLF stripped
+});
+
+test("renamedPath: handles plain, brace, and non-rename forms", () => {
+  expect(renamedPath("a.ts => b.ts")).toBe("b.ts");
+  expect(renamedPath("src/{old => new}/x.ts")).toBe("src/new/x.ts");
+  expect(renamedPath("dir/{ => sub}/x.ts")).toBe("dir/sub/x.ts");
+  expect(renamedPath("plain/path.ts")).toBe("plain/path.ts");
+});
+
+// ── codeActivity() shape + fail-closed ────────────────────────────────────────
+
+test("codeActivity: always returns the pinned shape (month, daysInMonth, totals)", () => {
+  const ca = codeActivity({ workspaces: [], now: new Date(2026, 5, 15) }); // June 2026
+  expect(ca.month).toBe("June 2026");
+  expect(ca.daysInMonth).toBe(30);
+  expect(ca.workspaces).toEqual([]);
+  expect(ca.totals).toEqual({ added: 0, deleted: 0, files: 0 });
+});
+
+test("codeActivity: a non-git dir is omitted (fail-closed, never faked)", () => {
+  const dir = mkdtempSync(join(homedir(), ".lucid-nogit-test-"));
+  cleanup.push(dir);
+  const ca = codeActivity({ workspaces: [dir] });
+  expect(ca.workspaces).toEqual([]);
+});
+
+test("codeActivity: a path outside the home subtree is omitted (pathWithin)", () => {
+  const outside = join(parse(homedir()).root, "definitely-not-under-home-xyz");
+  const ca = codeActivity({ workspaces: [outside] });
+  expect(ca.workspaces).toEqual([]);
+});
+
+test.skipIf(!gitAvailable)("codeActivity: real repo → workspace listed with diffstat for this month", () => {
+  const repo = tmpRepoUnderHome();
+  writeFileSync(join(repo, "a.ts"), "one\ntwo\nthree\n", "utf8");
+  mkdirSync(join(repo, "node_modules"), { recursive: true });
+  writeFileSync(join(repo, "node_modules", "dep.js"), "junk\nchurn\n", "utf8"); // must be EXCLUDED
+  git(repo, "add", "-A");
+  git(repo, "commit", "-q", "-m", "seed");
+
+  const ca = codeActivity({ workspaces: [repo] });
+  expect(ca.workspaces.length).toBe(1);
+  const ws = ca.workspaces[0]!;
+  expect(ws.added).toBe(3);              // a.ts only — node_modules churn excluded
+  expect(ws.deleted).toBe(0);
+  expect(ws.files).toBe(1);
+  expect(ws.spend).toBe(0);             // spend attribution is P-CODE.2
+  expect(ws.name).toBe(repo.split(/[\\/]/).pop() ?? "");
+  expect(ca.totals).toEqual({ added: 3, deleted: 0, files: 1 });
+});
+
+test.skipIf(!gitAvailable)("codeActivity: commits before this month are excluded by the window", () => {
+  const repo = tmpRepoUnderHome();
+  writeFileSync(join(repo, "old.ts"), "x\n", "utf8");
+  git(repo, "add", "-A");
+  // Backdate the commit well before the current month.
+  const past = "2020-01-15T12:00:00";
+  git(repo, "-c", `user.name=Test`, "commit", "-q", "-m", "old", "--date", past);
+  Bun.spawnSync(["git", "commit", "--amend", "--no-edit", "--date", past], { cwd: repo, env: { ...process.env, GIT_COMMITTER_DATE: past } });
+
+  const ca = codeActivity({ workspaces: [repo] });
+  expect(ca.workspaces).toEqual([]); // nothing landed THIS month
+});
+
+test.skipIf(!gitAvailable)("codeActivity: confirms our own .git layout is detected", () => {
+  // sanity: the helper actually produced a git repo
+  const repo = tmpRepoUnderHome();
+  expect(existsSync(join(repo, ".git"))).toBe(true);
+});

--- a/harness/scripts/demo_pcode1.ts
+++ b/harness/scripts/demo_pcode1.ts
@@ -1,0 +1,62 @@
+// harness/scripts/demo_pcode1.ts
+//
+// ADR-0030 P-CODE.1: git-based code-activity metric. Build a throwaway git repo,
+// land a commit this month (plus excluded dependency churn), and prove
+// codeActivity() reports the repo's diffstat — and FAIL-CLOSED-omits a non-git dir.
+//
+// Honest framing: this is REPO/WORKSPACE activity (every commit), NOT AI authorship
+// (that's the separate aiLoc metric, ADR-0031). Run with: bun run harness/scripts/demo_pcode1.ts
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { codeActivity } from "../../tools/memory_data.ts";
+
+const fail = (m: string): never => { console.error(`FAIL: ${m}`); process.exit(1); };
+
+if (!Bun.spawnSync(["git", "--version"], { stdout: "pipe", stderr: "pipe" }).success) fail("git is required for this demo");
+
+const git = (cwd: string, ...args: string[]) =>
+  Bun.spawnSync(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe", env: { ...process.env, GIT_CONFIG_NOSYSTEM: "1" } });
+
+// Created UNDER home so the home-subtree confinement (pathWithin, ADR-0022) admits it
+// on every platform (the system tmpdir is outside home on Linux CI).
+const repo = mkdtempSync(join(homedir(), ".lucid-demo-pcode1-"));
+const nogit = mkdtempSync(join(homedir(), ".lucid-demo-pcode1-nogit-"));
+
+try {
+  console.log("== [1/3] seed a git repo with a real change this month ==");
+  git(repo, "init", "-q", "-b", "main");
+  git(repo, "config", "user.email", "demo@demo.test");
+  git(repo, "config", "user.name", "Demo");
+  git(repo, "config", "commit.gpgsign", "false");
+  writeFileSync(join(repo, "feature.ts"), "export const a = 1;\nexport const b = 2;\nexport const c = 3;\n", "utf8");
+  writeFileSync(join(repo, "README.md"), "# demo\nline two\n", "utf8");
+  mkdirSync(join(repo, "node_modules"), { recursive: true });
+  writeFileSync(join(repo, "node_modules", "dep.js"), "lots\nof\nvendor\nchurn\n", "utf8"); // EXCLUDED from the metric
+  git(repo, "add", "-A");
+  git(repo, "commit", "-q", "-m", "seed");
+
+  console.log("== [2/3] codeActivity() reports the diffstat (vendored churn excluded) ==");
+  const ca = codeActivity({ workspaces: [repo, nogit] }); // nogit has no .git → must be omitted
+  console.log(`   month        : ${ca.month} (${ca.daysInMonth} days)`);
+  console.log(`   workspaces   : ${ca.workspaces.length}`);
+  for (const w of ca.workspaces) console.log(`     ${w.name}: +${w.added} / -${w.deleted} · ${w.files} files · spend $${w.spend}`);
+  console.log(`   totals       : +${ca.totals.added} / -${ca.totals.deleted} · ${ca.totals.files} files`);
+
+  if (ca.workspaces.length !== 1) fail(`expected exactly 1 workspace (the git repo), got ${ca.workspaces.length}`);
+  const ws = ca.workspaces[0]!;
+  if (ws.added !== 5) fail(`expected 5 lines added (3 + 2; node_modules excluded), got ${ws.added}`);
+  if (ws.files !== 2) fail(`expected 2 files (feature.ts + README.md), got ${ws.files}`);
+  if (ws.spend !== 0) fail(`expected spend 0 (attribution is P-CODE.2), got ${ws.spend}`);
+
+  console.log("== [3/3] FAIL-CLOSED: the non-git directory was omitted, never faked ==");
+  if (ca.workspaces.some((w) => w.path === nogit)) fail("non-git dir leaked into results");
+  console.log(`   omitted non-git dir: ${nogit.split(/[\\/]/).pop()}`);
+
+  console.log("\ndemo_pcode1 OK");
+} finally {
+  rmSync(repo, { recursive: true, force: true });
+  rmSync(nogit, { recursive: true, force: true });
+}
+process.exit(0);

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "demo-P8.1": "bun run harness/scripts/demo17_recall.ts",
     "demo-P8.2": "bun run harness/scripts/demo18_turns.ts",
     "demo-P-EXT.1": "bun run harness/scripts/demo19_lucid_launcher.ts",
+    "demo-P-CODE.1": "bun run harness/scripts/demo_pcode1.ts",
     "dashboards": "bun run harness/scripts/materialize_dashboards.ts",
     "omp:secure": "omp -e harness/omp/security_extension.ts",
     "dashboard:tui": "bun run tools/dashboard_tui.ts",

--- a/tools/memory_data.ts
+++ b/tools/memory_data.ts
@@ -11,10 +11,11 @@
 //   - Lucid memory layers + promotion gate   : agent_obs.duckdb (DuckDB READ_ONLY)
 
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { Database as Sqlite } from "bun:sqlite";
 import { DuckDBInstance } from "@duckdb/node-api";
+import { pathWithin } from "../desktop/path_guard.ts";
 
 // ── model context windows (tokens) ────────────────────────────────────────────
 // Keyed by the SHORT model id (provider prefix stripped). Keep in sync with
@@ -237,6 +238,126 @@ export function usageLedger(opts: { root?: string; maxFiles?: number } = {}): Us
   }
   totals.cacheHitRate = dDenom > 0 ? dRead / dDenom : 0;
   return { models, totals, bySource, files: scan.length, truncated, generatedAt };
+}
+
+// ── code activity (git workspace diffstat, ADR-0030 P-CODE.1) ──────────────────
+// Per-workspace lines added/deleted + files touched this calendar month, from
+// `git log --numstat`. Honest framing: this is REPO/WORKSPACE activity (every
+// commit — yours, others', merges), NOT AI authorship. The AI-authored metric is
+// a different source (ADR-0031, see aiLoc). Spend attribution per workspace is
+// deferred to P-CODE.2; spend is reported as 0 here.
+export interface CodeActivity {
+  workspaces: { name: string; path: string; added: number; deleted: number; files: number; spend: number }[];
+  totals: { added: number; deleted: number; files: number };
+  month: string; // e.g. "June 2026"
+  daysInMonth: number;
+}
+
+/** Resolve a `git log --numstat` rename path to its final path. Handles the two
+ *  git rename notations: `old => new` and `dir/{old => new}/file`. */
+export function renamedPath(p: string): string {
+  const brace = p.match(/^(.*)\{(.*?) => (.*?)\}(.*)$/);
+  if (brace) return ((brace[1] ?? "") + (brace[3] ?? "") + (brace[4] ?? "")).replace(/\/{2,}/g, "/");
+  const i = p.indexOf(" => ");
+  return i >= 0 ? p.slice(i + 4) : p;
+}
+
+/** PURE parser for `git log --numstat` output (keystone — over-tested). Sums
+ *  added/deleted lines and collects the set of files touched. Binary files show
+ *  as `-\t-\tpath`: the file counts as touched but contributes no line counts.
+ *  Rename rows are normalized to the final path so a rename isn't double-counted. */
+export function parseNumstat(output: string): { added: number; deleted: number; files: string[] } {
+  let added = 0, deleted = 0;
+  const files = new Set<string>();
+  for (const raw of output.split("\n")) {
+    const line = raw.replace(/\r$/, "");
+    if (!line.trim()) continue; // blank lines between commits (from --format=)
+    const tab = line.split("\t");
+    if (tab.length < 3) continue; // not a numstat row (e.g. a stray commit header)
+    const [a = "", d = "", ...rest] = tab;
+    const file = renamedPath(rest.join("\t").trim());
+    if (!file) continue;
+    files.add(file);
+    if (a !== "-") added += Number.parseInt(a, 10) || 0;   // "-" == binary → no line count
+    if (d !== "-") deleted += Number.parseInt(d, 10) || 0;
+  }
+  return { added, deleted, files: [...files].sort() };
+}
+
+/** Light read of an omp session file's working dir (the `session` line is first). */
+function readSessionCwd(path: string): string | undefined {
+  try {
+    for (const line of readFileSync(path, "utf8").split("\n")) {
+      if (!line) continue;
+      if (line.includes('"type":"session"')) {
+        try { const o = JSON.parse(line); if (o.cwd) return String(o.cwd); } catch { /* keep scanning */ }
+      }
+    }
+  } catch { /* unreadable */ }
+  return undefined;
+}
+
+/** Distinct git-repo working dirs seen across recent omp sessions (newest first). */
+function discoverWorkspaces(root?: string, cap = 500): string[] {
+  const base = root ?? join(homedir(), ".omp", "agent", "sessions");
+  if (!existsSync(base)) return [];
+  const files: { p: string; mtime: number }[] = [];
+  for (const d of readdirSync(base)) {
+    const dir = join(base, d);
+    try { if (!statSync(dir).isDirectory()) continue; for (const f of readdirSync(dir)) if (f.endsWith(".jsonl")) files.push({ p: join(dir, f), mtime: statSync(join(dir, f)).mtimeMs }); }
+    catch { /* skip */ }
+  }
+  files.sort((a, b) => b.mtime - a.mtime);
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const { p } of files.slice(0, cap)) {
+    const cwd = readSessionCwd(p);
+    if (!cwd || seen.has(cwd)) continue;
+    seen.add(cwd);
+    if (existsSync(join(cwd, ".git"))) out.push(cwd);
+  }
+  return out;
+}
+
+/** Per-workspace git diffstat for the current calendar month.
+ *  Workspaces: `opts.workspaces` if given, else discovered from omp session cwds.
+ *  Fail-closed: a workspace outside the home subtree, a non-git dir, or a failed
+ *  `git` invocation is OMITTED — never faked (CLAUDE.md invariant #3). */
+export function codeActivity(opts: { workspaces?: string[]; root?: string; now?: Date; timeoutMs?: number } = {}): CodeActivity {
+  const now = opts.now ?? new Date();
+  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+  const month = monthStart.toLocaleString("en-US", { month: "long", year: "numeric" });
+  const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
+  const timeout = opts.timeoutMs ?? 15_000; // generous — a large repo's `git log --numstat`
+  // can take several seconds; the result is cached 30s, so we'd rather wait than fail-close to
+  // an empty dashboard. A truly hung git still trips the timeout and the workspace is omitted.
+  const candidates = opts.workspaces ?? discoverWorkspaces(opts.root);
+
+  const workspaces: CodeActivity["workspaces"] = [];
+  for (const ws of candidates) {
+    const safe = pathWithin(homedir(), ws);            // confine to the home subtree (ADR-0022/0023)
+    if (!safe) continue;                                // outside home → omit (fail-closed)
+    if (!existsSync(join(safe, ".git"))) continue;      // not a git repo → omit
+    // Args ARRAY, never a shell string (no injection via paths/refs). Exclude vendored/
+    // generated churn so the metric reflects real source. `--format=` suppresses commit
+    // headers, leaving only numstat rows + blank separators.
+    const r = Bun.spawnSync(
+      ["git", "log", `--since=${monthStart.toISOString()}`, "--numstat", "--no-color", "--format=",
+        "--", ".", ":(exclude)node_modules", ":(exclude)vendor", ":(exclude)dist", ":(exclude)*.lock", ":(exclude)*.min.*"],
+      { cwd: safe, timeout, stdout: "pipe", stderr: "pipe" },
+    );
+    if (!r.success) continue;                           // git missing/failed/timeout → omit (never fake)
+    const { added, deleted, files } = parseNumstat(r.stdout.toString());
+    if (files.length === 0) continue;                   // no activity this month → not listed
+    workspaces.push({ name: basename(safe), path: safe, added, deleted, files: files.length, spend: 0 });
+  }
+
+  workspaces.sort((a, b) => b.added + b.deleted - (a.added + a.deleted));
+  const totals = workspaces.reduce(
+    (t, w) => ({ added: t.added + w.added, deleted: t.deleted + w.deleted, files: t.files + w.files }),
+    { added: 0, deleted: 0, files: 0 },
+  );
+  return { workspaces, totals, month, daysInMonth };
 }
 
 // ── omp compaction policy ─────────────────────────────────────────────────────


### PR DESCRIPTION
Implements **ADR-0030 P-CODE.1**, making the code-activity contract surface real (it was design-only until now). Honest framing throughout: this is **repo/workspace activity** (every commit), **not** AI authorship — that's the separate `aiLoc` metric (ADR-0031).

## What's included
- **`tools/memory_data.ts`** — `codeActivity()` + pure `parseNumstat()`/`renamedPath()`. `git log --numstat` for the calendar month via an **args array** (no shell), each workspace confined with `pathWithin` to the home subtree (ADR-0022/0023), 15s timeout, vendored-churn pathspec excludes, rename + binary handling. **Fail-closed**: a non-git / out-of-home / failed-git workspace is omitted, never faked (invariant #3). Per-workspace **spend** is deferred to P-CODE.2 (`spend: 0`).
- **`desktop/dev.ts`** — `GET /api/code-activity` (30s memo; `?force=1` bypass).
- **`desktop/renderer`** — `CodeActivity` bridge type + accessor; a "workspace activity" ledger-card row (+added / −deleted / files) with green/red CSS; a "lines" rail tile. Labels say "workspace activity", not "AI-authored" (AGENTS.md #10).
- **Tests/demo** — `harness/code_activity.test.ts` (12 tests; numstat parser keystone: renames, binary, dedup, blank lines, CRLF; fail-closed omits; pinned shape) + `demo-P-CODE.1`.

## Verification
- **456/456** harness tests green (444 baseline + 12 new); `demo-P-CODE.1` passes.
- **No new typecheck errors.** (The pre-existing `desktop/personal.ts:50` failure from ADR-0042 is unrelated and left as-is.)
- **Live endpoint**: `403` without token (fail-closed); real data with it — `LucidAgentIDE`: **+39,271 / −2,801, 302 files** this month.
- **UI rendered live** (ledger row + green "+39.3k LINES" rail tile), no console errors. Prompt prefix untouched (read-only metrics).

## Scope
Per the one-increment rule, stops at P-CODE.1. P-CODE.2 (monthly workspace table + spend attribution) and P-CODE.3 (polish: no-changes / detached-HEAD edges) are follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)