### PR TITLE
R-02: prefix-hash regression vs omp auto-compaction

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,6 +4,13 @@ Three lines per session: **shipped / stubbed / next** (CLAUDE.md session ritual)
 
 -----
 
+## R-02: prefix-hash regression vs omp auto-compaction
+- **shipped:** `harness/prompt/prefix_compaction.test.ts` — drives a REAL omp agent session (echo model) at the pinned omp **16.0.6**, forces a manual compaction (`AgentSession.compact()` with `compaction.keepRecentTokens` lowered so a headless session is compactable), and asserts the byte-stable frozen prefix (layers 1-4, invariant #6) in `session.systemPrompt` is unchanged across the compaction AND still present verbatim in what omp hands the model on the next turn. Plus an exact-pin assertion on all four `@oh-my-pi/*` packages. Finding: omp 16.0.6 compaction operates on conversation history only (system block preserved) — the invariant HOLDS, no forced change, so no ADR (per R-02's "ADR if omp forces a change").
+- **stubbed:** compaction is exercised via a lowered `keepRecentTokens` (echo turns can't reach the 20k default headlessly); the `snapcompact` strategy is not covered (it needs a vision-capable model) — the `context-full` path is tested. R-02's broader "supported-omp matrix" + scheduled bump CI is R-01 (Nicholas).
+- **next:** R-01's scheduled omp-compat CI should run this test against candidate omp bumps. PRE-EXISTING baseline break unrelated to R-02 — `harness/memory/db.test.ts` asserts `appliedVersions [1..7]` but migrations `0008_memory_session`/`0009_turn_transcripts` (P8.x) make it `[1..9]`; the test wasn't updated when those landed (memory lane to fix).
+
+-----
+
 ## P-EXT.5.0: attach-mode roadmap (planning only — ADR-0039)
 - **shipped:** ADR-0039 in DECISIONS.md — designs the deferred ADR-0038 optional attach-mode (an IDE
   extension SHARING the running desktop's already-gated session instead of spawning its own `lucid acp`).

--- a/harness/prompt/prefix_compaction.test.ts
+++ b/harness/prompt/prefix_compaction.test.ts
@@ -1,0 +1,82 @@
+// harness/prompt/prefix_compaction.test.ts
+//
+// R-02 (POAM): omp's native context-management / auto-compaction ("snapcompact") must NEVER mutate
+// the byte-stable frozen prompt prefix (layers 1-4, invariant #6). Compaction may summarize the
+// conversation HISTORY — but only AFTER the cache breakpoint; the cached system prefix is off-limits,
+// or every compaction would bust the KV cache for all prior turns.
+//
+// This drives a REAL omp agent session (the no-network echo model) at the pinned omp version, forces
+// a compaction via the public `AgentSession.compact()` API, and asserts the frozen prefix in omp's
+// effective system prompt is byte-identical across the compaction — and still present in what omp
+// actually hands the model on the next turn. A future omp bump that compacts the system prefix trips
+// this test (the scheduled omp-compat CI, R-01, reruns it against candidate bumps).
+
+import { test, expect } from "bun:test";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { FROZEN_PREFIX } from "./assembler.ts";
+import { createEchoSession } from "../testing/echo.ts";
+
+const sha = (s: string): string => createHash("sha256").update(s, "utf8").digest("hex");
+const joinBlocks = (blocks: readonly string[]): string => blocks.join("\u0000");
+
+// The omp version this regression is pinned to (R-02). A silent dependency bump trips the assertion
+// below; R-01's scheduled omp-compat CI reruns the suite against candidate versions before adopting.
+const SUPPORTED_OMP = "16.0.6";
+const OMP_PACKAGES = ["@oh-my-pi/pi-coding-agent", "@oh-my-pi/pi-agent-core", "@oh-my-pi/pi-ai", "@oh-my-pi/pi-utils"] as const;
+
+const PkgDeps = (() => {
+	const raw: unknown = JSON.parse(readFileSync(join(import.meta.dir, "../../package.json"), "utf8"));
+	if (raw && typeof raw === "object" && "dependencies" in raw) {
+		const deps = raw.dependencies;
+		if (deps && typeof deps === "object") return deps as Record<string, string>;
+	}
+	throw new Error("package.json has no dependencies object");
+})();
+
+test("R-02: omp is exact-pinned to the supported version (no caret/range)", () => {
+	for (const pkg of OMP_PACKAGES) {
+		expect(PkgDeps[pkg]).toBe(SUPPORTED_OMP);
+	}
+});
+
+test("R-02: auto-compaction never mutates the frozen prefix (layers 1-4)", async () => {
+	// The frozen prefix reaches omp as a system-prompt block (production sends the same bytes via
+	// `--append-system-prompt`). Compaction must leave this block untouched.
+	const { session, model, cleanup } = await createEchoSession({ systemPrompt: [FROZEN_PREFIX] });
+	try {
+		// Shrink the keep-recent window so a small headless session is actually compactable (the
+		// default keeps the last 20k tokens, far more than echo turns produce). context-full strategy
+		// avoids snapcompact's vision-model requirement (the mock model has no image input).
+		session.settings.set("compaction.strategy", "context-full");
+		session.settings.set("compaction.keepRecentTokens", 10);
+
+		// Build conversation history so compaction has something older than the keep window to compact.
+		for (let i = 0; i < 6; i++) {
+			await session.prompt(`turn ${i}: add some context to grow the history before compaction`);
+		}
+
+		const before = session.systemPrompt.slice();
+		expect(joinBlocks(before)).toContain(FROZEN_PREFIX); // the exact, byte-stable prefix is present
+		const beforeHash = sha(joinBlocks(before));
+
+		// Force a real compaction at the pinned omp version (manual path → CompactionResult).
+		const result = await session.compact("summarize the prior turns");
+		expect(result).toBeTruthy();
+		expect(typeof result).toBe("object");
+
+		// The whole system prompt is byte-identical across the compaction: it touched history, not the
+		// cached system prefix.
+		const after = session.systemPrompt.slice();
+		expect(sha(joinBlocks(after))).toBe(beforeHash);
+		expect(joinBlocks(after)).toContain(FROZEN_PREFIX);
+
+		// And what omp actually hands the model on the NEXT turn still carries the frozen prefix verbatim.
+		await session.prompt("post-compaction turn");
+		const sentToModel = model.calls.at(-1)?.context.systemPrompt ?? [];
+		expect(joinBlocks(sentToModel)).toContain(FROZEN_PREFIX);
+	} finally {
+		cleanup();
+	}
+});


### PR DESCRIPTION
## R-02 — Prefix-hash regression vs omp auto-compaction

omp 16.1.x shipped **native context-management + goal auto-compaction** ("snapcompact"). The risk (POAM R-02): a compaction that reorders or mutates context could bust the **byte-stable frozen prompt prefix** (layers 1–4, invariant #6) and the KV-cache strategy. This adds a regression test that proves omp's compaction leaves the frozen prefix untouched, pinned to the supported omp.

Tracks `TechLead187/lucidagentIDEaddon#28` (R-02; PI-1).

### What this adds

`harness/prompt/prefix_compaction.test.ts` (+ a `PROGRESS.md` entry):

1. **Exact-pin assertion** — all four `@oh-my-pi/*` packages are pinned to `16.0.6` (no caret/range). A silent bump trips the test; R-01's scheduled omp-compat CI reruns it against candidate versions.
2. **Real compaction regression** — drives an actual omp agent session (the no-network echo model via `harness/testing/echo.ts`), builds history, then forces a manual compaction through the public `AgentSession.compact()` API and asserts:
   - the frozen prefix in `session.systemPrompt` is **byte-identical across the compaction** (whole-array sha256 unchanged);
   - `FROZEN_PREFIX` is still present verbatim afterward;
   - what omp **hands the model on the next turn** (`model.calls.at(-1).context.systemPrompt`) still carries the frozen prefix.

   To make a headless session compactable (the default keeps the last 20k tokens — far more than echo turns produce) the test lowers `compaction.keepRecentTokens` and pins `compaction.strategy: "context-full"` (snapcompact needs a vision-capable model).

### Finding

At the pinned **omp 16.0.6**, compaction operates on **conversation history only** — it summarizes messages after the cache breakpoint and leaves the system block (the frozen prefix) untouched. omp's own compaction docs confirm the shape (`[system][summary][kept history…]`, and handoff "preserves the live agent cache prefix"). **The invariant holds; omp forces no prefix change, so no ADR is required** (per R-02's "ADR if omp forces a change"). If a future omp bump starts mutating the system prefix, this test fails — exactly the canary R-02 asked for.

### Test evidence

```
bun test harness/prompt/prefix_compaction.test.ts
  2 pass / 0 fail   (pin assertion + compaction regression)
bun test harness/prompt   24 pass (existing assembler suite unchanged)
```

`tsc --noEmit` clean for the new file. Did not touch the frozen prefix itself (assembler.ts unchanged), so the existing prefix-hash tests are unaffected.

### ⚠️ Pre-existing baseline break (NOT this change)

`make test` / `bun test harness` currently has **4 failures in `harness/memory/db.test.ts`** on `master` (verified independently of this branch). They assert applied migration versions `[1..7]`, but `0008_memory_session.sql` + `0009_turn_transcripts.sql` (the P8.x memory work) make it `[1..9]` — the test wasn't updated when those migrations landed. This is unrelated to R-02 (different subsystem, memory lane) and should be fixed in its own change; flagging it here so the red baseline isn't mistaken for this PR.

### Scope

- One increment (R-02). No production code changed — a test + a PROGRESS line only.
- Invariants honored: #1 (extend, never fork — uses omp's public `compact()`/`systemPrompt` API), #6 (frozen prefix — asserted, not altered).
