### PR TITLE
R-06: subagent edits gated + attributed (no stash-masking)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -4537,3 +4537,45 @@ chunks are retrieval context, never semantic memory).
 ADR-0007 (AskSage adapter + `/query` RAG this extends); ADR-0012 (compartments/classification); ADR-0019
 (gate/quarantine + Security-panel surfacing); ADR-0050 / P-GOAL.8 (the guided-walkthrough UI pattern
 reused); CLAUDE.md invariants #2/#3/#5/#10 + keystone #2.
+
+-----
+
+## ADR-0055 — Subagent edits are gated + attributed (no stash-masking) (R-06)
+
+**Date:** 2026-06-24
+**Status:** Accepted — verified + regression-locked this increment.
+**Relationship:** depends on ADR-0032 (task isolation OFF) and ADR-0031 (AI-LOC code-activity
+attribution); reconciles with the editor TOCTOU fix. Tracks add-on POAM **R-06**. (Numbered after
+ADR-0054 / R-04, a sibling PI risk PR.)
+
+### Context
+
+omp's subagent `agent()`/`task` can git-stash isolate → apply → merge a subagent's edits. R-06's risk:
+a stash-isolated edit could be masked from the in-process gate or from code-activity attribution
+(the AI bill-of-changes), and the nested-repo dirty-state path could mis-attribute.
+
+### Decision / finding
+
+On THIS product the masking surface does not exist, because **task isolation is OFF** (ADR-0032,
+`harness/omp/acp_config.yml` `task.isolation.mode: none`):
+
+- A `task` subagent runs in the **real workspace**, so its `write`/`edit` tool calls route through the
+  **same in-process fail-closed gate** as the main agent (keystone #1, invariants #3/#4). The
+  kill-the-sidecar test already proves the gate intercepts *every* tool call.
+- Code-activity attribution (ADR-0031) counts from that gate's `tool_result` hook. The counted event
+  shape (`EditResultLike`) carries **no agent/provenance dimension** — so a subagent's edit is counted
+  identically to a main-agent edit; there is no field a counter could use to drop it.
+- Editor TOCTOU: the applied bytes equal the scanned bytes regardless of which agent applied them, so
+  attribution counts exactly what the gate cleared.
+
+`harness/runs/loc_count_subagent.test.ts` regression-locks that subagent writes/edits are counted and
+that counting is provenance-independent.
+
+### Consequences
+
+- No code change needed to *track* subagent edits — isolation-off + the agent-agnostic gate hook make
+  it automatic. The risk is closed by architecture, not a patch.
+- **If isolation is ever re-enabled** (ADR-0032's conditions: a patch-review/apply UI + a verified
+  reliable Windows merge-back), R-06 MUST be re-opened: the stash merge-back would need explicit gate
+  scanning + attribution of the merged diff, and a nested-repo dirty-state test. This ADR is the
+  tripwire for that.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,6 +4,13 @@ Three lines per session: **shipped / stubbed / next** (CLAUDE.md session ritual)
 
 -----
 
+## R-06: subagent edits gated + attributed, no stash-masking (ADR-0055)
+- **shipped:** verified + regression-locked that subagent (`task`) edits are NOT masked from the gate or code-activity attribution. With task isolation OFF (ADR-0032), a subagent edits the REAL workspace → its write/edit tool calls route through the same in-process fail-closed gate → ADR-0031 attribution counts them from the gate's tool_result hook, and `EditResultLike` carries no agent/provenance dimension (so nothing can drop a subagent's edit). `harness/runs/loc_count_subagent.test.ts` (3 tests). ADR-0055.
+- **stubbed:** the stash-isolate/apply/merge masking risk only exists if isolation is RE-enabled (ADR-0032 conditions: patch-review UI + reliable Windows merge-back) — ADR-0055 is the tripwire to re-open R-06 then (gate-scan + attribute the merged diff; nested-repo dirty-state test).
+- **next:** add-on PI items continue (R-08 #38, B-ADR-001 #40, B-ADR-006 #42).
+
+-----
+
 ## P-EXT.5.0: attach-mode roadmap (planning only — ADR-0039)
 - **shipped:** ADR-0039 in DECISIONS.md — designs the deferred ADR-0038 optional attach-mode (an IDE
   extension SHARING the running desktop's already-gated session instead of spawning its own `lucid acp`).

--- a/harness/runs/loc_count_subagent.test.ts
+++ b/harness/runs/loc_count_subagent.test.ts
@@ -1,0 +1,34 @@
+// harness/runs/loc_count_subagent.test.ts
+//
+// R-06: subagent (task) edits must not be masked from the gate or from code-activity attribution.
+//
+// With omp task isolation OFF (ADR-0032; harness/omp/acp_config.yml `task.isolation.mode: none`), a
+// `task` subagent runs in the REAL workspace, so its write/edit tool calls flow through the SAME
+// in-process fail-closed gate as the main agent (keystone #1 / invariant #3/#4). Code-activity
+// attribution (ADR-0031) counts from that gate's tool_result hook — and the event shape it counts
+// (`EditResultLike`) carries NO agent/provenance dimension. So a subagent's edit is counted exactly
+// like a main-agent edit; there is no field a counter could use to silently drop it. This locks that.
+//
+// (The stash-isolate/apply/merge masking risk R-06 names only exists when isolation is ON; if it is
+// ever re-enabled per ADR-0032's conditions, this invariant must be re-verified for the merge-back.)
+
+import { test, expect } from "bun:test";
+import { countEdit, type EditResultLike } from "./loc_count.ts";
+
+test("a subagent write is counted (attribution is agent-agnostic)", () => {
+	const subagentWrite: EditResultLike = { toolName: "write", input: { path: "src/sub.ts", content: "a\nb\nc\n" } };
+	expect(countEdit(subagentWrite)).toEqual({ countable: true, tool: "write", added: 3, removed: 0, files: ["src/sub.ts"] });
+});
+
+test("a subagent edit diff is counted", () => {
+	const subagentEdit: EditResultLike = { toolName: "edit", details: { path: "src/sub.ts", diff: "+42|new line\n-7|old line\n 40|ctx\n" } };
+	expect(countEdit(subagentEdit)).toMatchObject({ countable: true, tool: "edit", added: 1, removed: 1, files: ["src/sub.ts"] });
+});
+
+test("counting is provenance-independent: identical results count identically", () => {
+	// The tool_result the counter sees is the same whether main or a subagent produced it, so a
+	// subagent's edits can never be selectively dropped by attribution.
+	const result: EditResultLike = { toolName: "edit", details: { path: "x.ts", diff: "+1|x\n+2|y\n" } };
+	expect(countEdit(result)).toEqual(countEdit(structuredClone(result)));
+	expect(countEdit(result).added).toBe(2);
+});


### PR DESCRIPTION
## R-06 — Subagent edits are gated + attributed (no stash-masking)

R-06 risk: a subagent's `agent()`/`task` git-stash isolate/apply/merge could mask its edits from the in-process gate or from code-activity attribution.

**Finding (ADR-0055): the masking surface does not exist on this product** — task isolation is **OFF** (ADR-0032, `harness/omp/acp_config.yml` `task.isolation.mode: none`). So:

- A `task` subagent runs in the **real workspace** → its `write`/`edit` tool calls route through the **same in-process fail-closed gate** as the main agent (keystone #1, invariants #3/#4; the kill-the-sidecar test already proves the gate hooks every call).
- Code-activity attribution (ADR-0031) counts from that gate's `tool_result` hook, and the counted event shape (`EditResultLike`) carries **no agent/provenance dimension** — a subagent's edit is counted identically to a main-agent edit; nothing can drop it by provenance.
- Editor TOCTOU: applied bytes == scanned bytes regardless of which agent applied them.

### What shipped
- `harness/runs/loc_count_subagent.test.ts` — 3 tests: a subagent write is counted; a subagent edit diff is counted; counting is provenance-independent. **Runs in the harness CI lane** (`bun test harness`).
- `DECISIONS.md` — ADR-0055 (the tripwire to re-open R-06 if isolation is re-enabled).

### Acceptance
- [x] Confirm lineage + code-activity attribution track subagent edits — yes, via the agent-agnostic gate hook (isolation off).
- [x] Test the path — regression test added.
- [x] Reconcile with the editor TOCTOU fix + ADR-0032 — done in ADR-0055.

```
bun test harness/runs/loc_count_subagent.test.ts -> 3 pass / 0 fail
```

Numbered ADR-0055 (after R-04's ADR-0054, a sibling PR). One increment; verification + regression-lock + ADR, no behavior change.