### PR TITLE
R-04: thinking-item governance (reasoning is display-only, never durable)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -4537,3 +4537,43 @@ chunks are retrieval context, never semantic memory).
 ADR-0007 (AskSage adapter + `/query` RAG this extends); ADR-0012 (compartments/classification); ADR-0019
 (gate/quarantine + Security-panel surfacing); ADR-0050 / P-GOAL.8 (the guided-walkthrough UI pattern
 reused); CLAUDE.md invariants #2/#3/#5/#10 + keystone #2.
+
+-----
+
+## ADR-0054 — Thinking-item governance: reasoning is display-only, never durable (R-04)
+
+**Date:** 2026-06-24
+**Status:** Accepted — built this increment.
+**Relationship:** ratifies ADR-0027 (the thinking stream is display-only) as a security policy; extends
+keystone #2 (semantic-promotion gate) and invariants #3 (fail-closed) / #5 (untrusted content) to omp's
+now-first-class reasoning/thinking items. Tracks add-on POAM **R-02 sibling R-04**.
+
+### Context
+
+omp made reasoning/thinking items first-class (a `--thinking` flag; reasoning items in replay). Raw
+model reasoning is a sensitive surface: if it were persisted, learned-from, recalled, or exported it
+could bypass the scan/trust-label gate, leak into semantic memory, or escape CUI exclusion.
+
+### Decision
+
+Thinking is **display-only and never durable**. The chat backend streams `agent_thought_chunk` to the
+UI as a `thinking` event (live reasoning, like the omp TUI) but it is excluded from everything that
+reaches durable state. The single chokepoint is `desktop/thinking_governance.ts`
+`isLearnableAssistantText(e)` — **only `token` text is learnable**. The per-turn `assistant` buffer (the
+sole input to both `recordTurns` persistence/transcripts and `learnFromTurn` — the personalization
+distiller / memory promotion) is built through that predicate, so thinking, tool, block, subagent, and
+usage events contribute nothing. Because thinking is never persisted, it is never recalled and never
+reaches an export (exports read persisted data) — CUI exclusion holds by construction.
+
+A future change that wants to persist thinking MUST first: scan it through the fail-closed gate,
+trust-label it, gate it against semantic promotion (keystone #2), and CUI-exclude it from exports.
+`desktop/thinking_governance.test.ts` regression-locks the invariant.
+
+### Consequences
+
+- The thinking-exclusion rule is now a tested pure function, not an inline `=== "token"` that could
+  silently drift; `acp_backend.prompt()`'s `sink` consumes it.
+- No new persistence/promotion/export path may special-case thinking without passing the four gates
+  above — enforced by review against this ADR + the regression test.
+- The desktop test suite (`bun test` / `make test`) covers it; note CI's `bun test harness` does not
+  yet include `desktop/` (pre-existing; a CI-scope item for R-01).

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,6 +4,13 @@ Three lines per session: **shipped / stubbed / next** (CLAUDE.md session ritual)
 
 -----
 
+## R-04: thinking-item governance (ADR-0054)
+- **shipped:** `desktop/thinking_governance.ts` — `isLearnableAssistantText` / `accumulateAssistantText`: **only assistant `token` text is learnable** (eligible for `recordTurns` persistence + `learnFromTurn` distiller/promotion). Reasoning/thinking (and tool/block/subagent/usage) are display-only (ratifies ADR-0027 as a security policy): never persisted → never recalled → never exported → CUI-excluded by construction; never auto-promoted to semantic memory (keystone #2). `acp_backend.prompt()`'s `sink` now routes the per-turn `assistant` buffer through the predicate. 3 regression tests lock it.
+- **stubbed:** persisting thinking in future REQUIRES scan + trust-label + promotion-gate + CUI-exclude first (gated by this ADR + the test). CI's `bun test harness` doesn't run `desktop/` yet (pre-existing; R-01 CI scope) — covered by `bun test` / `make test`.
+- **next:** R-06 (subagent stash-isolation provenance) — confirm lineage/attribution track subagent edits under ADR-0032 (isolation off).
+
+-----
+
 ## P-EXT.5.0: attach-mode roadmap (planning only — ADR-0039)
 - **shipped:** ADR-0039 in DECISIONS.md — designs the deferred ADR-0038 optional attach-mode (an IDE
   extension SHARING the running desktop's already-gated session instead of spawning its own `lucid acp`).

--- a/desktop/acp_backend.ts
+++ b/desktop/acp_backend.ts
@@ -16,6 +16,7 @@ import { currentWorkspace } from "./workspace.ts";
 import { learnFromTurn, recallPreamble } from "./personal.ts";
 import { buildUserTurnPreamble } from "./preamble.ts";
 import { recordTurns } from "./turns_log.ts";
+import { isLearnableAssistantText } from "./thinking_governance.ts";
 import { recordBlock } from "./security_log.ts";
 import { asksageOnly, attribution, checkerModel, lastModel, mcpServersForAcp, setCheckerModel, setLastModel } from "./settings_store.ts";
 import { managedConfig } from "./managed_config.ts";
@@ -360,7 +361,9 @@ class Backend {
     // While a permission is awaiting the user (Ask mode), pause the idle/stall clock — a human
     // deciding is not a stalled turn (askUser has its own fail-closed timeout).
     const arm = () => { if (idle) clearTimeout(idle); if (this.pendingPerms > 0) return; idle = setTimeout(() => { stalled = true; onStall(new Error("the model did not respond for 2 minutes — the provider may be rate-limited (check your hourly budget) or the turn stalled. Try again.")); }, Backend.IDLE_MS); };
-    const sink = (e: ChatEvent) => { arm(); if (e.type === "token") assistant += e.text; onEvent(e); };
+    // Only learnable assistant text accrues to `assistant` (→ recordTurns + learnFromTurn). Thinking
+    // and other display-only events are excluded by construction (R-04 / ADR-0054).
+    const sink = (e: ChatEvent) => { arm(); if (isLearnableAssistantText(e)) assistant += e.text; onEvent(e); };
     this.listener = sink;
     this.askActive = true; // permission requests in THIS turn may be forwarded to the UI (Ask mode)
     try {

--- a/desktop/thinking_governance.test.ts
+++ b/desktop/thinking_governance.test.ts
@@ -1,0 +1,41 @@
+// R-04 (ADR-0054): thinking/reasoning items must never reach durable state. The accumulated assistant
+// text — which is what recordTurns persists and learnFromTurn (the distiller / memory promotion) learns
+// from — must contain ONLY token text, never thinking/tool/block/etc. This locks the display-only
+// invariant so a future change can't silently start persisting/promoting/exporting raw reasoning.
+
+import { test, expect } from "bun:test";
+import { isLearnableAssistantText, accumulateAssistantText } from "./thinking_governance.ts";
+import type { ChatEvent } from "./acp_backend.ts";
+
+test("only token text is learnable; thinking and other events are display-only", () => {
+	expect(isLearnableAssistantText({ type: "token", text: "x" })).toBe(true);
+	const displayOnly: ChatEvent[] = [
+		{ type: "thinking", text: "secret chain of thought" },
+		{ type: "tool", name: "bash", detail: "ls" },
+		{ type: "block", tool: "bash", reason: "r", severity: "s", findings: "f" },
+		{ type: "subagent", id: "1", agent: "task", title: "t", assignments: [] },
+		{ type: "usage", used: 1, size: 2, cost: 0 },
+	];
+	for (const e of displayOnly) expect(isLearnableAssistantText(e)).toBe(false);
+});
+
+test("accumulated assistant text excludes thinking (never persisted / learned)", () => {
+	const turn: ChatEvent[] = [
+		{ type: "token", text: "Here is " },
+		{ type: "thinking", text: "CLASSIFIED REASONING that must not persist" },
+		{ type: "tool", name: "edit", detail: "file.ts" },
+		{ type: "token", text: "the answer." },
+	];
+	const learned = accumulateAssistantText(turn);
+	expect(learned).toBe("Here is the answer.");
+	expect(learned).not.toContain("CLASSIFIED REASONING");
+	expect(learned).not.toContain("REASONING");
+});
+
+test("a thinking-only turn contributes nothing durable", () => {
+	const turn: ChatEvent[] = [
+		{ type: "thinking", text: "lots of private reasoning" },
+		{ type: "thinking", text: "more reasoning" },
+	];
+	expect(accumulateAssistantText(turn)).toBe("");
+});

--- a/desktop/thinking_governance.ts
+++ b/desktop/thinking_governance.ts
@@ -1,0 +1,27 @@
+// Thinking-item governance (R-04, ADR-0054).
+//
+// omp made reasoning/thinking items first-class (a `--thinking` flag, reasoning items in replay). They
+// are a sensitive surface: if persisted, learned-from, recalled, or exported, raw model reasoning
+// could bypass the scan/trust-label gate, leak into semantic memory, or escape CUI exclusion.
+//
+// The policy (ratifying ADR-0027's display-only posture as a security invariant): only assistant
+// **token** text is "learnable" — eligible to be persisted (recordTurns) and learned-from (the
+// personalization distiller / memory promotion). Thinking, tool, block, subagent, usage, etc. are
+// DISPLAY-ONLY: never persisted, never promoted, never re-fed to a prompt — and therefore never reach
+// an export (exports read persisted data). A future change that wants to persist thinking MUST first
+// scan + trust-label + promotion-gate + CUI-exclude it; this predicate is the single chokepoint that
+// decides what a turn contributes to durable state.
+
+import type { ChatEvent } from "./acp_backend.ts";
+
+/** True only for assistant token text — the one event kind eligible for persistence + learning. */
+export function isLearnableAssistantText(e: ChatEvent): e is Extract<ChatEvent, { type: "token" }> {
+	return e.type === "token";
+}
+
+/** Accumulate ONLY the learnable assistant text from a turn's events (thinking et al. excluded). */
+export function accumulateAssistantText(events: Iterable<ChatEvent>): string {
+	let out = "";
+	for (const e of events) if (isLearnableAssistantText(e)) out += e.text;
+	return out;
+}


### PR DESCRIPTION
## R-04 — Thinking-item governance: reasoning is display-only, never durable

omp made reasoning/thinking items first-class (`--thinking`, reasoning items in replay). Raw model reasoning is a sensitive surface: persisted/learned/recalled/exported, it could bypass the scan/trust-label gate, leak into semantic memory, or escape CUI exclusion. This ratifies ADR-0027's display-only posture as a **security policy** and regression-locks it. See **ADR-0054**.

Tracks `TechLead187/lucidagentIDEaddon#33` (R-04, PI-2). No production behavior change — it makes the existing invariant explicit + tested.

### Decision

Thinking is **display-only and never durable.** Only assistant `token` text is "learnable" — eligible for `recordTurns` (persistence/transcripts) and `learnFromTurn` (personalization distiller / memory promotion). The single chokepoint is `desktop/thinking_governance.ts` `isLearnableAssistantText`; `acp_backend.prompt()`'s `sink` builds the per-turn `assistant` buffer through it, so thinking/tool/block/subagent/usage contribute nothing.

Because thinking is never persisted → it is never recalled, never exported (exports read persisted data → **CUI exclusion by construction**), and never auto-promoted to semantic memory (keystone #2).

### What changed

- `desktop/thinking_governance.ts` — `isLearnableAssistantText(e)` + `accumulateAssistantText(events)` (type-only import of `ChatEvent`; no runtime coupling).
- `desktop/acp_backend.ts` — `sink` now uses the predicate (was an inline `e.type === "token"`), so the rule is a named, tested function that can't silently drift.
- `desktop/thinking_governance.test.ts` — 3 regression tests.
- `DECISIONS.md` — ADR-0054.

### R-04 acceptance

- [x] **Never auto-promote to semantic memory** — `assistant` (distiller input) excludes thinking.
- [x] **CUI-exclude from exports** — thinking is never persisted, so never in exports (by construction).
- [x] **Scan / trust-label** — thinking never re-enters a prompt or durable state; if a future path persists it, the ADR mandates scan + trust-label + promotion-gate + CUI-exclude first.
- [x] **Tests** — 3 regression tests lock the invariant.
- [x] **ADR the policy** — ADR-0054.

### Testing

```
bun test desktop/thinking_governance.test.ts → 3 pass / 0 fail
tsc -p desktop/tsconfig.json → clean for the changed files
  (1 pre-existing unrelated error: renderer/markdown.ts missing `katex` types)
```

Tests: only `token` is learnable (thinking/tool/block/subagent/usage are not); accumulated assistant text excludes a thinking chunk's content; a thinking-only turn contributes nothing durable.

### ⚠️ Pre-existing CI gap (not this change)

CI's `bun test harness` (ci.yml) does **not** run `desktop/` tests — only `make test` / `bun test` do. So this regression runs locally + under `make test` but not in the harness-only CI lane. Pre-existing (all `desktop/*.test.ts` are affected); flagging for R-01's CI scope, not in scope for R-04.

### Invariant compliance
#3 fail-closed (durable state is opt-in via one predicate) · #5 untrusted content (reasoning stays out of prompts/memory) · keystone #2 (no promotion of thinking). One increment.
