### PR TITLE
/goal loop engineering: AAR + guards (P-GOAL.9), cross-run eval (P-GOAL.10), spend kill switch (P-GOAL.11), Pre-Flight Audit (P-GOAL.12)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -4537,3 +4537,96 @@ chunks are retrieval context, never semantic memory).
 ADR-0007 (AskSage adapter + `/query` RAG this extends); ADR-0012 (compartments/classification); ADR-0019
 (gate/quarantine + Security-panel surfacing); ADR-0050 / P-GOAL.8 (the guided-walkthrough UI pattern
 reused); CLAUDE.md invariants #2/#3/#5/#10 + keystone #2.
+
+-----
+
+## ADR-0054 — The `/goal` loop's After-Action Report + termination guards (P-GOAL.9)
+
+**Date:** 2026-06-25
+**Status:** Accepted — shipped this increment.
+**Context increment:** P-GOAL.9.
+
+### Context
+
+We reviewed our `/goal` loop (ADR-0046–0050) against Cobus Greyling's **loop-engineering**
+playbook (`cobusgreyling/loop-engineering`: failure-modes catalog + ship-readiness rubric,
+itself drawing on Osmani/Cherny). Our loop already does the hard parts the rubric stresses —
+a real **maker/checker split** on a separate, cheaper model (ADR-0048), a **fail-closed
+checker** (`goal_verdict.ts`), **durable on-disk memory** with resume (ADR-0046/0047), an
+iteration cap + no-progress stop, and a pre-run cost estimate (ADR-0049). The rubric exposed
+four gaps, all sharpest for **long-running / unattended** loops:
+
+1. **Resume injected the wrong end of memory.** `runGoal` fed `prior.slice(0, 3000)` — the
+   *head* (header + oldest rounds) — so a long resumed loop never saw what it just did. A
+   correctness bug squarely in the long-running case (their "State Rot").
+2. **No "Infinite Fix Loop" guard (their #1 failure mode).** We stopped on *no actions*, but
+   not on *acting-yet-never-converging* — the agent edits every round and the same check keeps
+   failing until the cap.
+3. **Tool failure was invisible to the loop.** A failed/blocked tool call emitted a generic
+   `block` event the loop never counted or reacted to.
+4. **No metrics/observability surface (rubric §9).** The markdown memory is human-readable but
+   not *measurable*; nothing told the user what a run actually did.
+
+The user asked specifically for an **After-Action Report** as the loop's **last task**, with
+"the best type of graphs" for **Tool Calls (by type)**, **LOC changed (added/removed)**,
+**Errors recorded**, and **websites visited**.
+
+### Decision
+
+One coherent increment — instrument the loop once, then use that data for both the
+termination guards and the report.
+
+- **Pure report core — `desktop/loop_report.ts`** (no I/O, no `Date.now()`; tested like
+  `loop_estimate.ts`/`goal_verdict.ts`). Collectors: `normalizeToolName` (group raw omp kinds
+  into a stable type set), `extractUrls`, `parseNumstat`, `stallSignature`. Renderer:
+  `renderLoopReport(LoopMetrics)` emits a deterministic markdown AAR.
+- **"Best type of graphs" = Mermaid + a text scoreboard.** The durable record lives on disk;
+  Mermaid (`pie` for tool-calls-by-type, `xychart-beta` bars for LOC and per-iteration errors)
+  renders natively on GitHub / VS Code / Obsidian — portable, zero-dependency, and TS-only
+  (we generate text, not a charting lib; invariant #2). A unicode **scoreboard** + tables make
+  it render even in our in-app `marked` view, which has no Mermaid. Sections with no data
+  degrade to an honest one-liner — never an empty/invalid chart.
+- **The report is the loop's LAST task.** Generated in `runGoal`'s `finally`, so *every* exit
+  path (met / stopped / cancelled / error) produces one; emitted as a new `goal-report`
+  ChatEvent (path + summary + markdown) and written beside the memory file via
+  `saveGoalReport` (same `<id>-<slug>` stem, `.report.md`, confined by `pathWithin`).
+- **Termination guards from the same instrumentation.** (#2) `stallSignature` collapses a
+  recurring checker blocker across rounds; three identical not-done rounds stop the loop as
+  "not converging" instead of burning the cap. (#3) per-iteration tool-failure counts are
+  recorded and fed back into the next maker prompt ("N tool calls failed last round — fix the
+  cause"), and surfaced in the report's Errors section.
+- **LOC via best-effort git.** `gitHead()` pins a baseline commit; `gitDiffVs()` parses
+  `git diff --numstat` of the tree vs that commit at the end, minus any changes already present
+  at start. Non-git workspace ⇒ `loc: null` ⇒ the report says so. Never a precondition.
+- **Resume fix (#1).** `prior.slice(0, 3000)` → `slice(-3000)` (the most-recent rounds).
+
+Everything new is **best-effort**: a failure assembling/writing the report is swallowed so the
+turn always settles with `done`. The fail-closed gate remains the only safety boundary.
+
+### Alternatives considered
+
+- **Render charts in-app (add a Mermaid/Chart.js dependency).** Rejected: a new vendored
+  bundle + CSP surface for a report whose durable, portable home is the on-disk file. The text
+  scoreboard covers the in-app view; the rich graphs live where they render for free.
+- **Have the checker model write the report prose.** Rejected: the metrics are objective —
+  deterministic generation is cheaper, reproducible, and can't hallucinate ("verifier theater"
+  in the report itself).
+- **A structured JSONL run-log instead of markdown.** Deferred — a good *next* increment for
+  cross-run success-rate/eval. This increment delivers the per-run record the user asked for;
+  the JSONL ledger + live token budget + escalation ping are the follow-ons.
+
+### Invariants preserved
+
+#2 (TS-only; the report is generated text, no new language surface, no charting lib) · #3
+(the report is best-effort and never gates anything; the fail-closed scanner is still the
+boundary) · #5 (no untrusted content enters the prefix; the report is a post-hoc artifact) ·
+#8 (`goal-report` is an ACP **ChatEvent**, the UI stream — not an `EventName` provenance event) ·
+path confinement via `pathWithin` for the on-disk report.
+
+### Relates to
+
+ADR-0046 (the maker/checker loop + durable memory this instruments); ADR-0047 (automations —
+their background ticks now also produce a report); ADR-0048 (the checker model whose verdicts
+feed the stall guard); ADR-0049/0050 (the launcher/cost estimate this complements with
+*actuals*); `cobusgreyling/loop-engineering` (failure-modes #1 Infinite Fix Loop, State Rot,
+Token Burn; ship-readiness §9 Observability — the external review that motivated this).

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -4630,3 +4630,72 @@ their background ticks now also produce a report); ADR-0048 (the checker model w
 feed the stall guard); ADR-0049/0050 (the launcher/cost estimate this complements with
 *actuals*); `cobusgreyling/loop-engineering` (failure-modes #1 Infinite Fix Loop, State Rot,
 Token Burn; ship-readiness §9 Observability — the external review that motivated this).
+
+-----
+
+## ADR-0055 — Cross-run evaluation: the `/goal` loop run-log + stats surface (P-GOAL.10)
+
+**Date:** 2026-06-25
+**Status:** Accepted — shipped this increment.
+**Context increment:** P-GOAL.10.
+
+### Context
+
+ADR-0054 (P-GOAL.9) gave each `/goal` run an After-Action Report — metrics + graphs for ONE
+run. loop-engineering's ship-readiness rubric (§9 Observability) also asks for the cross-run
+view: "success metrics established", an "append-only run history" the team can read without
+chat logs. That is the "metrics/evaluation layer" the user asked for in the original review.
+We already compute a rich `LoopMetrics` per run (ADR-0054); nothing yet persists it across runs
+or aggregates it.
+
+### Decision
+
+A flat, append-only **JSONL ledger** plus a PURE aggregator, reusing the P-GOAL.9 metrics.
+
+- **`desktop/loop_runlog.ts`** (PURE; no I/O, no `Date.now()`; unit-tested):
+  - `toRunRecord(LoopMetrics, {id, ts})` projects a finished run into a compact `LoopRunRecord`
+    (outcome, iterations, duration, tool totals + by-type, LOC, errors, websites). `id`/`ts`
+    come from the backend (pure modules can't read the clock).
+  - `runRecordLine` / `parseRunLog` serialize to / from JSONL; a malformed line is skipped, never
+    fatal (append-only, best-effort).
+  - `aggregateRuns(records): RunStats` — runs, success rate, **average iterations-to-success**
+    (over met runs only), avg duration, summed tools/LOC/errors, and a **failure breakdown** that
+    groups non-success runs by recurring blocker via `stallSignature` (so "3 of 5 tests fail" and
+    "2 of 5 tests fail" collapse to one). `summarizeRunStats` gives a one-line chip.
+- **Persistence — `.omp/loops/run-log.jsonl`** (`appendRunLog`/`readRunLog` in `goal_memory.ts`,
+  path-confined, best-effort). `runGoal`'s `finally` appends one line per completed run, right
+  after writing the AAR — so the ledger and the per-run report are produced together as the
+  loop's last task.
+- **Surface** — backend `loopRunStats()` → `GET /api/goal/stats` → a compact **evaluation banner**
+  in the `/goal` launcher (success rate, avg iters-to-win, avg duration, tool mix, most-common
+  stop). Hidden until there's history, so a first-time user sees nothing extra.
+
+**Why JSONL, not DuckDB.** The desktop `/goal` loop persists to `.omp/loops/` markdown
+(goal-memory, ADR-0046) — this stays in that lightweight, air-gap-clean lane. The DuckDB schema
+(invariant #10) is the harness security/provenance pipeline, a different layer; a per-loop eval
+ledger does not belong there and must not trigger a migration. The flat file is inspectable,
+append-only, and trivially exportable.
+
+### Alternatives considered
+
+- **Write to the DuckDB telemetry store.** Rejected — couples the desktop loop to the harness
+  analytics DB + a frozen-schema migration (invariant #10) for a lightweight, workspace-local
+  ledger. JSONL keeps it in the goal-memory lane.
+- **Recompute stats by scanning the markdown memory/report files.** Rejected — parsing prose for
+  metrics is brittle; a typed JSONL record is the stable contract the aggregator reads.
+- **A full history table UI.** Deferred — the launcher banner is the high-value at-a-glance view;
+  a deeper drill-down can come later (the records carry enough to build it without a migration).
+
+### Invariants preserved
+
+#2 (TS-only; pure aggregator + a flat file, no new language surface) · #3 (the ledger is
+best-effort and never gates the loop; the fail-closed scanner remains the boundary) · #10 (does
+NOT touch the frozen DuckDB schema — a separate workspace-local JSONL file) · path confinement via
+`pathWithin` for the ledger.
+
+### Relates to
+
+ADR-0054 (the After-Action Report + `LoopMetrics` this serializes across runs); ADR-0046/0047
+(the loop + automations whose every run now logs); `cobusgreyling/loop-engineering` (ship-
+readiness §9 Observability — "append-only run history", "success metrics established"). Follow-ons:
+a live per-loop token budget + kill switch, and an escalation ping on unattended stop.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -4763,3 +4763,76 @@ ADR-0049 (the pre-run cost estimate this complements with ACTUALS), ADR-0054 (th
 shows spend), ADR-0055 (the run-log/eval that now sums spend), ADR-0048 (the cheap checker that
 keeps the meter ≈ maker spend); `cobusgreyling/loop-engineering` (Token Burn — "daily budget
 limit", "kill switch"). Remaining follow-on: an escalation ping on unattended stop.
+
+-----
+
+## ADR-0057 — The Pre-Flight Audit: loop design + readiness before you build (P-GOAL.12)
+
+**Date:** 2026-06-25
+**Status:** Accepted — shipped this increment.
+**Context increment:** P-GOAL.12.
+
+### Context
+
+loop-engineering ships two CLIs — `loop-init` (scaffold run-log/budget/state templates) and
+`loop-audit` (score a repo 0→100, L0→L3, on readiness for unattended loops). We already *generate*
+live what they scaffold static (run-log P-GOAL.10, budget kill switch P-GOAL.11, goal-memory
+P-GOAL.4), so adopting the CLIs would be redundant + drift (Node CLIs for grok/codex workflows;
+we're in-process Bun/Electron). But their **readiness rubric** is valuable — reframed from "is this
+REPO ready?" to "is THIS loop well-formed?", surfaced at the moment of building a loop. The user
+asked for an active **"Pre-Flight Audit"**: an optional button above the Goal input that pauses the
+builder, scopes the loop (branch/worktree) and runs a prompt-engineering interview, reads past-run
+history so context isn't lost, folds in **user/product-owner AND engineer** feedback, and emits a
+**repeatable Loop Design report (.md)** the user adopts as the goal — whose matured success criteria
+thread to the small checker so it grades against the real design. The whole thing closes a
+**recursive self-improvement loop**: each run's After-Action Report + run-log feed the next loop's
+Pre-Flight, which matures the next goal.
+
+### Decision
+
+- **`desktop/loop_preflight.ts`** (PURE, unit-tested): `assessReadiness` scores the spec L0→L3 with
+  **gated** levels (L3 "unattended-capable" REQUIRES the safety-bearing four — verification command,
+  budget cap, explicit scope, cheap checker — so a verbose goal can't buy L3 without a real verifier,
+  defeating *Verifier Theater*). `renderLoopDesign` emits the repeatable report; `maturedGoalFrom`
+  distills the adoptable goal; `successCriteria` distills the checker's grading rubric. History:
+  `relevantPriorRuns` / `summarizePriorRuns` / `renderPriorRuns` surface prior runs of a similar loop
+  (their AARs live in `.omp/loops/`). Interview: `preflightSystemPrompt` / `preflightUserPrompt` /
+  `parsePreflightJson` / `mergeMatured` (user-provided values always win; the model fills blanks).
+- **Backend** `preflightAudit(spec)`: reads the run-log for history, runs ONE interview pass on the
+  cheap **checker** model (`complete()`, best-effort; deterministic fallback to the user's answers if
+  the model is unavailable), scores readiness, writes the Loop Design under `.omp/loops/*.preflight.md`,
+  and returns the matured goal + criteria + report. `loopScopes()` lists branches/worktrees (git,
+  best-effort). It mutates nothing — a planning step.
+- **Checker context (deterministic grading).** `runGoal`/`checkGoal` gain an optional `criteria`; the
+  small checker now grades against the matured success criteria and **reports back which are met/unmet**
+  — appropriate context, not a bare condition. Adopting a Pre-Flight design stashes its criteria and
+  threads it to the next run.
+- **UI**: an optional "Pre-Flight Audit" button above the Goal field opens a panel (scope picker +
+  interview incl. user/PO feedback + engineer notes), runs the audit, shows the readiness chip + the
+  rendered report + prior-run note, and "Adopt as goal" fills the Goal field (+ command) and stashes
+  the criteria. The builder is paused until the user adopts or closes.
+
+### Alternatives considered
+
+- **Vendor loop-init / loop-audit.** Rejected — Node CLIs that scaffold static markdown for grok/codex;
+  we already generate those live, and a CLI surface cuts against "extend, don't fork".
+- **Open-ended multi-turn interview chat.** Rejected for this increment — a structured interview + one
+  model maturation pass is reliable, testable, and bounded; a multi-turn agent can come later.
+- **A passive readiness chip only.** Rejected — the user wanted an active design step that produces an
+  adoptable artifact and carries history/feedback forward (the self-improvement loop).
+
+### Invariants preserved
+
+#2 (TS-only; a pure core + a model call via existing `complete()`, no new surface) · #3 (best-effort
+throughout — git scopes, the model interview, the report write all degrade gracefully; the checker
+stays fail-closed and the gate is still the boundary) · #5 (the matured goal is shown to the user to
+review/edit before it ever runs — human in the loop) · #10 (the Loop Design + preflight reports are
+flat `.omp/loops/` files; no DuckDB schema change).
+
+### Relates to
+
+ADR-0048 (the cheap checker that runs the interview + now grades against criteria), ADR-0054/0055
+(the AARs + run-log this reads for history — the recursive loop), ADR-0056 (the budget cap the rubric
+checks), ADR-0046/0047 (the loop + automations); loop-engineering's `loop-audit` rubric (L0→L3) and
+`loop-design-checklist` (the report's shape). Follow-on: a budget field for automations; an escalation
+ping on unattended stop.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -4699,3 +4699,67 @@ ADR-0054 (the After-Action Report + `LoopMetrics` this serializes across runs); 
 (the loop + automations whose every run now logs); `cobusgreyling/loop-engineering` (ship-
 readiness §9 Observability — "append-only run history", "success metrics established"). Follow-ons:
 a live per-loop token budget + kill switch, and an escalation ping on unattended stop.
+
+-----
+
+## ADR-0056 — Live per-loop spend meter + budget kill switch (P-GOAL.11)
+
+**Date:** 2026-06-25
+**Status:** Accepted — shipped this increment.
+**Context increment:** P-GOAL.11.
+
+### Context
+
+loop-engineering's costliest failure mode is **Token Burn** — an unattended loop running full
+turns until "the bill spikes"; its prescribed mitigation is a "daily budget limit" / "kill
+switch". ADR-0049 already shows a pre-run cost ESTIMATE in the launcher, but the running loop had
+no view of ACTUAL spend and no ceiling that could halt it. The only bound was `maxIters`, which
+says nothing about dollars. For long-running / scheduled loops — exactly the ones the user cares
+about — that's the gap.
+
+### Decision
+
+A live spend meter fed by the maker's usage telemetry, plus a hard dollar cap that stops the loop.
+
+- **`desktop/loop_budget.ts`** (PURE, unit-tested): `LoopSpend` + `addTurnSpend` (sum each maker
+  turn's PEAK cost; track context tokens as a high-water mark, never summed — `used` is cumulative
+  within the persistent maker session), `overBudget(spent, cap)` (the kill switch — a non-positive
+  cap means "no budget"), and `normalizeBudget` (clamp the user's input to a non-negative $ amount).
+- **Why per-turn peak, summed.** `runGoal` owns the turn boundaries, so accounting needs no fragile
+  counter-reset detection: omp's `usage_update.cost` is a per-turn figure, and each maker iteration
+  is one turn, so total spend = Σ(per-turn peak cost). The checker runs in a separate throwaway
+  `complete()` session whose usage never reaches the loop sink, so the meter measures maker spend —
+  the dominant cost (the checker is cheap by ADR-0048's design).
+- **Kill switch, two-stage.** In the maker sink, the moment `spend + thisTurnPeak` crosses the cap
+  we `cancel()` the in-flight turn (stops mid-stream). After the turn, if `overBudget` we end the
+  loop with `stopped: budget cap $X reached (spent $Y)` — before spending a checker call. The bill
+  cannot run away unattended.
+- **Surfaced everywhere the metrics already flow.** `LoopMetrics` gains `spendUsd` /
+  `peakContextTokens` / `budgetUsd` (spend is `null`, not `$0`, when no usage telemetry was seen);
+  the After-Action Report shows a "Spend $X of $Y cap · peak context N" row (ADR-0054); the run-log
+  record + cross-run eval sum actual spend (ADR-0055); the launcher gains an optional "Budget cap"
+  field next to Max iterations.
+
+### Alternatives considered
+
+- **Budget in tokens.** Rejected as the primary unit — "Token Burn" is about the bill, and `used`
+  is cumulative context (re-counts the cached prefix each turn), so a token cap would be confusing.
+  Dollars are what the user sets a ceiling on; tokens are shown as informational peak context.
+- **Reset-detecting accumulator over a possibly-cumulative cost counter.** Rejected — the loop owns
+  turn boundaries, so "sum per-turn peaks" is exact and simpler than guessing counter semantics.
+- **A cap on scheduled automations too.** Deferred — needs an `Automation` schema field + form; the
+  iteration cap still bounds automations today. A clean follow-on.
+
+### Invariants preserved
+
+#2 (TS-only; a pure meter, no new surface) · #3 (the meter is best-effort telemetry and the kill
+switch only ever stops EARLY — it can never let a run continue past a limit; the fail-closed gate
+remains the safety boundary) · #6 (the budget field is user-turn/launcher state, never the frozen
+prefix). No schema/DuckDB change (spend rides the ADR-0055 JSONL ledger).
+
+### Relates to
+
+ADR-0049 (the pre-run cost estimate this complements with ACTUALS), ADR-0054 (the AAR that now
+shows spend), ADR-0055 (the run-log/eval that now sums spend), ADR-0048 (the cheap checker that
+keeps the meter ≈ maker spend); `cobusgreyling/loop-engineering` (Token Burn — "daily budget
+limit", "kill switch"). Remaining follow-on: an escalation ping on unattended stop.

--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,10 @@ demo-P-GOAL.9: ## P-GOAL.9 (ADR-0054): /goal After-Action Report — tool calls/
 demo-P-GOAL.10: ## P-GOAL.10 (ADR-0055): /goal cross-run evaluation ledger — success rate, avg iters, failure breakdown
 	$(BUN) run harness/scripts/demo_pgoal10.ts
 
+.PHONY: demo-P-GOAL.11
+demo-P-GOAL.11: ## P-GOAL.11 (ADR-0056): /goal live spend meter + budget kill switch — halts an unattended run at a $ cap
+	$(BUN) run harness/scripts/demo_pgoal11.ts
+
 .PHONY: dashboards
 dashboards: ## Materialize dashboard CSVs from a DuckDB into observable/docs/data (DB=path)
 	$(BUN) run harness/scripts/materialize_dashboards.ts $(DB) observable/docs/data

--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,10 @@ demo-P-GOAL.10: ## P-GOAL.10 (ADR-0055): /goal cross-run evaluation ledger — s
 demo-P-GOAL.11: ## P-GOAL.11 (ADR-0056): /goal live spend meter + budget kill switch — halts an unattended run at a $ cap
 	$(BUN) run harness/scripts/demo_pgoal11.ts
 
+.PHONY: demo-P-GOAL.12
+demo-P-GOAL.12: ## P-GOAL.12 (ADR-0057): Pre-Flight Audit — readiness L0→L3, history awareness, interview, Loop Design report
+	$(BUN) run harness/scripts/demo_pgoal12.ts
+
 .PHONY: dashboards
 dashboards: ## Materialize dashboard CSVs from a DuckDB into observable/docs/data (DB=path)
 	$(BUN) run harness/scripts/materialize_dashboards.ts $(DB) observable/docs/data

--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,10 @@ demo-P-TPS.1: ## P-TPS.1 (ADR-0044): streaming output-token readout — output-o
 demo-P-SKILL.1: ## P-SKILL.1 (ADR-0045): gated skill import — clean .md writes to .omp/skills/, poisoned blocks at the gate
 	$(BUN) run harness/scripts/demo_pskill1.ts
 
+.PHONY: demo-P-GOAL.9
+demo-P-GOAL.9: ## P-GOAL.9 (ADR-0054): /goal After-Action Report — tool calls/LOC/errors/websites graphs + stall guard
+	$(BUN) run harness/scripts/demo_pgoal9.ts
+
 .PHONY: dashboards
 dashboards: ## Materialize dashboard CSVs from a DuckDB into observable/docs/data (DB=path)
 	$(BUN) run harness/scripts/materialize_dashboards.ts $(DB) observable/docs/data

--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,10 @@ demo-P-SKILL.1: ## P-SKILL.1 (ADR-0045): gated skill import — clean .md writes
 demo-P-GOAL.9: ## P-GOAL.9 (ADR-0054): /goal After-Action Report — tool calls/LOC/errors/websites graphs + stall guard
 	$(BUN) run harness/scripts/demo_pgoal9.ts
 
+.PHONY: demo-P-GOAL.10
+demo-P-GOAL.10: ## P-GOAL.10 (ADR-0055): /goal cross-run evaluation ledger — success rate, avg iters, failure breakdown
+	$(BUN) run harness/scripts/demo_pgoal10.ts
+
 .PHONY: dashboards
 dashboards: ## Materialize dashboard CSVs from a DuckDB into observable/docs/data (DB=path)
 	$(BUN) run harness/scripts/materialize_dashboards.ts $(DB) observable/docs/data

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2093,3 +2093,20 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
   Gemini) is the manual check; parametersJsonSchema assumes AskSage's Gemini proxy is current (omp uses it for
   real Gemini).
 - **next:** live end-to-end tool run on the gov gateway for both providers.
+
+---
+**P-GOAL.9 — /goal After-Action Report + termination guards (ADR-0054)**
+- **shipped:** the loop's LAST task is now an After-Action Report — `desktop/loop_report.ts` (PURE,
+  unit-tested) renders a deterministic markdown AAR with portable Mermaid graphs (pie: Tool Calls by type;
+  xychart bars: LOC added/removed + Errors per iteration) + a unicode scoreboard + Websites-visited table,
+  written beside the memory file via `saveGoalReport` (same `<id>-<slug>` stem, `.report.md`) and streamed
+  as a new `goal-report` ChatEvent rendered as a collapsible card in the chat. Same instrumentation powers
+  three guards: convergence-stall detection (3 identical checker blockers → stop "not converging", #2
+  Infinite Fix Loop), per-iteration tool-failure counts fed back into the next maker prompt (#3), and LOC
+  via best-effort git numstat. Fixed the resume bug: `prior.slice(0,3000)` (head/stale) → `slice(-3000)`
+  (most-recent rounds). bun test desktop 143 pass (+19 new; 4 fails are the pre-existing missing-omp-dep
+  env issue, unchanged from baseline); `make demo-P-GOAL.9` green; AAR artifact renders pie+bar on GitHub/VSCode.
+- **stubbed:** typecheck not run here (this container lacks @types/node/electron/bun); in-app `marked` view
+  shows the scoreboard+tables, not Mermaid (charts live in the on-disk record by design).
+- **next:** structured JSONL run-log for cross-run success-rate/eval; live per-loop token budget + kill
+  switch; escalation ping on unattended stop (loop-engineering Token Burn / Escalation Failure).

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2110,3 +2110,20 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
   shows the scoreboard+tables, not Mermaid (charts live in the on-disk record by design).
 - **next:** structured JSONL run-log for cross-run success-rate/eval; live per-loop token budget + kill
   switch; escalation ping on unattended stop (loop-engineering Token Burn / Escalation Failure).
+
+---
+**P-GOAL.10 — cross-run evaluation: the /goal run-log + stats surface (ADR-0055)**
+- **shipped:** every completed /goal run now appends one compact JSON line to `.omp/loops/run-log.jsonl`
+  (best-effort, path-confined, written in runGoal's finally beside the AAR). New PURE `desktop/loop_runlog.ts`
+  (unit-tested) projects a P-GOAL.9 LoopMetrics → record, round-trips JSONL (malformed lines skipped), and
+  `aggregateRuns` computes the eval stats: success rate, avg iterations-to-success (over met runs), avg
+  duration, summed tools/LOC/errors, and a failure breakdown that collapses recurring blockers via
+  stallSignature. Surfaced via backend `loopRunStats()` → `GET /api/goal/stats` → a compact evaluation
+  banner in the /goal launcher (hidden until there's history). Flat JSONL by design — stays in the
+  goal-memory lane, never touches the frozen DuckDB schema (invariant #10). bun test desktop 158 pass
+  (+11 new); `make demo-P-GOAL.10` green; typecheck clean across all 3 desktop/root tsconfigs (verified
+  after installing the container's missing bun/node type stubs, then reverting the manifest).
+- **stubbed:** the launcher shows aggregate stats + a 10-run recent slice from the API but no deep
+  per-run history drill-down UI yet (records carry enough to build it without a migration).
+- **next:** live per-loop token budget + kill switch; escalation ping on unattended stop (loop-engineering
+  Token Burn / Escalation Failure) — both can read/append this same ledger.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2127,3 +2127,20 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
   per-run history drill-down UI yet (records carry enough to build it without a migration).
 - **next:** live per-loop token budget + kill switch; escalation ping on unattended stop (loop-engineering
   Token Burn / Escalation Failure) — both can read/append this same ledger.
+
+---
+**P-GOAL.11 — live spend meter + budget kill switch (ADR-0056)**
+- **shipped:** the /goal loop now meters ACTUAL spend and enforces an optional hard dollar cap (loop-
+  engineering "Token Burn" kill switch). New PURE `desktop/loop_budget.ts` (unit-tested) sums each maker
+  turn's peak cost (context tokens tracked as a high-water mark, never summed) and `overBudget` trips the
+  switch. runGoal aborts the in-flight turn the instant running spend crosses the cap, then ends the loop
+  "budget cap $X reached" before wasting a checker call. Spend flows through everything the metrics already
+  touch: LoopMetrics gains spendUsd/peakContextTokens/budgetUsd (null when no usage telemetry, not $0); the
+  After-Action Report shows a Spend row; the run-log + cross-run eval sum actual spend; a "Budget cap" field
+  sits beside Max iterations in the launcher (plumbed via GoalOpts → /api/goal → runGoal). bun test desktop
+  195 pass / 0 fail (+10 new); make demo-P-GOAL.{9,10,11} green; typecheck clean across all 3 tsconfigs.
+- **stubbed:** scheduled automations run uncapped for now (the iteration cap still bounds them) — a budget
+  field on the Automation schema/form is the clean follow-on; the meter measures MAKER spend (checker runs
+  in a separate throwaway session, cheap by ADR-0048 design).
+- **next:** escalation ping on unattended stop (loop-engineering Escalation Failure) — the last follow-on;
+  then a budget field for automations.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2144,3 +2144,24 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
   in a separate throwaway session, cheap by ADR-0048 design).
 - **next:** escalation ping on unattended stop (loop-engineering Escalation Failure) — the last follow-on;
   then a budget field for automations.
+
+---
+**P-GOAL.12 — the Pre-Flight Audit: loop design + readiness before you build (ADR-0057)**
+- **shipped:** an optional "Pre-Flight Audit" button above the Goal input that pauses the builder and
+  designs the loop first. New PURE `desktop/loop_preflight.ts` (unit-tested): `assessReadiness` scores the
+  spec L0→L3 with GATED levels (L3 needs the safety-bearing four — verify command, budget, scope, cheap
+  checker — so a verbose goal can't buy L3 without a real verifier); `renderLoopDesign` emits a repeatable
+  Loop Design .md; history awareness (`relevantPriorRuns`/`renderPriorRuns`) surfaces prior runs of a similar
+  loop so context isn't lost; a prompt-engineering interview (`preflight*Prompt`/`parsePreflightJson`/
+  `mergeMatured`) matures the goal with user/PO + engineer feedback; `successCriteria` distills the checker's
+  grading rubric. Backend `preflightAudit` reads the run-log, runs ONE interview pass on the cheap checker
+  (best-effort, deterministic fallback), writes `.omp/loops/*.preflight.md`, returns matured goal + criteria;
+  `loopScopes` lists branches/worktrees. The checker (`runGoal`/`checkGoal`) now grades against the matured
+  `criteria` and reports which are met/unmet — closing the recursive self-improvement loop (AAR/run-log →
+  preflight → run → AAR). UI: scope picker + interview panel + readiness chip + rendered report + "Adopt as
+  goal". bun test desktop 216 pass / 0 fail (+21); make demo-P-GOAL.12 green; typecheck clean across all 3
+  tsconfigs (verified with electron/node/bun types installed, manifest reverted).
+- **stubbed:** the interview is one structured maturation pass (not open-ended multi-turn); adopting carries
+  criteria to the immediate next run only; automations still don't take a budget/criteria.
+- **next:** escalation ping on unattended stop; a budget + criteria field for scheduled automations; an
+  optional multi-turn interview.

--- a/README.md
+++ b/README.md
@@ -148,6 +148,15 @@ never fail open.
   in minutes, with a token/runtime estimate before any model call.
 - **✍️ A read-write IDE where _Save_ is gated.** Edit code in an embedded editor and save it back through the
   *same* in-process scanner - a hidden-Unicode payload is **blocked before a single byte lands on disk**.
+- **🔁 Loop engineering, not just a loop.** The `/goal` primitive iterates an agent to a **verifiable** stop
+  condition with a **separate, cheaper checker model**, durable on-disk memory, and resume - then adds the
+  operational spine unattended loops actually need: a **budget kill switch** (a hard `$` ceiling that aborts
+  the run mid-turn before the bill runs away), **convergence-stall + tool-failure guards** that stop a loop
+  spinning on the same blocker, an **After-Action Report** (portable Mermaid graphs of tool calls, LOC,
+  errors, and sites visited - rendered straight on GitHub/VS Code), and a **cross-run evaluation ledger**
+  (success rate, avg iterations-to-win, failure breakdown). Inspired by the
+  [loop-engineering](https://github.com/cobusgreyling/loop-engineering) playbook; every action still passes
+  the fail-closed gate.
 - **💰 Cross-model cost tracking & showback.** Real-time per-model token usage, cache savings, and estimated
   cost with a built-in showback ledger - know exactly what every conversation costs.
 
@@ -407,7 +416,8 @@ the full security lifecycle, provenance lineage, replay, the cache-optimized pre
 AskSage gov gateway, cross-model observability, CUI isolation, the encrypted personalization graph with
 cross-session recall, AI-authorship attribution, one-command ChatGPT/Claude/Gemini migration, and a
 read-write IDE with gated saves, AskSage **tool use on the gov gateway** (Claude *and* Gemini), and the
-**`/goal` agentic loop primitive**. Everything green:
+**`/goal` agentic loop** with full loop-engineering instrumentation - After-Action Reports, a budget kill
+switch, convergence/tool-failure guards, and a cross-run evaluation ledger. Everything green:
 **473 harness tests**, **326 desktop tests**, **55 sidecar tests**, `tsc --noEmit` clean across 3 projects
 (TypeScript 6.0 + Python).
 
@@ -415,6 +425,7 @@ read-write IDE with gated saves, AskSage **tool use on the gov gateway** (Claude
 
 | Phase | Feature | ADR |
 |:--|:--|:--|
+| **P-GOAL.9-11** | **Loop engineering** for the `/goal` loop - an **After-Action Report** (Mermaid graphs: tool calls by type, LOC ±, errors, sites visited), **convergence-stall + tool-failure guards**, a **cross-run evaluation ledger** (success rate / avg iterations-to-win / failure breakdown), and a **budget kill switch** (a hard `$` cap that aborts an unattended run mid-turn) | [ADR-0054-0056](DECISIONS.md) |
 | **P-GOAL.1-8** | The **`/goal` agentic loop** - iterate to a verifiable stop condition with a separate (cheaper, recommended) checker model, durable on-disk memory, resume, scheduled automations, a cost estimate, and a guided walkthrough | [ADR-0046-0050](DECISIONS.md) |
 | **AskSage tool use** | Claude **and** Gemini routed through the **gov gateway can now use omp tools** (write files, run commands) - the streamSimple adapter parses tool calls + scans each through the gate | [ADR-0051](DECISIONS.md) |
 | **P-IDE.5-6** | Read-write Monaco IDE - **Save routed through the scanner gate** (≥high finding or dead scanner *blocks* the write), Save-As, conflict banner, Send-to-chat | [ADR-0036/0037](DECISIONS.md) |

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -74,6 +74,16 @@ native-only bits are crisp text zoom (`webFrame`) and window controls, from
   the composer to run.
 - **Live telemetry** — the status bar's context gauge + cost update from the
   session's `usage_update` stream.
+- **`/goal` agentic loop** — run an agent to a *verifiable* stop condition (a
+  shell command that exits 0, or a separate checker model's judgement) with a
+  cheaper recommended checker, durable on-disk memory + resume, and scheduled
+  automations. Built for unattended runs: a **budget kill switch** halts the loop
+  at a hard `$` cap, **convergence-stall + tool-failure guards** stop it spinning
+  on the same blocker, each run ends with an **After-Action Report** (Mermaid
+  graphs of tool calls, LOC ±, errors, and sites visited, written to
+  `.omp/loops/*.report.md`), and a **cross-run ledger** (`.omp/loops/run-log.jsonl`)
+  tracks success rate and failure breakdown across runs. Every action is still
+  scanned by the fail-closed gate.
 
 ## AskSage gov gateway (ADR-0007)
 

--- a/desktop/acp_backend.ts
+++ b/desktop/acp_backend.ts
@@ -24,6 +24,8 @@ import { parseGoalVerdict } from "./goal_verdict.ts";
 import { appendGoalIteration, appendRunLog, finishGoalMemory, type GoalMemory, readRunLog, resumeGoalMemory, saveGoalReport, startGoalMemory } from "./goal_memory.ts";
 import { extractUrls, type IterStat, type LocStat, type LoopMetrics, type LoopOutcome, normalizeToolName, parseNumstat, renderLoopReport, stallSignature, summarizeLoop } from "./loop_report.ts";
 import { aggregateRuns, type LoopRunRecord, type RunStats, summarizeRunStats, toRunRecord } from "./loop_runlog.ts";
+import { addTurnSpend, type LoopSpend, newLoopSpend, normalizeBudget, overBudget } from "./loop_budget.ts";
+import { formatSpend } from "./loop_report.ts";
 import { execFileSync } from "node:child_process";
 import { type Automation, listAutomations, nextDueAutomation, updateAutomation } from "./automations.ts";
 
@@ -410,11 +412,12 @@ class Backend {
   // when given). Capped at `maxIters`, auto-stops on no-progress. Runs UNATTENDED — permissions are
   // auto-approved for the duration, but every tool call is still scanned fail-closed by the in-process
   // gate (that, not human approval, is the safety boundary). Streams the usual chat events plus goal-*.
-  async runGoal(opts: { goal: string; condition: string; command?: string; maxIters: number; resume?: string }, onEvent: (e: ChatEvent) => void): Promise<void> {
+  async runGoal(opts: { goal: string; condition: string; command?: string; maxIters: number; resume?: string; budgetUsd?: number }, onEvent: (e: ChatEvent) => void): Promise<void> {
     const goal = opts.goal.trim();
     const condition = (opts.condition || opts.command || "the goal is fully accomplished").trim();
     const command = opts.command?.trim() || "";
     const maxIters = Math.min(Math.max(1, Math.floor(opts.maxIters) || 6), 20); // hard ceiling
+    const budgetUsd = normalizeBudget(opts.budgetUsd); // P-GOAL.11: 0 = no cap (iteration cap stays the ceiling)
     const prevMode = this.permissionMode;
     this.permissionMode = "auto"; // unattended: auto-approve tool calls (the gate still scans every one)
     this.goalActive = true; this.goalCancelled = false;
@@ -448,6 +451,10 @@ class Backend {
     let lastSig = "";       // P-GOAL.9 (#2 Infinite Fix Loop): the prior round's blocker signature
     let stallCount = 0;     // consecutive rounds stuck on the SAME blocker
     let lastIterErrors = 0; // P-GOAL.9 (#3): tool failures last round, fed back into the next prompt
+    // P-GOAL.11 (ADR-0056): live spend + budget kill switch. We own the turn boundaries, so spend is
+    // just the sum of each maker turn's PEAK cost; context tokens are tracked as a peak, never summed.
+    let spend: LoopSpend = newLoopSpend();
+    let sawUsage = false;   // false ⇒ no usage telemetry at all ⇒ report spend as "unknown", not "$0"
     try {
       for (let i = 1; i <= maxIters; i++) {
         if (this.goalCancelled) { terminalOutcome = "cancelled"; terminalReason = "stopped by you"; onEvent({ type: "goal-stop", reason: terminalReason }); finishGoalMemory(mem, terminalReason); return; }
@@ -455,6 +462,7 @@ class Backend {
         let work = "";
         let actedThisIter = false;
         let iterTools = 0, iterErrors = 0;
+        let turnPeakCost = 0, turnPeakCtx = 0, budgetHit = false;
         // Forward the maker's stream, but swallow the per-iteration `done` so the client sees ONE loop.
         const sink = (e: ChatEvent) => {
           if (e.type === "done") return;
@@ -462,6 +470,13 @@ class Backend {
           if (e.type === "tool") { actedThisIter = true; iterTools++; const t = normalizeToolName(e.name); toolCalls[t] = (toolCalls[t] ?? 0) + 1; for (const u of extractUrls(e.detail)) websites.add(u); }
           else if (e.type === "subagent") { actedThisIter = true; iterTools++; toolCalls.subagent = (toolCalls.subagent ?? 0) + 1; }
           else if (e.type === "block") { iterErrors++; errors.push({ iter: i, detail: `${e.tool}: ${e.reason}`.slice(0, 200) }); }
+          else if (e.type === "usage") {
+            sawUsage = true;
+            turnPeakCost = Math.max(turnPeakCost, e.cost);
+            turnPeakCtx = Math.max(turnPeakCtx, e.used);
+            // P-GOAL.11 kill switch: abort THIS turn the instant running spend crosses the cap.
+            if (!budgetHit && overBudget(spend.usd + turnPeakCost, budgetUsd)) { budgetHit = true; this.cancel(); }
+          }
           onEvent(e);
         };
         // P-GOAL.9 (#3): when the previous round had failed/blocked tool calls, tell the maker so it
@@ -473,7 +488,15 @@ class Backend {
         await this.prompt(iterText, sink);
         for (const u of extractUrls(work)) websites.add(u); // links the maker mentioned in its own text
         lastIterErrors = iterErrors;
+        spend = addTurnSpend(spend, turnPeakCost, turnPeakCtx); // P-GOAL.11: fold this turn's peak into the running spend
         if (this.goalCancelled) { perIteration.push({ n: i, tools: iterTools, errors: iterErrors, done: false, reason: "cancelled" }); terminalOutcome = "cancelled"; terminalReason = "stopped by you"; onEvent({ type: "goal-stop", reason: terminalReason }); finishGoalMemory(mem, terminalReason); return; }
+        // P-GOAL.11 (ADR-0056): budget kill switch — once spend crosses the cap, stop the loop (the
+        // current turn was already aborted mid-stream above). The bill can't run away unattended.
+        if (overBudget(spend.usd, budgetUsd)) {
+          perIteration.push({ n: i, tools: iterTools, errors: iterErrors, done: false, reason: `budget cap ${formatSpend(budgetUsd)} reached` });
+          terminalReason = `stopped: budget cap ${formatSpend(budgetUsd)} reached (spent ${formatSpend(spend.usd)})`;
+          onEvent({ type: "goal-stop", reason: terminalReason }); finishGoalMemory(mem, terminalReason); return;
+        }
 
         const verdict = await this.checkGoal({ goal, condition, command, lastWork: work });
         onEvent({ type: "goal-check", n: i, done: verdict.done, reason: verdict.reason });
@@ -514,6 +537,10 @@ class Backend {
           outcome: terminalOutcome, outcomeReason: terminalReason || "(no reason recorded)",
           iterations: perIteration.length, maxIters, durationMs: Date.now() - startedAt,
           toolCalls, loc, errors, websites: [...websites], perIteration,
+          // P-GOAL.11: actual spend (null when no usage telemetry was seen) + the cap that was in force.
+          spendUsd: sawUsage ? spend.usd : null,
+          peakContextTokens: sawUsage ? spend.peakContextTokens : null,
+          budgetUsd: budgetUsd || undefined,
         };
         const markdown = renderLoopReport(metrics);
         const path = saveGoalReport(currentWorkspace(), loopId, goal, markdown) ?? "";

--- a/desktop/acp_backend.ts
+++ b/desktop/acp_backend.ts
@@ -21,8 +21,9 @@ import { asksageOnly, attribution, checkerModel, lastModel, mcpServersForAcp, se
 import { managedConfig } from "./managed_config.ts";
 import { recommendCheckerModel, resolveCheckerModel, type ModelOption } from "./checker_model.ts";
 import { parseGoalVerdict } from "./goal_verdict.ts";
-import { appendGoalIteration, finishGoalMemory, type GoalMemory, resumeGoalMemory, saveGoalReport, startGoalMemory } from "./goal_memory.ts";
+import { appendGoalIteration, appendRunLog, finishGoalMemory, type GoalMemory, readRunLog, resumeGoalMemory, saveGoalReport, startGoalMemory } from "./goal_memory.ts";
 import { extractUrls, type IterStat, type LocStat, type LoopMetrics, type LoopOutcome, normalizeToolName, parseNumstat, renderLoopReport, stallSignature, summarizeLoop } from "./loop_report.ts";
+import { aggregateRuns, type LoopRunRecord, type RunStats, summarizeRunStats, toRunRecord } from "./loop_runlog.ts";
 import { execFileSync } from "node:child_process";
 import { type Automation, listAutomations, nextDueAutomation, updateAutomation } from "./automations.ts";
 
@@ -517,6 +518,8 @@ class Backend {
         const markdown = renderLoopReport(metrics);
         const path = saveGoalReport(currentWorkspace(), loopId, goal, markdown) ?? "";
         if (mem && path) { try { finishGoalMemory(mem, `After-Action Report: ${path}`); } catch { /* best-effort */ } }
+        // P-GOAL.10: append this run to the cross-run evaluation ledger (best-effort).
+        try { appendRunLog(currentWorkspace(), toRunRecord(metrics, { id: loopId, ts: Date.now() })); } catch { /* best-effort */ }
         onEvent({ type: "goal-report", path, summary: summarizeLoop(metrics), markdown });
       } catch { /* the report never blocks the loop's completion */ }
       onEvent({ type: "done" });
@@ -541,6 +544,14 @@ class Backend {
   cancelGoal(): void { if (this.goalActive) { this.goalCancelled = true; this.cancel(); } }
   /** Whether a /goal loop is currently running (so the UI routes Stop to cancelGoal, not cancelChat). */
   isGoalRunning(): boolean { return this.goalActive; }
+
+  /** P-GOAL.10 (ADR-0055): the cross-run evaluation surface — aggregate stats over the run-log plus the
+   *  most-recent runs for a compact history view. Reads the workspace's `.omp/loops/run-log.jsonl`. */
+  loopRunStats(limit = 10): { stats: RunStats; summary: string; recent: LoopRunRecord[] } {
+    const records = readRunLog(currentWorkspace());
+    const stats = aggregateRuns(records);
+    return { stats, summary: summarizeRunStats(stats), recent: records.slice(0, Math.max(0, limit)) };
+  }
 
   // P-GOAL.5 (ADR-0047): the automation scheduler. Arm a timer that, while the app is open, fires the
   // first DUE automation through runGoal — same maker/checker loop, same fail-closed gate, same durable

--- a/desktop/acp_backend.ts
+++ b/desktop/acp_backend.ts
@@ -21,7 +21,9 @@ import { asksageOnly, attribution, checkerModel, lastModel, mcpServersForAcp, se
 import { managedConfig } from "./managed_config.ts";
 import { recommendCheckerModel, resolveCheckerModel, type ModelOption } from "./checker_model.ts";
 import { parseGoalVerdict } from "./goal_verdict.ts";
-import { appendGoalIteration, finishGoalMemory, type GoalMemory, resumeGoalMemory, startGoalMemory } from "./goal_memory.ts";
+import { appendGoalIteration, finishGoalMemory, type GoalMemory, resumeGoalMemory, saveGoalReport, startGoalMemory } from "./goal_memory.ts";
+import { extractUrls, type IterStat, type LocStat, type LoopMetrics, type LoopOutcome, normalizeToolName, parseNumstat, renderLoopReport, stallSignature, summarizeLoop } from "./loop_report.ts";
+import { execFileSync } from "node:child_process";
 import { type Automation, listAutomations, nextDueAutomation, updateAutomation } from "./automations.ts";
 
 const REPO = join(import.meta.dir, "..");
@@ -58,6 +60,8 @@ export type ChatEvent =
   | { type: "goal-check"; n: number; done: boolean; reason: string }
   | { type: "goal-done"; iters: number; reason: string }
   | { type: "goal-stop"; reason: string }
+  // P-GOAL.9 (ADR-0054): the loop's last task — an After-Action Report (metrics + portable graphs).
+  | { type: "goal-report"; path: string; summary: string; markdown: string }
   | { type: "done" };
 
 class Backend {
@@ -416,49 +420,120 @@ class Backend {
     // P-GOAL.3/4: durable on-disk memory (best-effort). `resume` continues an existing loop-memory file
     // and injects its prior progress; otherwise start a fresh record.
     const resumed = opts.resume ? resumeGoalMemory(currentWorkspace(), opts.resume) : null;
-    const mem: GoalMemory | null = resumed ? resumed.mem : startGoalMemory(currentWorkspace(), Date.now().toString(36), { goal, condition, command });
+    // P-GOAL.9: a stable id shared by the memory file and the After-Action Report (same `<id>-<slug>`
+    // stem). When resuming, reuse the existing file's id so the report lands beside it.
+    const loopId = resumed ? (resumed.mem.rel.split("/").pop()?.split("-")[0] || Date.now().toString(36)) : Date.now().toString(36);
+    const mem: GoalMemory | null = resumed ? resumed.mem : startGoalMemory(currentWorkspace(), loopId, { goal, condition, command });
     if (mem) onEvent({ type: "goal-memory", path: mem.rel });
     const memNote = mem ? ` Your durable progress memory is the file ${mem.rel} (it records what's done across iterations).` : "";
-    const resumeNote = resumed ? `\n\nThis loop was already in progress. Below is the progress so far — do NOT redo completed work, continue from where it stopped:\n${resumed.prior.slice(0, 3000)}` : "";
+    // P-GOAL.9 fix: inject the TAIL of the prior progress (the most-recent iterations), not the head —
+    // a long resumed loop must see what it just did, not the stale opening rounds.
+    const resumeNote = resumed ? `\n\nThis loop was already in progress. Below is the most recent progress — do NOT redo completed work, continue from where it stopped:\n${resumed.prior.slice(-3000)}` : "";
+
+    // ── P-GOAL.9 (ADR-0054): run-time instrumentation feeding the After-Action Report ──────────────
+    const startedAt = Date.now();
+    const toolCalls: Record<string, number> = {};
+    const errors: { iter: number; detail: string }[] = [];
+    const websites = new Set<string>();
+    const perIteration: IterStat[] = [];
+    // LOC: pin a baseline COMMIT now; at the end, diff the tree against it (captures committed-since +
+    // uncommitted) and subtract any changes that were already present at start. Best-effort, git-only.
+    const startRef = this.gitHead();
+    const startDiff = startRef ? this.gitDiffVs(startRef) : null;
+    let terminalOutcome: LoopOutcome = "stopped";
+    let terminalReason = `stopped: hit the ${maxIters}-iteration cap without meeting the condition`;
+
     let noProgress = 0;
+    let lastSig = "";       // P-GOAL.9 (#2 Infinite Fix Loop): the prior round's blocker signature
+    let stallCount = 0;     // consecutive rounds stuck on the SAME blocker
+    let lastIterErrors = 0; // P-GOAL.9 (#3): tool failures last round, fed back into the next prompt
     try {
       for (let i = 1; i <= maxIters; i++) {
-        if (this.goalCancelled) { onEvent({ type: "goal-stop", reason: "stopped by you" }); finishGoalMemory(mem, "stopped by you"); return; }
+        if (this.goalCancelled) { terminalOutcome = "cancelled"; terminalReason = "stopped by you"; onEvent({ type: "goal-stop", reason: terminalReason }); finishGoalMemory(mem, terminalReason); return; }
         onEvent({ type: "goal-iter", n: i, max: maxIters });
         let work = "";
         let actedThisIter = false;
+        let iterTools = 0, iterErrors = 0;
         // Forward the maker's stream, but swallow the per-iteration `done` so the client sees ONE loop.
         const sink = (e: ChatEvent) => {
           if (e.type === "done") return;
           if (e.type === "token") work += e.text;
-          if (e.type === "tool" || e.type === "subagent") actedThisIter = true;
+          if (e.type === "tool") { actedThisIter = true; iterTools++; const t = normalizeToolName(e.name); toolCalls[t] = (toolCalls[t] ?? 0) + 1; for (const u of extractUrls(e.detail)) websites.add(u); }
+          else if (e.type === "subagent") { actedThisIter = true; iterTools++; toolCalls.subagent = (toolCalls.subagent ?? 0) + 1; }
+          else if (e.type === "block") { iterErrors++; errors.push({ iter: i, detail: `${e.tool}: ${e.reason}`.slice(0, 200) }); }
           onEvent(e);
         };
+        // P-GOAL.9 (#3): when the previous round had failed/blocked tool calls, tell the maker so it
+        // changes approach instead of re-issuing the same failing call.
+        const failNote = lastIterErrors > 0 ? ` Note: ${lastIterErrors} tool call${lastIterErrors === 1 ? "" : "s"} failed or were blocked last round — fix the cause (paths, permissions, syntax) rather than repeating them.` : "";
         const iterText = i === 1
           ? `${goal}\n\nWork toward this goal now. The stop condition is: ${condition}${command ? ` (verified by running \`${command}\`)` : ""}. Take the next concrete step.${memNote}${resumeNote}`
-          : `Continue toward the goal. Stop condition: ${condition}. Take the next concrete step; if you believe the condition now holds, say so briefly and stop.${memNote}`;
+          : `Continue toward the goal. Stop condition: ${condition}. Take the next concrete step; if you believe the condition now holds, say so briefly and stop.${memNote}${failNote}`;
         await this.prompt(iterText, sink);
-        if (this.goalCancelled) { onEvent({ type: "goal-stop", reason: "stopped by you" }); finishGoalMemory(mem, "stopped by you"); return; }
+        for (const u of extractUrls(work)) websites.add(u); // links the maker mentioned in its own text
+        lastIterErrors = iterErrors;
+        if (this.goalCancelled) { perIteration.push({ n: i, tools: iterTools, errors: iterErrors, done: false, reason: "cancelled" }); terminalOutcome = "cancelled"; terminalReason = "stopped by you"; onEvent({ type: "goal-stop", reason: terminalReason }); finishGoalMemory(mem, terminalReason); return; }
 
         const verdict = await this.checkGoal({ goal, condition, command, lastWork: work });
         onEvent({ type: "goal-check", n: i, done: verdict.done, reason: verdict.reason });
         appendGoalIteration(mem, i, work, verdict);
-        if (verdict.done) { onEvent({ type: "goal-done", iters: i, reason: verdict.reason }); finishGoalMemory(mem, `Goal met in ${i} iteration${i === 1 ? "" : "s"}: ${verdict.reason}`); return; }
+        perIteration.push({ n: i, tools: iterTools, errors: iterErrors, done: verdict.done, reason: verdict.reason });
+        if (verdict.done) { terminalOutcome = "met"; terminalReason = verdict.reason; onEvent({ type: "goal-done", iters: i, reason: verdict.reason }); finishGoalMemory(mem, `Goal met in ${i} iteration${i === 1 ? "" : "s"}: ${verdict.reason}`); return; }
+
+        // P-GOAL.9 (#2): if the checker reports the SAME blocker three rounds running, the loop is not
+        // converging — stop and surface it rather than burning iterations on an unbreakable wall.
+        const sig = stallSignature(verdict.reason);
+        stallCount = sig && sig === lastSig ? stallCount + 1 : 1;
+        lastSig = sig;
+        if (stallCount >= 3) { terminalReason = `stopped: not converging — the same blocker held for ${stallCount} rounds (${verdict.reason})`; onEvent({ type: "goal-stop", reason: terminalReason }); finishGoalMemory(mem, terminalReason); return; }
 
         noProgress = actedThisIter ? 0 : noProgress + 1;
-        if (noProgress >= 2) { onEvent({ type: "goal-stop", reason: "stopped: two iterations with no actions and the condition still unmet" }); finishGoalMemory(mem, "stopped: no progress for two iterations"); return; }
+        if (noProgress >= 2) { terminalReason = "stopped: two iterations with no actions and the condition still unmet"; onEvent({ type: "goal-stop", reason: terminalReason }); finishGoalMemory(mem, "stopped: no progress for two iterations"); return; }
       }
-      onEvent({ type: "goal-stop", reason: `stopped: hit the ${maxIters}-iteration cap without meeting the condition` });
-      finishGoalMemory(mem, `stopped: hit the ${maxIters}-iteration cap without meeting the condition`);
+      onEvent({ type: "goal-stop", reason: terminalReason });
+      finishGoalMemory(mem, terminalReason);
     } catch (e) {
-      const reason = `loop error: ${String((e as Error)?.message ?? e)}`;
-      onEvent({ type: "goal-stop", reason });
-      finishGoalMemory(mem, reason);
+      terminalOutcome = "error";
+      terminalReason = `loop error: ${String((e as Error)?.message ?? e)}`;
+      onEvent({ type: "goal-stop", reason: terminalReason });
+      finishGoalMemory(mem, terminalReason);
     } finally {
       this.goalActive = false;
       this.permissionMode = prevMode;
+      // P-GOAL.9: the loop's LAST task — assemble metrics + render the After-Action Report. Wholly
+      // best-effort: a failure here is swallowed so the turn always settles with `done`.
+      try {
+        let loc: LocStat | null = null;
+        if (startRef) {
+          const end = this.gitDiffVs(startRef);
+          if (end) loc = { added: Math.max(0, end.added - (startDiff?.added ?? 0)), removed: Math.max(0, end.removed - (startDiff?.removed ?? 0)), files: end.files };
+        }
+        const metrics: LoopMetrics = {
+          goal, condition, command: command || undefined,
+          outcome: terminalOutcome, outcomeReason: terminalReason || "(no reason recorded)",
+          iterations: perIteration.length, maxIters, durationMs: Date.now() - startedAt,
+          toolCalls, loc, errors, websites: [...websites], perIteration,
+        };
+        const markdown = renderLoopReport(metrics);
+        const path = saveGoalReport(currentWorkspace(), loopId, goal, markdown) ?? "";
+        if (mem && path) { try { finishGoalMemory(mem, `After-Action Report: ${path}`); } catch { /* best-effort */ } }
+        onEvent({ type: "goal-report", path, summary: summarizeLoop(metrics), markdown });
+      } catch { /* the report never blocks the loop's completion */ }
       onEvent({ type: "done" });
     }
+  }
+
+  /** P-GOAL.9: the current HEAD commit, or null when the workspace isn't a git repo / git is absent.
+   *  Best-effort and quick (5s cap); a missing baseline just means the report shows "LOC n/a". */
+  private gitHead(): string | null {
+    try { return execFileSync("git", ["rev-parse", "HEAD"], { cwd: currentWorkspace(), encoding: "utf8", timeout: 5_000, stdio: ["ignore", "pipe", "ignore"] }).trim() || null; }
+    catch { return null; }
+  }
+  /** P-GOAL.9: parsed `git diff --numstat <ref>` for the working tree vs `ref` (tracked changes,
+   *  staged + unstaged + committed-since). Null on any git failure — LOC tracking is best-effort. */
+  private gitDiffVs(ref: string): LocStat | null {
+    try { return parseNumstat(execFileSync("git", ["diff", "--numstat", ref], { cwd: currentWorkspace(), encoding: "utf8", timeout: 5_000, maxBuffer: 4 * 1024 * 1024, stdio: ["ignore", "pipe", "ignore"] })); }
+    catch { return null; }
   }
 
   /** P-GOAL.2: stop a running /goal loop — aborts the current maker turn and halts further iterations.

--- a/desktop/acp_backend.ts
+++ b/desktop/acp_backend.ts
@@ -21,11 +21,12 @@ import { asksageOnly, attribution, checkerModel, lastModel, mcpServersForAcp, se
 import { managedConfig } from "./managed_config.ts";
 import { recommendCheckerModel, resolveCheckerModel, type ModelOption } from "./checker_model.ts";
 import { parseGoalVerdict } from "./goal_verdict.ts";
-import { appendGoalIteration, appendRunLog, finishGoalMemory, type GoalMemory, readRunLog, resumeGoalMemory, saveGoalReport, startGoalMemory } from "./goal_memory.ts";
+import { appendGoalIteration, appendRunLog, finishGoalMemory, type GoalMemory, readRunLog, resumeGoalMemory, saveGoalReport, savePreflightReport, startGoalMemory } from "./goal_memory.ts";
 import { extractUrls, type IterStat, type LocStat, type LoopMetrics, type LoopOutcome, normalizeToolName, parseNumstat, renderLoopReport, stallSignature, summarizeLoop } from "./loop_report.ts";
 import { aggregateRuns, type LoopRunRecord, type RunStats, summarizeRunStats, toRunRecord } from "./loop_runlog.ts";
 import { addTurnSpend, type LoopSpend, newLoopSpend, normalizeBudget, overBudget } from "./loop_budget.ts";
 import { formatSpend } from "./loop_report.ts";
+import { assessReadiness, maturedGoalFrom, mergeMatured, parsePreflightJson, type PreflightSpec, preflightSystemPrompt, preflightUserPrompt, type ReadinessReport, relevantPriorRuns, renderLoopDesign, successCriteria, summarizePriorRuns } from "./loop_preflight.ts";
 import { execFileSync } from "node:child_process";
 import { type Automation, listAutomations, nextDueAutomation, updateAutomation } from "./automations.ts";
 
@@ -412,10 +413,11 @@ class Backend {
   // when given). Capped at `maxIters`, auto-stops on no-progress. Runs UNATTENDED — permissions are
   // auto-approved for the duration, but every tool call is still scanned fail-closed by the in-process
   // gate (that, not human approval, is the safety boundary). Streams the usual chat events plus goal-*.
-  async runGoal(opts: { goal: string; condition: string; command?: string; maxIters: number; resume?: string; budgetUsd?: number }, onEvent: (e: ChatEvent) => void): Promise<void> {
+  async runGoal(opts: { goal: string; condition: string; command?: string; maxIters: number; resume?: string; budgetUsd?: number; criteria?: string }, onEvent: (e: ChatEvent) => void): Promise<void> {
     const goal = opts.goal.trim();
     const condition = (opts.condition || opts.command || "the goal is fully accomplished").trim();
     const command = opts.command?.trim() || "";
+    const criteria = opts.criteria?.trim() || ""; // P-GOAL.12: matured success criteria for the checker
     const maxIters = Math.min(Math.max(1, Math.floor(opts.maxIters) || 6), 20); // hard ceiling
     const budgetUsd = normalizeBudget(opts.budgetUsd); // P-GOAL.11: 0 = no cap (iteration cap stays the ceiling)
     const prevMode = this.permissionMode;
@@ -498,7 +500,7 @@ class Backend {
           onEvent({ type: "goal-stop", reason: terminalReason }); finishGoalMemory(mem, terminalReason); return;
         }
 
-        const verdict = await this.checkGoal({ goal, condition, command, lastWork: work });
+        const verdict = await this.checkGoal({ goal, condition, command, lastWork: work, criteria });
         onEvent({ type: "goal-check", n: i, done: verdict.done, reason: verdict.reason });
         appendGoalIteration(mem, i, work, verdict);
         perIteration.push({ n: i, tools: iterTools, errors: iterErrors, done: verdict.done, reason: verdict.reason });
@@ -578,6 +580,43 @@ class Backend {
     const records = readRunLog(currentWorkspace());
     const stats = aggregateRuns(records);
     return { stats, summary: summarizeRunStats(stats), recent: records.slice(0, Math.max(0, limit)) };
+  }
+
+  /** P-GOAL.12 (ADR-0057): the branches + worktrees the Pre-Flight Audit offers as loop scope. Best-effort. */
+  private gitLines(args: string[]): string[] {
+    try { return execFileSync("git", args, { cwd: currentWorkspace(), encoding: "utf8", timeout: 5_000, maxBuffer: 2 * 1024 * 1024, stdio: ["ignore", "pipe", "ignore"] }).split("\n").map((s) => s.trim()).filter(Boolean); }
+    catch { return []; }
+  }
+  loopScopes(): { current: string; branches: string[]; worktrees: string[] } {
+    const current = this.gitLines(["rev-parse", "--abbrev-ref", "HEAD"])[0] ?? "";
+    const branches = this.gitLines(["branch", "--format=%(refname:short)"]);
+    const worktrees = this.gitLines(["worktree", "list", "--porcelain"]).filter((l) => l.startsWith("worktree ")).map((l) => l.slice(9).trim());
+    return { current, branches, worktrees };
+  }
+
+  /** P-GOAL.12 (ADR-0057): the Pre-Flight Audit. Reads prior-run history (so the new loop carries past
+   *  context, not re-solving old blockers), runs ONE prompt-engineering interview pass on the cheap checker
+   *  model to mature the goal (best-effort; falls back to the user's structured answers), scores readiness
+   *  against the rubric, and writes a durable Loop Design report. Returns the matured goal to adopt + the
+   *  report. Never mutates the loop or the session — it's a planning step. */
+  async preflightAudit(spec: PreflightSpec): Promise<{ maturedGoal: string; criteria: string; reportMd: string; reportPath: string; readiness: ReadinessReport; prior: { total: number; relevant: number } }> {
+    const ws = currentWorkspace();
+    const records = readRunLog(ws);                                  // history awareness
+    const relevant = relevantPriorRuns(records, spec.goal, 3);
+    let matured: PreflightSpec = spec;
+    let maturedGoal = "";
+    try {
+      const model = resolveCheckerModel({ chosen: checkerModel(), models: this.accessibleModels(), current: this.activeModel() }).value;
+      const out = await this.complete(preflightSystemPrompt(), preflightUserPrompt(spec, summarizePriorRuns(relevant)), { idleMs: 90_000, model });
+      const fields = parsePreflightJson(out);
+      matured = mergeMatured(spec, fields);
+      maturedGoal = fields.maturedGoal || "";
+    } catch { /* model unavailable — fall back to the user's structured answers */ }
+    if (!maturedGoal) maturedGoal = maturedGoalFrom(matured);        // deterministic fallback
+    const readiness = assessReadiness(matured);
+    const reportMd = renderLoopDesign(matured, readiness, maturedGoal, { total: records.length, relevant });
+    const reportPath = savePreflightReport(ws, Date.now().toString(36), spec.goal || "loop", reportMd) ?? "";
+    return { maturedGoal, criteria: successCriteria(matured), reportMd, reportPath, readiness, prior: { total: records.length, relevant: relevant.length } };
   }
 
   // P-GOAL.5 (ADR-0047): the automation scheduler. Arm a timer that, while the app is open, fires the
@@ -665,19 +704,22 @@ class Backend {
    *  against the maker's reported work, conservatively. Fail-closed: an empty/failed reply ⇒ not done.
    *  P-GOAL.6: runs on the resolved CHECKER model (the user's choice, else a cheap/capable recommendation,
    *  else the maker's model) — a distinct, cheaper judge that costs less to run every iteration. */
-  private async checkGoal(a: { goal: string; condition: string; command: string; lastWork: string }): Promise<{ done: boolean; reason: string }> {
+  private async checkGoal(a: { goal: string; condition: string; command: string; lastWork: string; criteria?: string }): Promise<{ done: boolean; reason: string }> {
     const model = resolveCheckerModel({ chosen: checkerModel(), models: this.accessibleModels(), current: this.activeModel() }).value;
+    // P-GOAL.12 (ADR-0057): give the small checker the matured SUCCESS CRITERIA from the Pre-Flight design,
+    // and have it report back against EACH — appropriate context for a deterministic grade, not a bare check.
+    const criteriaBlock = a.criteria ? `\n\nGrade against these success criteria (report which are met / unmet):\n${a.criteria.slice(0, 1500)}` : "";
     if (a.command) {
       const out = await this.complete(
-        `You are a verification CHECKER, separate from the agent that did the work. Run the given command EXACTLY in the workspace and report only the outcome. Do NOT modify any files or try to fix anything. Output ONLY strict JSON on one line: {"done": <true only if the command finished with exit code 0>, "reason": "<short summary of what happened>"}.`,
-        `Run this verification command and report whether it passed:\n\n\`\`\`\n${a.command}\n\`\`\``,
+        `You are a verification CHECKER, separate from the agent that did the work. Run the given command EXACTLY in the workspace and report only the outcome. Do NOT modify any files or try to fix anything. ${a.criteria ? "Also note any success criterion that the command does not cover. " : ""}Output ONLY strict JSON on one line: {"done": <true only if the command finished with exit code 0${a.criteria ? " AND every success criterion holds" : ""}>, "reason": "<short summary: what happened + which criteria are met/unmet>"}.`,
+        `Run this verification command and report whether it passed:\n\n\`\`\`\n${a.command}\n\`\`\`${criteriaBlock}`,
         { idleMs: 180_000, model },
       );
       return parseGoalVerdict(out);
     }
     const out = await this.complete(
-      `You are a strict CHECKER, separate from the agent that did the work. Decide whether the goal is fully met. Be conservative: if you are not sure, answer done=false. Output ONLY strict JSON on one line: {"done": bool, "reason": "<one line>"}.`,
-      `Goal: ${a.goal}\nStop condition: ${a.condition}\n\nThe agent reported:\n${(a.lastWork || "(no output)").slice(0, 4000)}\n\nIs the goal fully met?`,
+      `You are a strict CHECKER, separate from the agent that did the work. Decide whether the goal is fully met against the success criteria. Be conservative: if you are not sure, answer done=false. Output ONLY strict JSON on one line: {"done": bool, "reason": "<one line: which criteria are met/unmet>"}.`,
+      `Goal: ${a.goal}\nStop condition: ${a.condition}${criteriaBlock}\n\nThe agent reported:\n${(a.lastWork || "(no output)").slice(0, 4000)}\n\nIs the goal fully met?`,
       { idleMs: 120_000, model },
     );
     return parseGoalVerdict(out);

--- a/desktop/dev.ts
+++ b/desktop/dev.ts
@@ -528,13 +528,25 @@ const server = Bun.serve({
       if (p === "/api/goal/resumable") return json({ ok: true, data: listResumableLoops(currentWorkspace()) });
       // P-GOAL.10 (ADR-0055): cross-run evaluation — success rate / avg iters / failure breakdown + recent runs.
       if (p === "/api/goal/stats") return json({ ok: true, data: backend.loopRunStats() });
+      // P-GOAL.12 (ADR-0057): Pre-Flight Audit — git scopes for the picker, and the readiness/design pass.
+      if (p === "/api/goal/scopes") return json({ ok: true, data: backend.loopScopes() });
+      if (p === "/api/goal/preflight" && req.method === "POST") {
+        const b = await readBody<Record<string, unknown>>(req);
+        const spec = {
+          goal: String(b.goal ?? ""), command: b.command ? String(b.command) : undefined, scope: b.scope ? String(b.scope) : undefined,
+          budgetUsd: Number(b.budgetUsd) || 0, maxIters: Number(b.maxIters) || undefined, checkerIsCheap: b.checkerIsCheap === true,
+          doneDefinition: b.doneDefinition ? String(b.doneDefinition) : undefined, nonGoals: b.nonGoals ? String(b.nonGoals) : undefined,
+          risks: b.risks ? String(b.risks) : undefined, feedback: b.feedback ? String(b.feedback) : undefined,
+        };
+        return json({ ok: true, data: await backend.preflightAudit(spec) });
+      }
       if (p === "/api/goal" && req.method === "POST") {
-        const b = await readBody<{ goal?: unknown; condition?: unknown; command?: unknown; maxIters?: unknown; resume?: unknown; budgetUsd?: unknown }>(req);
+        const b = await readBody<{ goal?: unknown; condition?: unknown; command?: unknown; maxIters?: unknown; resume?: unknown; budgetUsd?: unknown; criteria?: unknown }>(req);
         const enc = new TextEncoder();
         const stream = new ReadableStream({
           async start(controller) {
             await backend.runGoal(
-              { goal: String(b.goal ?? ""), condition: String(b.condition ?? ""), command: b.command ? String(b.command) : undefined, maxIters: Number(b.maxIters) || 6, resume: b.resume ? String(b.resume) : undefined, budgetUsd: Number(b.budgetUsd) || 0 },
+              { goal: String(b.goal ?? ""), condition: String(b.condition ?? ""), command: b.command ? String(b.command) : undefined, maxIters: Number(b.maxIters) || 6, resume: b.resume ? String(b.resume) : undefined, budgetUsd: Number(b.budgetUsd) || 0, criteria: b.criteria ? String(b.criteria) : undefined },
               (e) => { try { controller.enqueue(enc.encode(JSON.stringify(e) + "\n")); } catch { /* stream closed */ } },
             );
             try { controller.close(); } catch { /* already closed */ }

--- a/desktop/dev.ts
+++ b/desktop/dev.ts
@@ -529,12 +529,12 @@ const server = Bun.serve({
       // P-GOAL.10 (ADR-0055): cross-run evaluation — success rate / avg iters / failure breakdown + recent runs.
       if (p === "/api/goal/stats") return json({ ok: true, data: backend.loopRunStats() });
       if (p === "/api/goal" && req.method === "POST") {
-        const b = await readBody<{ goal?: unknown; condition?: unknown; command?: unknown; maxIters?: unknown; resume?: unknown }>(req);
+        const b = await readBody<{ goal?: unknown; condition?: unknown; command?: unknown; maxIters?: unknown; resume?: unknown; budgetUsd?: unknown }>(req);
         const enc = new TextEncoder();
         const stream = new ReadableStream({
           async start(controller) {
             await backend.runGoal(
-              { goal: String(b.goal ?? ""), condition: String(b.condition ?? ""), command: b.command ? String(b.command) : undefined, maxIters: Number(b.maxIters) || 6, resume: b.resume ? String(b.resume) : undefined },
+              { goal: String(b.goal ?? ""), condition: String(b.condition ?? ""), command: b.command ? String(b.command) : undefined, maxIters: Number(b.maxIters) || 6, resume: b.resume ? String(b.resume) : undefined, budgetUsd: Number(b.budgetUsd) || 0 },
               (e) => { try { controller.enqueue(enc.encode(JSON.stringify(e) + "\n")); } catch { /* stream closed */ } },
             );
             try { controller.close(); } catch { /* already closed */ }

--- a/desktop/dev.ts
+++ b/desktop/dev.ts
@@ -526,6 +526,8 @@ const server = Bun.serve({
         return json({ ok: true, data: backend.setCheckerModelChoice(String(b.value ?? "")) });
       }
       if (p === "/api/goal/resumable") return json({ ok: true, data: listResumableLoops(currentWorkspace()) });
+      // P-GOAL.10 (ADR-0055): cross-run evaluation — success rate / avg iters / failure breakdown + recent runs.
+      if (p === "/api/goal/stats") return json({ ok: true, data: backend.loopRunStats() });
       if (p === "/api/goal" && req.method === "POST") {
         const b = await readBody<{ goal?: unknown; condition?: unknown; command?: unknown; maxIters?: unknown; resume?: unknown }>(req);
         const enc = new TextEncoder();

--- a/desktop/goal_memory.test.ts
+++ b/desktop/goal_memory.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, test } from "bun:test";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { appendGoalIteration, finishGoalMemory, listResumableLoops, parseGoalMemory, resumeGoalMemory, startGoalMemory } from "./goal_memory.ts";
+import { appendGoalIteration, finishGoalMemory, listResumableLoops, parseGoalMemory, resumeGoalMemory, saveGoalReport, startGoalMemory } from "./goal_memory.ts";
 
 describe("goal_memory", () => {
   test("writes a durable markdown record under .omp/loops/", () => {
@@ -94,6 +94,39 @@ describe("parseGoalMemory + resume (P-GOAL.4)", () => {
       expect(readFileSync(mem.path, "utf8")).toContain("## Resumed");
       expect(resumeGoalMemory(ws, "../../../etc/passwd")).toBeNull(); // confinement
       expect(resumeGoalMemory(ws, ".omp/loops/nope.md")).toBeNull();   // missing
+    } finally { rmSync(ws, { recursive: true, force: true }); }
+  });
+});
+
+describe("saveGoalReport (P-GOAL.9)", () => {
+  test("writes the AAR beside the memory file, confined to the loops root", () => {
+    const ws = mkdtempSync(join(homedir(), ".lucid-goalreport-"));
+    try {
+      const rel = saveGoalReport(ws, "rep1", "Make auth tests pass", "# After-Action Report: x\n\nbody\n");
+      expect(rel).not.toBeNull();
+      expect(rel!.replace(/\\/g, "/")).toBe(".omp/loops/rep1-make-auth-tests-pass.report.md");
+      expect(readFileSync(join(ws, rel!), "utf8")).toContain("After-Action Report");
+    } finally { rmSync(ws, { recursive: true, force: true }); }
+  });
+
+  test("shares the memory file's <id>-<slug> stem so they co-locate", () => {
+    const ws = mkdtempSync(join(homedir(), ".lucid-goalreport2-"));
+    try {
+      const mem = startGoalMemory(ws, "stem9", { goal: "Fix the build", condition: "c" })!;
+      const rel = saveGoalReport(ws, "stem9", "Fix the build", "report")!;
+      // same directory + same id prefix as the memory file, distinguished by the .report.md suffix
+      expect(mem.rel.replace(/\\/g, "/")).toBe(".omp/loops/stem9-fix-the-build.md");
+      expect(rel.replace(/\\/g, "/")).toBe(".omp/loops/stem9-fix-the-build.report.md");
+    } finally { rmSync(ws, { recursive: true, force: true }); }
+  });
+
+  test("a hostile goal cannot escape the loops root", () => {
+    const ws = mkdtempSync(join(homedir(), ".lucid-goalreport3-"));
+    try {
+      const rel = saveGoalReport(ws, "id", "../../etc/passwd evil", "x");
+      expect(rel).not.toBeNull();
+      expect(rel!).not.toContain("..");
+      expect(rel!.replace(/\\/g, "/")).toContain(".omp/loops/");
     } finally { rmSync(ws, { recursive: true, force: true }); }
   });
 });

--- a/desktop/goal_memory.ts
+++ b/desktop/goal_memory.ts
@@ -11,6 +11,7 @@
 import { appendFileSync, existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { pathWithin } from "./path_guard.ts";
+import { type LoopRunRecord, parseRunLog, runRecordLine } from "./loop_runlog.ts";
 
 export interface GoalMemory { path: string; rel: string }
 
@@ -66,6 +67,35 @@ export function saveGoalReport(workspace: string, id: string, goal: string, mark
     writeFileSync(target, markdown, "utf8");
     return join(".omp", "loops", file);
   } catch { return null; }
+}
+
+// ── P-GOAL.10 (ADR-0055): the cross-run evaluation ledger (`.omp/loops/run-log.jsonl`) ─────────────
+
+const RUN_LOG = "run-log.jsonl";
+
+/** Append one completed loop to the run-log (append-only JSONL). Best-effort: a failed write never
+ *  affects the loop. Returns true on success. */
+export function appendRunLog(workspace: string, record: LoopRunRecord): boolean {
+  const root = join(workspace, ".omp", "loops");
+  const target = pathWithin(root, join(root, RUN_LOG));
+  if (!target) return false;
+  try {
+    mkdirSync(dirname(target), { recursive: true });
+    appendFileSync(target, runRecordLine(record) + "\n", "utf8");
+    return true;
+  } catch { return false; }
+}
+
+/** Read the run-log back into records (most-recent first), for the evaluation surface. Empty when the
+ *  ledger is missing/unreadable — never throws. */
+export function readRunLog(workspace: string): LoopRunRecord[] {
+  const root = join(workspace, ".omp", "loops");
+  const target = pathWithin(root, join(root, RUN_LOG));
+  if (!target) return [];
+  try {
+    const records = parseRunLog(readFileSync(target, "utf8"));
+    return records.sort((a, b) => b.ts - a.ts);
+  } catch { return []; }
 }
 
 // ── P-GOAL.4: read a memory file back to RESUME a stopped loop ─────────────────

--- a/desktop/goal_memory.ts
+++ b/desktop/goal_memory.ts
@@ -53,6 +53,21 @@ export function finishGoalMemory(mem: GoalMemory | null, result: string): void {
   try { appendFileSync(mem.path, `## Result\n${result}\n`, "utf8"); } catch { /* best-effort */ }
 }
 
+/** P-GOAL.9 (ADR-0054): write the loop's After-Action Report next to its memory file (same
+ *  `<id>-<slug>` stem, `.report.md`). Best-effort like the memory itself — a failed write never
+ *  affects the loop's outcome. Returns the workspace-relative path on success, else null. */
+export function saveGoalReport(workspace: string, id: string, goal: string, markdown: string): string | null {
+  const root = join(workspace, ".omp", "loops");
+  const file = `${id}-${slugify(goal)}.report.md`;
+  const target = pathWithin(root, join(root, file));
+  if (!target) return null;
+  try {
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, markdown, "utf8");
+    return join(".omp", "loops", file);
+  } catch { return null; }
+}
+
 // ── P-GOAL.4: read a memory file back to RESUME a stopped loop ─────────────────
 
 export interface ParsedGoalMemory { goal: string; condition: string; command?: string; iterations: number; succeeded: boolean; result?: string }

--- a/desktop/goal_memory.ts
+++ b/desktop/goal_memory.ts
@@ -69,6 +69,20 @@ export function saveGoalReport(workspace: string, id: string, goal: string, mark
   } catch { return null; }
 }
 
+/** P-GOAL.12 (ADR-0057): write a Pre-Flight Audit's Loop Design report under `.omp/loops/`
+ *  (`<id>-<slug>.preflight.md`). Best-effort; returns the workspace-relative path or null. */
+export function savePreflightReport(workspace: string, id: string, goal: string, markdown: string): string | null {
+  const root = join(workspace, ".omp", "loops");
+  const file = `${id}-${slugify(goal)}.preflight.md`;
+  const target = pathWithin(root, join(root, file));
+  if (!target) return null;
+  try {
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, markdown, "utf8");
+    return join(".omp", "loops", file);
+  } catch { return null; }
+}
+
 // ── P-GOAL.10 (ADR-0055): the cross-run evaluation ledger (`.omp/loops/run-log.jsonl`) ─────────────
 
 const RUN_LOG = "run-log.jsonl";

--- a/desktop/loop_budget.test.ts
+++ b/desktop/loop_budget.test.ts
@@ -1,0 +1,60 @@
+// desktop/loop_budget.test.ts — P-GOAL.11 (ADR-0056): the per-loop spend meter + budget kill switch.
+
+import { describe, expect, test } from "bun:test";
+import { addTurnSpend, type LoopSpend, newLoopSpend, normalizeBudget, overBudget } from "./loop_budget.ts";
+
+describe("addTurnSpend", () => {
+  test("sums per-turn peak cost and counts turns", () => {
+    let s = newLoopSpend();
+    s = addTurnSpend(s, 0.02, 1200);
+    s = addTurnSpend(s, 0.05, 3400);
+    expect(s.usd).toBeCloseTo(0.07, 10);
+    expect(s.turns).toBe(2);
+  });
+  test("context tokens are a PEAK high-water mark, never summed", () => {
+    let s = newLoopSpend();
+    s = addTurnSpend(s, 0.01, 5000);
+    s = addTurnSpend(s, 0.01, 9000);
+    s = addTurnSpend(s, 0.01, 7000);
+    expect(s.peakContextTokens).toBe(9000); // max, not 21000
+  });
+  test("non-finite / negative usage folds in as zero (telemetry never corrupts the total)", () => {
+    let s = newLoopSpend();
+    s = addTurnSpend(s, Number.NaN, -100);
+    s = addTurnSpend(s, -0.5, Number.POSITIVE_INFINITY);
+    expect(s.usd).toBe(0);
+    expect(s.peakContextTokens).toBe(0);
+    expect(s.turns).toBe(2); // a turn still counts even if it reported no usable usage
+  });
+  test("is pure — does not mutate its input", () => {
+    const a: LoopSpend = newLoopSpend();
+    const b = addTurnSpend(a, 0.03, 100);
+    expect(a.usd).toBe(0);
+    expect(b.usd).toBeCloseTo(0.03, 10);
+  });
+});
+
+describe("overBudget (kill switch)", () => {
+  test("trips at or above a positive cap", () => {
+    expect(overBudget(0.49, 0.5)).toBe(false);
+    expect(overBudget(0.5, 0.5)).toBe(true);
+    expect(overBudget(0.51, 0.5)).toBe(true);
+  });
+  test("a non-positive cap means no budget — never trips", () => {
+    expect(overBudget(9999, 0)).toBe(false);
+    expect(overBudget(9999, -1)).toBe(false);
+  });
+});
+
+describe("normalizeBudget", () => {
+  test("accepts a positive amount, rounds to cents", () => {
+    expect(normalizeBudget(2.5)).toBe(2.5);
+    expect(normalizeBudget("1.239")).toBe(1.24);
+  });
+  test("zero / negative / junk ⇒ 0 (no cap)", () => {
+    expect(normalizeBudget(0)).toBe(0);
+    expect(normalizeBudget(-3)).toBe(0);
+    expect(normalizeBudget("abc")).toBe(0);
+    expect(normalizeBudget(undefined)).toBe(0);
+  });
+});

--- a/desktop/loop_budget.ts
+++ b/desktop/loop_budget.ts
@@ -1,0 +1,49 @@
+// desktop/loop_budget.ts
+//
+// P-GOAL.11 (ADR-0056): live per-loop SPEND accounting + a budget KILL SWITCH. loop-engineering's
+// costliest failure mode is "Token Burn" — an unattended loop running full turns until the bill spikes;
+// its mitigation is a "daily budget limit" / "kill switch". ADR-0049 already shows a pre-run cost
+// ESTIMATE; this adds the ACTUALS and a hard ceiling that halts the loop the moment spend crosses it.
+//
+// PURE module (no I/O, no Date.now()), unit-tested. The backend folds each maker turn's peak usage into
+// a running `LoopSpend`; because runGoal owns the turn boundaries, accounting is just "sum the per-turn
+// peak cost" — exact for omp's per-turn `cost`, with no fragile counter-reset detection. Context tokens
+// (`used`) are cumulative within the persistent maker session, so they are tracked as a PEAK, never summed.
+
+export interface LoopSpend {
+  /** total dollars spent so far = sum of each finished maker turn's peak cost. */
+  usd: number;
+  /** peak context-window fill seen (informational; NOT summed — context is cumulative per session). */
+  peakContextTokens: number;
+  /** number of turns folded in (maker iterations that reported usage). */
+  turns: number;
+}
+
+export function newLoopSpend(): LoopSpend {
+  return { usd: 0, peakContextTokens: 0, turns: 0 };
+}
+
+/** Fold a finished turn into the running spend: add its peak cost, raise the peak-context high-water
+ *  mark. Non-finite / negative inputs are treated as zero (best-effort telemetry must never corrupt
+ *  the total). Returns a NEW object (pure). */
+export function addTurnSpend(spend: LoopSpend, turnPeakUsd: number, turnPeakContextTokens: number): LoopSpend {
+  const usd = Number.isFinite(turnPeakUsd) && turnPeakUsd > 0 ? turnPeakUsd : 0;
+  const ctx = Number.isFinite(turnPeakContextTokens) && turnPeakContextTokens > 0 ? turnPeakContextTokens : 0;
+  return {
+    usd: spend.usd + usd,
+    peakContextTokens: Math.max(spend.peakContextTokens, ctx),
+    turns: spend.turns + 1,
+  };
+}
+
+/** The kill switch: true once a POSITIVE cap has been reached or exceeded. A non-positive cap (the
+ *  default) means "no budget" and never trips — the iteration cap stays the only ceiling. */
+export function overBudget(spentUsd: number, capUsd: number): boolean {
+  return capUsd > 0 && spentUsd >= capUsd;
+}
+
+/** Clamp/normalize a user-entered budget cap: a finite, non-negative dollar amount (0 = no cap). */
+export function normalizeBudget(capUsd: unknown): number {
+  const n = Number(capUsd);
+  return Number.isFinite(n) && n > 0 ? Math.round(n * 100) / 100 : 0;
+}

--- a/desktop/loop_preflight.test.ts
+++ b/desktop/loop_preflight.test.ts
@@ -1,0 +1,176 @@
+// desktop/loop_preflight.test.ts — P-GOAL.12 (ADR-0057): the Pre-Flight Audit's pure core.
+
+import { describe, expect, test } from "bun:test";
+import { type LoopRunRecord } from "./loop_runlog.ts";
+import {
+  assessReadiness,
+  maturedGoalFrom,
+  mergeMatured,
+  parsePreflightJson,
+  type PreflightSpec,
+  preflightUserPrompt,
+  relevantPriorRuns,
+  renderLoopDesign,
+  renderPriorRuns,
+  successCriteria,
+  summarizePriorRuns,
+} from "./loop_preflight.ts";
+
+function run(over: Partial<LoopRunRecord> = {}): LoopRunRecord {
+  return {
+    ts: 1000, id: "r", goal: "make auth tests pass", outcome: "stopped", outcomeReason: "3 lint errors remain",
+    iterations: 5, maxIters: 6, durationMs: 1000, tools: 9, toolsByType: {}, added: 0, removed: 0,
+    hasLoc: false, errors: 0, websites: 0, spendUsd: 0.4, hasSpend: true, ...over,
+  };
+}
+
+function spec(over: Partial<PreflightSpec> = {}): PreflightSpec {
+  return { goal: "Make all auth tests pass and fix lint", ...over };
+}
+
+describe("assessReadiness — gated levels", () => {
+  test("bare objective ⇒ L0", () => {
+    expect(assessReadiness(spec({ goal: "speed things up" })).level).toBe("L0"); // too short / vague-ish but present
+    expect(assessReadiness({ goal: "" }).level).toBe("L0");
+  });
+  test("objective + done ⇒ L1", () => {
+    expect(assessReadiness(spec({ doneDefinition: "all 42 auth tests green" })).level).toBe("L1");
+  });
+  test("objective + done + verification ⇒ L2", () => {
+    expect(assessReadiness(spec({ doneDefinition: "all 42 auth tests green", command: "npm test" })).level).toBe("L2");
+  });
+  test("the safety-bearing four lift it to L3 (unattended-capable)", () => {
+    const r = assessReadiness(spec({
+      doneDefinition: "all 42 auth tests green", command: "npm test && npm run lint",
+      budgetUsd: 2, scope: "branch: feat/auth", checkerIsCheap: true,
+    }));
+    expect(r.level).toBe("L3");
+    expect(r.score).toBeGreaterThanOrEqual(90);
+  });
+  test("a long goal can NOT buy L3 without the verification command (no Verifier Theater)", () => {
+    const r = assessReadiness(spec({ doneDefinition: "x".repeat(40), budgetUsd: 5, scope: "branch: x", checkerIsCheap: true }));
+    expect(r.level).not.toBe("L3"); // missing command caps it
+    expect(r.checks.find((c) => c.key === "verify")!.ok).toBe(false);
+  });
+  test("each failed check carries an actionable nudge", () => {
+    const verify = assessReadiness(spec()).checks.find((c) => c.key === "verify")!;
+    expect(verify.ok).toBe(false);
+    expect(verify.nudge).toContain("Verifier Theater");
+  });
+});
+
+describe("maturedGoalFrom", () => {
+  test("distills a self-contained goal from the spec", () => {
+    const g = maturedGoalFrom(spec({ doneDefinition: "all auth tests green", command: "npm test", nonGoals: "touch payments" }));
+    expect(g).toContain("Make all auth tests pass");
+    expect(g).toContain("Done when: all auth tests green");
+    expect(g).toContain("`npm test`");
+    expect(g).toContain("Do NOT: touch payments");
+    expect(g.endsWith(".")).toBe(true);
+  });
+});
+
+describe("renderLoopDesign", () => {
+  test("repeatable report carries readiness, matured goal, design table, and gaps", () => {
+    const s = spec({ doneDefinition: "tests green", command: "npm test", scope: "branch: feat/auth", budgetUsd: 2, maxIters: 6, checkerIsCheap: true, nonGoals: "do not touch payments or auth secrets" });
+    const r = assessReadiness(s);
+    const md = renderLoopDesign(s, r, maturedGoalFrom(s));
+    expect(md).toContain("# Loop Design — Make all auth tests pass");
+    expect(md).toContain("**Readiness: L3");
+    expect(md).toContain("## Matured goal");
+    expect(md).toContain("| Verification | `npm test` |");
+    expect(md).toContain("- [x] Verification command");
+    expect(md).toContain("_Nothing outstanding"); // no gaps at L3
+  });
+  test("an incomplete loop lists its gaps under 'Before you run'", () => {
+    const s = spec();
+    const md = renderLoopDesign(s, assessReadiness(s), maturedGoalFrom(s));
+    expect(md).toContain("## Before you run");
+    expect(md).toContain("**Verification command (exit 0 = done)**");
+    expect(md).toContain("_none — checker judges self-report_");
+  });
+  test("escapes pipes/newlines so a hostile answer can't break the table", () => {
+    const s = spec({ goal: "a | b\nc", risks: "x | y" });
+    const md = renderLoopDesign(s, assessReadiness(s), "g");
+    expect(md).toContain("a \\| b c"); // pipe escaped, newline flattened
+  });
+});
+
+describe("model maturation (interview)", () => {
+  test("parsePreflightJson extracts fields, fails soft on junk", () => {
+    const ok = parsePreflightJson('noise {"maturedGoal":"do X","suggestedCommand":"make test"} trailing');
+    expect(ok.maturedGoal).toBe("do X");
+    expect(ok.suggestedCommand).toBe("make test");
+    expect(parsePreflightJson("not json at all")).toEqual({});
+  });
+  test("mergeMatured fills gaps but never overrides what the user provided", () => {
+    const merged = mergeMatured(spec({ command: "npm test" }), { suggestedCommand: "make", definitionOfDone: "green", risks: "infra" });
+    expect(merged.command).toBe("npm test");      // user value wins
+    expect(merged.doneDefinition).toBe("green");  // model fills the blank
+    expect(merged.risks).toBe("infra");
+  });
+  test("preflightUserPrompt includes the answers that were given, omits the blanks", () => {
+    const p = preflightUserPrompt(spec({ command: "npm test", scope: "branch: x" }));
+    expect(p).toContain("Verification command (user): npm test");
+    expect(p).toContain("Scope: branch: x");
+    expect(p).not.toContain("Non-goals (user):");
+  });
+  test("preflightUserPrompt folds in stakeholder feedback + prior-run digest", () => {
+    const p = preflightUserPrompt(spec({ feedback: "PO wants zero flaky tests" }), "Prior runs of similar loops:\n- ...");
+    expect(p).toContain("product-owner feedback to honor: PO wants zero flaky tests");
+    expect(p).toContain("don't repeat what already failed");
+  });
+});
+
+describe("history awareness (don't lose context of past runs)", () => {
+  test("relevantPriorRuns ranks by shared significant tokens, drops unrelated", () => {
+    const records = [
+      run({ id: "a", goal: "make auth tests pass", ts: 1 }),
+      run({ id: "b", goal: "update the changelog", ts: 2 }),
+      run({ id: "c", goal: "fix auth tests and lint", ts: 3 }),
+    ];
+    const rel = relevantPriorRuns(records, "make all auth tests pass", 3);
+    expect(rel.map((r) => r.id)).toEqual(["a", "c"]); // both share "auth"/"tests"; changelog dropped
+  });
+  test("feedback flows into the matured goal", () => {
+    expect(maturedGoalFrom(spec({ feedback: "ship by Friday" }))).toContain("Per product-owner feedback: ship by Friday");
+  });
+  test("summarizePriorRuns + renderPriorRuns state whether history exists", () => {
+    expect(renderPriorRuns(0, [])).toContain("No prior loop runs on record");
+    const rel = [run({ goal: "fix auth tests", outcome: "stopped", outcomeReason: "lint errors", iterations: 6 })];
+    const md = renderPriorRuns(4, rel);
+    expect(md).toContain("4 prior loop runs on record");
+    expect(md).toContain(".omp/loops/");
+    expect(md).toContain("⏹️ stopped in 6 iter");
+    expect(summarizePriorRuns(rel)).toContain("fix auth tests");
+  });
+  test("renderLoopDesign surfaces a Prior runs section when history is passed", () => {
+    const s = spec();
+    const md = renderLoopDesign(s, assessReadiness(s), "g", { total: 2, relevant: [run({ goal: "auth tests" })] });
+    expect(md).toContain("## Prior runs");
+    expect(md).toContain("2 prior loop runs on record");
+    expect(md).toContain("| User / PO feedback |");
+  });
+});
+
+describe("successCriteria (checker context) + engineer input", () => {
+  test("distills the checker's grading rubric from the matured design", () => {
+    const c = successCriteria(spec({
+      doneDefinition: "42 tests pass", command: "npm test", nonGoals: "edit payments",
+      feedback: "no flaky tests", engineerNotes: "use the existing fixture loader",
+    }));
+    expect(c).toContain("Done when: 42 tests pass");
+    expect(c).toContain("Proven by: `npm test` exits 0");
+    expect(c).toContain("Must NOT: edit payments");
+    expect(c).toContain("Honor (product-owner): no flaky tests");
+    expect(c).toContain("Honor (engineer): use the existing fixture loader");
+  });
+  test("empty when nothing beyond the goal was specified", () => {
+    expect(successCriteria(spec())).toBe("");
+  });
+  test("engineer notes flow into the matured goal and the design report", () => {
+    expect(maturedGoalFrom(spec({ engineerNotes: "keep diffs small" }))).toContain("Per engineering guidance: keep diffs small");
+    const s = spec({ engineerNotes: "keep diffs small" });
+    expect(renderLoopDesign(s, assessReadiness(s), "g")).toContain("| Engineer notes | keep diffs small |");
+  });
+});

--- a/desktop/loop_preflight.test.ts
+++ b/desktop/loop_preflight.test.ts
@@ -89,10 +89,11 @@ describe("renderLoopDesign", () => {
     expect(md).toContain("**Verification command (exit 0 = done)**");
     expect(md).toContain("_none — checker judges self-report_");
   });
-  test("escapes pipes/newlines so a hostile answer can't break the table", () => {
-    const s = spec({ goal: "a | b\nc", risks: "x | y" });
+  test("escapes backslash-then-pipe and flattens newlines (CodeQL: incomplete escaping)", () => {
+    const s = spec({ goal: "a | b\nc", risks: "C:\\tmp | bad" });
     const md = renderLoopDesign(s, assessReadiness(s), "g");
-    expect(md).toContain("a \\| b c"); // pipe escaped, newline flattened
+    expect(md).toContain("a \\| b c");           // pipe escaped, newline flattened
+    expect(md).toContain("C:\\\\tmp \\| bad");   // backslash → \\ FIRST, then pipe → \|
   });
 });
 

--- a/desktop/loop_preflight.ts
+++ b/desktop/loop_preflight.ts
@@ -139,7 +139,9 @@ export function summarizePriorRuns(runs: LoopRunRecord[]): string {
   return "Prior runs of similar loops:\n" + runs.map((r) => `- "${r.goal.slice(0, 60)}": ${priorLine(r)}`).join("\n");
 }
 
-const esc = (s: string | undefined): string => (s ?? "").replace(/\|/g, "\\|").replace(/[\r\n]+/g, " ").trim();
+// Escape for a Markdown table cell: backslash FIRST (else a trailing "\" escapes the cell's closing
+// pipe), then pipe, then flatten newlines. Same rule as loop_report.mdCell (CodeQL: incomplete escaping).
+const esc = (s: string | undefined): string => (s ?? "").replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/[\r\n]+/g, " ").trim();
 
 /** The "## Prior runs" report section — states whether history exists and surfaces the relevant runs so
  *  the new loop design carries their context forward (their After-Action Reports live in `.omp/loops/`). */

--- a/desktop/loop_preflight.ts
+++ b/desktop/loop_preflight.ts
@@ -1,0 +1,260 @@
+// desktop/loop_preflight.ts
+//
+// P-GOAL.12 (ADR-0057): the "Pre-Flight Audit" — a structured, repeatable readiness pass the user can
+// run BEFORE building a /goal loop. It adapts loop-engineering's loop-audit ship-readiness rubric (L0→L3)
+// and loop-design-checklist from "is this REPO ready?" to the more actionable "is THIS loop well-formed?",
+// then emits a durable Loop Design report (.md) that becomes the loop's starting point — the user adopts
+// the matured goal into the Goal field and tweaks it.
+//
+// PURE module (no I/O, no Date.now()), unit-tested like loop_report / loop_runlog / loop_budget. The
+// backend collects the spec (scope + a short prompt-engineering interview), optionally matures it with one
+// model call, then calls assessReadiness + renderLoopDesign here. The model step is best-effort: with no
+// model, the user's structured answers still produce a complete report + a matured goal (graceful fallback).
+
+import { type LoopRunRecord } from "./loop_runlog.ts";
+
+export interface PreflightSpec {
+  goal: string;              // the rough objective the user typed
+  command?: string;          // verification command (exit 0 = done) — the strongest "done" signal
+  scope?: string;            // "branch: feat/x" | "worktree: ../wt" | "workspace" — where the loop runs
+  budgetUsd?: number;        // a $ kill-switch cap (P-GOAL.11)
+  maxIters?: number;
+  checkerIsCheap?: boolean;  // is the checker a small/cheap model (ADR-0048)?
+  // ── the prompt-engineering interview answers ──
+  doneDefinition?: string;   // "what does done look like, concretely?"
+  nonGoals?: string;         // "what should this loop NOT do?"
+  risks?: string;            // risky / off-limits paths (auth, payments, secrets, infra) — the denylist
+  feedback?: string;         // USER / product-owner feedback to fold into the loop design
+  engineerNotes?: string;    // ENGINEER input — constraints, gotchas, the right approach to take
+}
+
+/** The explicit success criteria the (small, deterministic) checker grades against and reports back on —
+ *  distilled from the matured design so the checker has the right context, not just a bare stop condition.
+ *  Returns "" when nothing beyond the goal was specified (the checker falls back to its condition). */
+export function successCriteria(spec: PreflightSpec): string {
+  const lines: string[] = [];
+  if (nonEmpty(spec.doneDefinition)) lines.push(`Done when: ${spec.doneDefinition!.trim()}`);
+  if (nonEmpty(spec.command)) lines.push(`Proven by: \`${spec.command!.trim()}\` exits 0`);
+  if (nonEmpty(spec.nonGoals)) lines.push(`Must NOT: ${spec.nonGoals!.trim()}`);
+  if (nonEmpty(spec.risks)) lines.push(`Off-limits: ${spec.risks!.trim()}`);
+  if (nonEmpty(spec.feedback)) lines.push(`Honor (product-owner): ${spec.feedback!.trim()}`);
+  if (nonEmpty(spec.engineerNotes)) lines.push(`Honor (engineer): ${spec.engineerNotes!.trim()}`);
+  return lines.join("\n");
+}
+
+export type ReadinessLevel = "L0" | "L1" | "L2" | "L3";
+export interface ReadinessCheck { key: string; label: string; ok: boolean; weight: number; nudge?: string }
+export interface ReadinessReport {
+  level: ReadinessLevel;     // L0 intent · L1 report-ready · L2 assisted-fix · L3 unattended-capable
+  score: number;             // 0..100 (weighted)
+  checks: ReadinessCheck[];
+  summary: string;
+}
+
+function nonEmpty(s: string | undefined, min = 1): boolean { return !!s && s.trim().length >= min; }
+
+/** Score a loop spec against the ship-readiness rubric. The checks mirror loop-engineering's
+ *  loop-design-checklist (purpose, verification, maker/checker, budget, safety) but applied to ONE loop.
+ *  Level is gated, not just averaged: L3 (unattended) REQUIRES the load-bearing safety checks, never a
+ *  high score alone — a missing verification command can't be out-weighed by a long goal description. */
+export function assessReadiness(spec: PreflightSpec): ReadinessReport {
+  const goalOk = nonEmpty(spec.goal, 12);
+  const doneOk = nonEmpty(spec.doneDefinition, 6);
+  const verifyOk = nonEmpty(spec.command, 2);
+  const scopeOk = nonEmpty(spec.scope) && spec.scope!.toLowerCase() !== "workspace" ? true : nonEmpty(spec.scope);
+  const budgetOk = (spec.budgetUsd ?? 0) > 0;
+  const checkerOk = spec.checkerIsCheap === true;
+  const denylistOk = nonEmpty(spec.risks, 3) || nonEmpty(spec.nonGoals, 3);
+
+  const checks: ReadinessCheck[] = [
+    { key: "objective", label: "Clear objective (one concrete end-state)", ok: goalOk, weight: 18, nudge: goalOk ? undefined : "Describe the finished result in one concrete sentence." },
+    { key: "done", label: "Definition of done", ok: doneOk, weight: 14, nudge: doneOk ? undefined : "Say exactly what 'done' looks like so the checker can judge it." },
+    { key: "verify", label: "Verification command (exit 0 = done)", ok: verifyOk, weight: 22, nudge: verifyOk ? undefined : "Add a shell command that proves done by exit code — without it the checker only judges the agent's self-report (Verifier Theater)." },
+    { key: "scope", label: "Explicit scope (branch / worktree)", ok: scopeOk, weight: 12, nudge: scopeOk ? undefined : "Pick the branch or worktree the loop runs in, so it can't wander." },
+    { key: "budget", label: "Budget cap (kill switch)", ok: budgetOk, weight: 14, nudge: budgetOk ? undefined : "Set a $ ceiling so an unattended run can't burn the budget." },
+    { key: "checker", label: "Cheap, separate checker model", ok: checkerOk, weight: 10, nudge: checkerOk ? undefined : "Grade with a small fast model — it's cheaper to run every round." },
+    { key: "denylist", label: "Non-goals / risky paths noted", ok: denylistOk, weight: 10, nudge: denylistOk ? undefined : "List off-limits areas (auth, payments, secrets, infra) and what the loop must NOT do." },
+  ];
+
+  const score = Math.round(checks.reduce((a, c) => a + (c.ok ? c.weight : 0), 0));
+  // Gated levels (loop-engineering L0→L3). L3 = "unattended-capable": needs the verification command,
+  // a budget kill switch, an explicit scope, and a cheap checker — the safety-bearing four.
+  let level: ReadinessLevel;
+  if (goalOk && doneOk && verifyOk && budgetOk && scopeOk && checkerOk) level = "L3";
+  else if (goalOk && doneOk && verifyOk) level = "L2";
+  else if (goalOk && doneOk) level = "L1";
+  else level = "L0";
+
+  const LEVEL_BLURB: Record<ReadinessLevel, string> = {
+    L0: "intent only — sharpen the objective before running",
+    L1: "report-ready — fine to run and watch, but add a verification command to trust 'done'",
+    L2: "assisted — verifiable; add a budget cap + explicit scope before running it unattended",
+    L3: "unattended-capable — verifiable, budgeted, scoped, and cheaply graded",
+  };
+  return { level, score, checks, summary: `${level} (${score}/100) — ${LEVEL_BLURB[level]}` };
+}
+
+/** A crisp, self-contained goal string distilled from the spec — what gets adopted into the Goal field.
+ *  Deterministic fallback used when no model maturation is available. */
+export function maturedGoalFrom(spec: PreflightSpec): string {
+  const parts = [spec.goal.trim().replace(/\.+$/, "")];
+  if (nonEmpty(spec.doneDefinition)) parts.push(`Done when: ${spec.doneDefinition!.trim().replace(/\.+$/, "")}`);
+  if (nonEmpty(spec.command)) parts.push(`Verify by running \`${spec.command!.trim()}\` (exit 0 = done)`);
+  if (nonEmpty(spec.nonGoals)) parts.push(`Do NOT: ${spec.nonGoals!.trim().replace(/\.+$/, "")}`);
+  if (nonEmpty(spec.risks)) parts.push(`Stay clear of: ${spec.risks!.trim().replace(/\.+$/, "")}`);
+  if (nonEmpty(spec.feedback)) parts.push(`Per product-owner feedback: ${spec.feedback!.trim().replace(/\.+$/, "")}`);
+  if (nonEmpty(spec.engineerNotes)) parts.push(`Per engineering guidance: ${spec.engineerNotes!.trim().replace(/\.+$/, "")}`);
+  return parts.join(". ") + ".";
+}
+
+// ── history awareness: don't lose context of past runs ────────────────────────
+
+const STOPWORDS = new Set(["the", "and", "for", "with", "all", "any", "make", "fix", "add", "run", "loop", "this", "that", "into", "from", "are", "was"]);
+function sigTokens(s: string): Set<string> {
+  return new Set((s || "").toLowerCase().split(/[^a-z0-9]+/).filter((t) => t.length >= 3 && !STOPWORDS.has(t)));
+}
+
+/** Pick prior runs RELATED to this goal (most-relevant first), so the Pre-Flight Audit carries forward
+ *  what past runs of a similar loop did. Relevance = shared significant tokens; ties broken by recency.
+ *  Returns [] when nothing overlaps (the caller still reports the total count, so "history exists" shows). */
+export function relevantPriorRuns(records: LoopRunRecord[], goal: string, limit = 3): LoopRunRecord[] {
+  const want = sigTokens(goal);
+  if (!want.size) return [];
+  const scored = records
+    .map((r) => { const t = sigTokens(r.goal); let overlap = 0; for (const w of want) if (t.has(w)) overlap++; return { r, overlap }; })
+    .filter((x) => x.overlap > 0)
+    .sort((a, b) => b.overlap - a.overlap || b.r.ts - a.r.ts);
+  return scored.slice(0, limit).map((x) => x.r);
+}
+
+const OUTCOME_WORD: Record<string, string> = { met: "✅ met", stopped: "⏹️ stopped", cancelled: "🛑 cancelled", error: "❗ error" };
+function priorLine(r: LoopRunRecord): string {
+  const spend = r.hasSpend ? ` · $${r.spendUsd.toFixed(2)}` : "";
+  return `${OUTCOME_WORD[r.outcome] ?? r.outcome} in ${r.iterations} iter${spend} — ${(r.outcomeReason || "").slice(0, 90)}`;
+}
+
+/** Plain-text history digest for the model interview, so maturation accounts for what failed before. */
+export function summarizePriorRuns(runs: LoopRunRecord[]): string {
+  if (!runs.length) return "";
+  return "Prior runs of similar loops:\n" + runs.map((r) => `- "${r.goal.slice(0, 60)}": ${priorLine(r)}`).join("\n");
+}
+
+const esc = (s: string | undefined): string => (s ?? "").replace(/\|/g, "\\|").replace(/[\r\n]+/g, " ").trim();
+
+/** The "## Prior runs" report section — states whether history exists and surfaces the relevant runs so
+ *  the new loop design carries their context forward (their After-Action Reports live in `.omp/loops/`). */
+export function renderPriorRuns(totalRuns: number, relevant: LoopRunRecord[]): string {
+  const out: string[] = ["## Prior runs", ""];
+  if (totalRuns === 0) { out.push("_No prior loop runs on record — this is a first run._", ""); return out.join("\n"); }
+  out.push(`${totalRuns} prior loop run${totalRuns === 1 ? "" : "s"} on record (full After-Action Reports in \`.omp/loops/\`).`);
+  out.push("");
+  if (relevant.length) {
+    out.push("Most relevant to this goal:");
+    out.push("");
+    out.push("| Goal | Outcome |");
+    out.push("|---|---|");
+    for (const r of relevant) out.push(`| ${esc(r.goal).slice(0, 50)} | ${esc(priorLine(r))} |`);
+  } else {
+    out.push("_None match this goal closely — review the reports if this overlaps past work._");
+  }
+  out.push("");
+  return out.join("\n");
+}
+
+/** Render the repeatable Loop Design report (markdown) — the durable artifact the Pre-Flight Audit
+ *  produces. Same template every time so it's comparable run-to-run (loop-engineering's design doc). */
+export function renderLoopDesign(spec: PreflightSpec, report: ReadinessReport, maturedGoal: string, history?: { total: number; relevant: LoopRunRecord[] }): string {
+  const out: string[] = [];
+  out.push(`# Loop Design — ${esc(spec.goal).slice(0, 80) || "(untitled loop)"}`);
+  out.push("");
+  out.push(`**Readiness: ${report.summary}**`);
+  out.push("");
+  out.push("## Matured goal");
+  out.push("");
+  out.push("> " + maturedGoal.replace(/\n/g, "\n> "));
+  out.push("");
+  if (history) out.push(renderPriorRuns(history.total, history.relevant));
+  out.push("## Design");
+  out.push("");
+  out.push("| | |");
+  out.push("|---|---|");
+  out.push(`| Objective | ${esc(spec.goal) || "—"} |`);
+  out.push(`| Definition of done | ${esc(spec.doneDefinition) || "_unset_"} |`);
+  out.push(`| Verification | ${spec.command ? "`" + esc(spec.command) + "`" : "_none — checker judges self-report_"} |`);
+  out.push(`| Scope | ${esc(spec.scope) || "workspace"} |`);
+  out.push(`| Budget cap | ${spec.budgetUsd && spec.budgetUsd > 0 ? "$" + spec.budgetUsd.toFixed(2) : "_none_"} |`);
+  out.push(`| Max iterations | ${spec.maxIters ?? "—"} |`);
+  out.push(`| Checker | ${spec.checkerIsCheap ? "cheap/separate ✓" : "_review — flagship is wasteful_"} |`);
+  out.push(`| Non-goals | ${esc(spec.nonGoals) || "_unset_"} |`);
+  out.push(`| Risky / off-limits | ${esc(spec.risks) || "_unset_"} |`);
+  out.push(`| User / PO feedback | ${esc(spec.feedback) || "_none provided_"} |`);
+  out.push(`| Engineer notes | ${esc(spec.engineerNotes) || "_none provided_"} |`);
+  out.push("");
+  out.push("## Readiness checklist");
+  out.push("");
+  for (const c of report.checks) out.push(`- [${c.ok ? "x" : " "}] ${c.label}${c.ok ? "" : ` — _${c.nudge}_`}`);
+  out.push("");
+  const gaps = report.checks.filter((c) => !c.ok);
+  out.push("## Before you run");
+  out.push("");
+  if (!gaps.length) out.push("_Nothing outstanding — this loop is unattended-capable._");
+  else for (const c of gaps) out.push(`- **${c.label}** — ${c.nudge}`);
+  out.push("");
+  return out.join("\n");
+}
+
+// ── model-assisted maturation (prompt-engineering interview) ───────────────────
+
+/** The interviewer system prompt: a prompt-engineering coach that hardens a loose goal into a crisp,
+ *  verifiable loop design and returns STRICT JSON (so the result is parseable, never free prose). */
+export function preflightSystemPrompt(): string {
+  return [
+    "You are a LOOP-DESIGN interviewer. Turn a loose automation goal into a crisp, verifiable, safely-scoped",
+    "loop the agent can run to a stop condition. Be concrete and conservative. Prefer a shell command that",
+    "exits 0 as the proof of 'done'. Do not invent facts about the repo. Output ONLY strict JSON on one line:",
+    `{"maturedGoal": "<one concrete sentence>", "definitionOfDone": "<observable end-state>", "suggestedCommand": "<shell verify cmd or empty>", "nonGoals": "<what it must NOT do>", "risks": "<off-limits paths>"}`,
+  ].join(" ");
+}
+
+/** The interview user turn: the user's draft + their answers + the chosen scope + any stakeholder
+ *  feedback + a digest of prior runs (so maturation carries history forward, not re-solving old blockers). */
+export function preflightUserPrompt(spec: PreflightSpec, priorRunsDigest = ""): string {
+  return [
+    `Goal draft: ${spec.goal}`,
+    spec.doneDefinition ? `Definition of done (user): ${spec.doneDefinition}` : "",
+    spec.command ? `Verification command (user): ${spec.command}` : "",
+    spec.scope ? `Scope: ${spec.scope}` : "",
+    spec.nonGoals ? `Non-goals (user): ${spec.nonGoals}` : "",
+    spec.risks ? `Risky areas (user): ${spec.risks}` : "",
+    spec.feedback ? `User / product-owner feedback to honor: ${spec.feedback}` : "",
+    spec.engineerNotes ? `Engineer guidance to honor: ${spec.engineerNotes}` : "",
+    priorRunsDigest ? `\n${priorRunsDigest}\n(Account for these — don't repeat what already failed.)` : "",
+    "Harden this into a verifiable loop and return the JSON.",
+  ].filter(Boolean).join("\n");
+}
+
+export interface MaturedFields { maturedGoal?: string; definitionOfDone?: string; suggestedCommand?: string; nonGoals?: string; risks?: string }
+
+/** Parse the interviewer's JSON reply. Fail-soft: returns {} on anything unparseable, so the backend
+ *  falls back to the user's own structured answers (the report is produced either way). */
+export function parsePreflightJson(out: string): MaturedFields {
+  const m = /\{[\s\S]*\}/.exec(out ?? "");
+  if (!m) return {};
+  try {
+    const o = JSON.parse(m[0]) as Record<string, unknown>;
+    const str = (v: unknown) => (typeof v === "string" ? v.trim().slice(0, 600) : undefined);
+    return { maturedGoal: str(o.maturedGoal), definitionOfDone: str(o.definitionOfDone), suggestedCommand: str(o.suggestedCommand), nonGoals: str(o.nonGoals), risks: str(o.risks) };
+  } catch { return {}; }
+}
+
+/** Merge model-matured fields over the user's spec (user-provided values win when the model left a gap
+ *  empty; the model fills the blanks). Pure — used by the backend after the model call. */
+export function mergeMatured(spec: PreflightSpec, m: MaturedFields): PreflightSpec {
+  return {
+    ...spec,
+    doneDefinition: spec.doneDefinition || m.definitionOfDone,
+    command: spec.command || m.suggestedCommand || undefined,
+    nonGoals: spec.nonGoals || m.nonGoals,
+    risks: spec.risks || m.risks,
+  };
+}

--- a/desktop/loop_report.test.ts
+++ b/desktop/loop_report.test.ts
@@ -1,0 +1,167 @@
+// desktop/loop_report.test.ts — P-GOAL.9 (ADR-0054): the After-Action Report's pure core.
+
+import { describe, expect, test } from "bun:test";
+import {
+  bar,
+  extractUrls,
+  formatDuration,
+  type LoopMetrics,
+  mermaidBar,
+  mermaidPie,
+  normalizeToolName,
+  parseNumstat,
+  renderLoopReport,
+  stallSignature,
+  summarizeLoop,
+} from "./loop_report.ts";
+
+describe("normalizeToolName", () => {
+  test("groups common omp kinds into stable types", () => {
+    expect(normalizeToolName("Edit")).toBe("edit");
+    expect(normalizeToolName("Write")).toBe("edit");
+    expect(normalizeToolName("Bash")).toBe("shell");
+    expect(normalizeToolName("execute_command")).toBe("shell");
+    expect(normalizeToolName("Grep")).toBe("search");
+    expect(normalizeToolName("Read")).toBe("read");
+    expect(normalizeToolName("WebFetch")).toBe("web-fetch");
+    expect(normalizeToolName("web_search")).toBe("web-search");
+  });
+  test("web-search is matched before web-fetch (order matters)", () => {
+    expect(normalizeToolName("WebSearch")).toBe("web-search");
+  });
+  test("unknown kinds pass through slugged, never throw", () => {
+    expect(normalizeToolName("MyCustomThing!!")).toBe("mycustomthing");
+    expect(normalizeToolName("")).toBe("other");
+  });
+});
+
+describe("extractUrls", () => {
+  test("pulls, dedupes, and trims trailing punctuation", () => {
+    const urls = extractUrls("see https://example.com/docs. also https://example.com/docs and http://a.io/x)");
+    expect(urls).toEqual(["https://example.com/docs", "http://a.io/x"]);
+  });
+  test("ignores non-http text and respects the cap", () => {
+    expect(extractUrls("nothing here, ftp://x not matched")).toEqual([]);
+    const many = Array.from({ length: 10 }, (_, i) => `https://h${i}.com`).join(" ");
+    expect(extractUrls(many, 3)).toHaveLength(3);
+  });
+});
+
+describe("parseNumstat", () => {
+  test("sums added/removed and counts files", () => {
+    const loc = parseNumstat("12\t3\tsrc/a.ts\n0\t8\tsrc/b.ts\n");
+    expect(loc).toEqual({ added: 12, removed: 11, files: 2 });
+  });
+  test("skips binary (-) files for line counts but still counts the file", () => {
+    const loc = parseNumstat("-\t-\timg.png\n5\t0\tnote.md");
+    expect(loc).toEqual({ added: 5, removed: 0, files: 2 });
+  });
+  test("empty input is zeroed", () => {
+    expect(parseNumstat("")).toEqual({ added: 0, removed: 0, files: 0 });
+  });
+});
+
+describe("stallSignature", () => {
+  test("collapses digits so a recurring blocker matches across rounds", () => {
+    expect(stallSignature("3 of 5 tests fail")).toBe(stallSignature("2 of 5 tests fail"));
+  });
+  test("different blockers do not collide", () => {
+    expect(stallSignature("lint errors remain")).not.toBe(stallSignature("type check fails"));
+  });
+});
+
+describe("bar / formatDuration", () => {
+  test("bar fills proportionally and is fixed width", () => {
+    expect(bar(5, 10, 10)).toBe("█████░░░░░");
+    expect(bar(0, 10, 4)).toBe("░░░░");
+    expect(bar(99, 0, 4)).toBe("░░░░"); // max 0 → empty, no divide-by-zero
+  });
+  test("duration formats across scales", () => {
+    expect(formatDuration(800)).toBe("0.8s");
+    expect(formatDuration(192_000)).toBe("3m 12s");
+    expect(formatDuration(3_840_000)).toBe("1h 04m");
+  });
+});
+
+describe("mermaid helpers", () => {
+  test("pie omits zero slices and returns '' when empty", () => {
+    expect(mermaidPie("T", { edit: 3, read: 0 })).toContain('"edit" : 3');
+    expect(mermaidPie("T", { edit: 3, read: 0 })).not.toContain("read");
+    expect(mermaidPie("T", { a: 0 })).toBe("");
+  });
+  test("bar returns '' when all values are zero, else a valid xychart", () => {
+    expect(mermaidBar("L", ["Added", "Removed"], [0, 0])).toBe("");
+    const c = mermaidBar("L", ["Added", "Removed"], [12, 4], "Lines");
+    expect(c).toContain("xychart-beta");
+    expect(c).toContain("bar [12, 4]");
+    expect(c).toContain("0 --> 12");
+  });
+});
+
+function metrics(over: Partial<LoopMetrics> = {}): LoopMetrics {
+  return {
+    goal: "make auth tests pass",
+    condition: "npm test exits 0",
+    command: "npm test",
+    outcome: "met",
+    outcomeReason: "all tests pass",
+    iterations: 2,
+    maxIters: 6,
+    durationMs: 192_000,
+    toolCalls: { edit: 4, shell: 6, read: 2 },
+    loc: { added: 40, removed: 9, files: 3 },
+    errors: [{ iter: 1, detail: "tool call rejected: bash" }],
+    websites: ["https://example.com/docs"],
+    perIteration: [
+      { n: 1, tools: 7, errors: 1, done: false, reason: "1 test still failing" },
+      { n: 2, tools: 5, errors: 0, done: true, reason: "all green" },
+    ],
+    ...over,
+  };
+}
+
+describe("renderLoopReport", () => {
+  test("includes every required section and graph", () => {
+    const md = renderLoopReport(metrics());
+    expect(md).toContain("# After-Action Report: make auth tests pass");
+    expect(md).toContain("✅ Goal met");
+    expect(md).toContain("## Scoreboard");
+    expect(md).toContain("## Tool calls by type");
+    expect(md).toContain("```mermaid"); // at least one chart
+    expect(md).toContain("## Lines of code changed");
+    expect(md).toContain("+40 / -9");
+    expect(md).toContain("## Errors recorded");
+    expect(md).toContain("## Websites visited");
+    expect(md).toContain("https://example.com/docs");
+    expect(md).toContain("## Per-iteration log");
+    expect(md).toContain("Iterations | 2 of 6");
+  });
+
+  test("degrades honestly when data is absent (no charts crash)", () => {
+    const md = renderLoopReport(metrics({
+      toolCalls: {}, loc: null, errors: [], websites: [],
+      outcome: "stopped", outcomeReason: "hit the cap",
+      perIteration: [{ n: 1, tools: 0, errors: 0, done: false, reason: "no progress" }],
+    }));
+    expect(md).toContain("⏹️ Stopped");
+    expect(md).toContain("_No tool calls recorded._");
+    expect(md).toContain("Not a git workspace");
+    expect(md).toContain("_No errors recorded");
+    expect(md).toContain("_None._"); // websites
+    // an all-absent report must NOT emit an (invalid) empty mermaid block
+    expect(md).not.toContain("```mermaid\npie showData title Tool calls by type\n```");
+  });
+
+  test("is deterministic — same metrics, same bytes", () => {
+    expect(renderLoopReport(metrics())).toBe(renderLoopReport(metrics()));
+  });
+});
+
+describe("summarizeLoop", () => {
+  test("compact one-liner for the banner / event", () => {
+    expect(summarizeLoop(metrics())).toBe("2 iter · 12 tool calls · +40/-9 LOC · 1 errors · 1 sites");
+  });
+  test("notes when LOC is unavailable", () => {
+    expect(summarizeLoop(metrics({ loc: null }))).toContain("LOC n/a");
+  });
+});

--- a/desktop/loop_report.test.ts
+++ b/desktop/loop_report.test.ts
@@ -155,6 +155,20 @@ describe("renderLoopReport", () => {
   test("is deterministic — same metrics, same bytes", () => {
     expect(renderLoopReport(metrics())).toBe(renderLoopReport(metrics()));
   });
+
+  test("table cells escape backslash before pipe (CodeQL: incomplete escaping)", () => {
+    // A trailing backslash must NOT be left able to escape the cell's closing pipe.
+    const md = renderLoopReport(metrics({
+      errors: [{ iter: 1, detail: "path C:\\tmp | bad" }],
+      perIteration: [{ n: 1, tools: 1, errors: 1, done: false, reason: "regex a\\|b failed" }],
+    }));
+    expect(md).toContain("C:\\\\tmp \\| bad");   // backslash → \\, pipe → \|
+    expect(md).toContain("regex a\\\\\\|b failed"); // a, \ →\\, | →\|, b
+    // every body row still has the right number of cell delimiters (not broken by a stray pipe)
+    for (const line of md.split("\n").filter((l) => /^\| 1 \|/.test(l))) {
+      expect(line.endsWith(" |")).toBe(true);
+    }
+  });
 });
 
 describe("summarizeLoop", () => {

--- a/desktop/loop_report.ts
+++ b/desktop/loop_report.ts
@@ -1,0 +1,274 @@
+// desktop/loop_report.ts
+//
+// P-GOAL.9 (ADR-0054): the loop's AFTER-ACTION REPORT (AAR) and the pure helpers behind the loop's
+// run-time instrumentation. loop-engineering's ship-readiness rubric (Observability §9) asks every
+// unattended loop to "log each run: started, items found, actions taken" and to surface metrics the
+// team can read WITHOUT scrolling chat. ADR-0046's durable goal-memory is the human-readable trail;
+// this is the measurable one — a self-contained markdown record with portable graphs that renders on
+// GitHub / VS Code / Obsidian (Mermaid, zero deps, fits the TS-only invariant) plus a plain-text
+// scoreboard that renders even in our in-app `marked` view.
+//
+// PURE module: no I/O, no Date.now(). The backend (acp_backend.ts) collects a `LoopMetrics` during the
+// run and calls `renderLoopReport` as the loop's LAST task; the file write is best-effort (goal_memory).
+// Everything here is unit-tested — the same discipline as loop_estimate.ts / goal_verdict.ts.
+
+export interface IterStat {
+  /** 1-based iteration number. */ n: number;
+  /** tool calls the maker made this iteration. */ tools: number;
+  /** errors recorded this iteration (failed/blocked tool calls). */ errors: number;
+  /** did the checker pass this round? */ done: boolean;
+  /** the checker's one-line reason (for the per-iteration log). */ reason: string;
+}
+
+export interface LocStat { added: number; removed: number; files: number }
+
+export type LoopOutcome = "met" | "stopped" | "cancelled" | "error";
+
+export interface LoopMetrics {
+  goal: string;
+  condition: string;
+  command?: string;
+  outcome: LoopOutcome;
+  outcomeReason: string;
+  iterations: number;
+  maxIters: number;
+  durationMs: number;
+  /** tool-call tally keyed by normalized type (see normalizeToolName). */
+  toolCalls: Record<string, number>;
+  /** lines of code changed across the run; null when the workspace isn't a git repo. */
+  loc: LocStat | null;
+  /** every error recorded, with the iteration it happened in. */
+  errors: { iter: number; detail: string }[];
+  /** unique http(s) URLs the maker touched (web fetch / search / links in tool details). */
+  websites: string[];
+  perIteration: IterStat[];
+}
+
+// ── pure collectors (used by the backend's instrumentation) ───────────────────
+
+/** Group a raw omp tool kind/title into a small, stable set of TYPES for the "by type" chart.
+ *  Unknown kinds pass through lowercased so a new tool still shows up (just ungrouped). */
+export function normalizeToolName(raw: string): string {
+  const n = (raw || "").toLowerCase().trim();
+  if (!n) return "other";
+  if (/web.?search|google|brave|ddg/.test(n)) return "web-search";
+  if (/web.?fetch|fetch|http|curl|url|browse/.test(n)) return "web-fetch";
+  if (/edit|write|patch|apply|create|insert|replace/.test(n)) return "edit";
+  if (/bash|shell|exec|command|run|terminal|process/.test(n)) return "shell";
+  if (/grep|glob|search|find|ripgrep|rg/.test(n)) return "search";
+  if (/read|cat|open|view/.test(n)) return "read";
+  if (/delete|remove|rm\b/.test(n)) return "delete";
+  if (/task|agent|subagent|delegate|spawn/.test(n)) return "subagent";
+  return n.replace(/[^a-z0-9-]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 24) || "other";
+}
+
+/** Pull http(s) URLs out of arbitrary text (tool details, the maker's stream). Deduped, trailing
+ *  punctuation trimmed, capped so a chatty run can't bloat the report. */
+export function extractUrls(text: string, cap = 50): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const re = /https?:\/\/[^\s"'`)<>\]}]+/gi;
+  for (const m of (text || "").matchAll(re)) {
+    let u = m[0].replace(/[.,;:!?)\]]+$/, ""); // strip trailing sentence punctuation
+    if (u.length > 200) u = u.slice(0, 200);
+    const key = u.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(u);
+    if (out.length >= cap) break;
+  }
+  return out;
+}
+
+/** Parse `git diff --numstat` output into totals. Binary files (numstat shows "-\t-") are skipped.
+ *  Pure so it can be unit-tested without a git repo; the backend runs git, this reads the bytes. */
+export function parseNumstat(out: string): LocStat {
+  let added = 0, removed = 0, files = 0;
+  for (const line of (out || "").split("\n")) {
+    const m = /^(\d+|-)\t(\d+|-)\t(.+)$/.exec(line.trim());
+    if (!m) continue;
+    files++;
+    if (m[1] !== "-") added += Number(m[1]);
+    if (m[2] !== "-") removed += Number(m[2]);
+  }
+  return { added, removed, files };
+}
+
+/** A normalized signature of a checker's not-done reason, so the loop can detect it is STUCK on the
+ *  SAME failure round after round (loop-engineering's #1 "Infinite Fix Loop"). Digits/punctuation
+ *  dropped so "3 of 5 tests fail" and "2 of 5 tests fail" collapse to the same recurring blocker. */
+export function stallSignature(reason: string): string {
+  return (reason || "")
+    .toLowerCase()
+    .replace(/[0-9]+/g, "#")
+    .replace(/[^a-z#]+/g, " ")
+    .trim()
+    .split(/\s+/)
+    .slice(0, 12)
+    .join(" ");
+}
+
+// ── rendering ─────────────────────────────────────────────────────────────────
+
+/** A fixed-width unicode meter, e.g. bar(3, 10, 20) → "██████░░░░░░░░░░░░░░". */
+export function bar(value: number, max: number, width = 20): string {
+  const filled = max > 0 ? Math.max(0, Math.min(width, Math.round((value / max) * width))) : 0;
+  return "█".repeat(filled) + "░".repeat(width - filled);
+}
+
+/** "3m 12s" / "0.8s" / "1h 04m" — compact, no library. */
+export function formatDuration(ms: number): string {
+  const s = Math.max(0, Math.round(ms / 1000));
+  if (s < 60) return `${(ms / 1000).toFixed(ms < 10_000 ? 1 : 0)}s`;
+  const m = Math.floor(s / 60), rs = s % 60;
+  if (m < 60) return `${m}m ${String(rs).padStart(2, "0")}s`;
+  const h = Math.floor(m / 60), rm = m % 60;
+  return `${h}h ${String(rm).padStart(2, "0")}m`;
+}
+
+/** Quote+sanitize a label for a Mermaid string literal (no quotes/newlines/brackets). */
+function mlabel(s: string): string {
+  return s.replace(/["\n\r[\]{}]/g, " ").replace(/\s+/g, " ").trim().slice(0, 32) || "?";
+}
+
+/** A Mermaid pie chart, or "" when there's nothing to plot (an empty pie is invalid Mermaid). */
+export function mermaidPie(title: string, data: Record<string, number>): string {
+  const entries = Object.entries(data).filter(([, v]) => v > 0).sort((a, b) => b[1] - a[1]);
+  if (!entries.length) return "";
+  const rows = entries.map(([k, v]) => `  "${mlabel(k)}" : ${v}`).join("\n");
+  return "```mermaid\npie showData title " + mlabel(title) + "\n" + rows + "\n```";
+}
+
+/** A Mermaid bar chart (xychart-beta), or "" when every value is zero. */
+export function mermaidBar(title: string, xLabels: (string | number)[], values: number[], yTitle = "Count"): string {
+  if (!values.length || values.every((v) => v === 0)) return "";
+  const max = Math.max(1, ...values);
+  const xs = xLabels.map((x) => `"${mlabel(String(x))}"`).join(", ");
+  return (
+    "```mermaid\nxychart-beta\n" +
+    `  title "${mlabel(title)}"\n` +
+    `  x-axis [${xs}]\n` +
+    `  y-axis "${mlabel(yTitle)}" 0 --> ${max}\n` +
+    `  bar [${values.join(", ")}]\n` +
+    "```"
+  );
+}
+
+const OUTCOME_BADGE: Record<LoopOutcome, string> = {
+  met: "✅ Goal met",
+  stopped: "⏹️ Stopped",
+  cancelled: "🛑 Cancelled",
+  error: "❗ Error",
+};
+
+/** One-line summary for the event payload / in-app banner. */
+export function summarizeLoop(m: LoopMetrics): string {
+  const tools = Object.values(m.toolCalls).reduce((a, b) => a + b, 0);
+  const loc = m.loc ? `+${m.loc.added}/-${m.loc.removed} LOC` : "LOC n/a";
+  return `${m.iterations} iter · ${tools} tool calls · ${loc} · ${m.errors.length} errors · ${m.websites.length} sites`;
+}
+
+/** Render the full After-Action Report markdown. Deterministic: the same metrics always produce the
+ *  same bytes (so a future diff/regression test is stable). Sections that have no data degrade to an
+ *  honest one-liner rather than an empty/invalid chart. */
+export function renderLoopReport(m: LoopMetrics): string {
+  const totalTools = Object.values(m.toolCalls).reduce((a, b) => a + b, 0);
+  const added = m.loc?.added ?? 0, removed = m.loc?.removed ?? 0;
+  const scoreMax = Math.max(1, totalTools, added, removed, m.errors.length, m.websites.length);
+  const pad = (s: string) => s.padEnd(14);
+  const scoreboard = [
+    `${pad("Tool calls")}${bar(totalTools, scoreMax)}  ${totalTools}`,
+    `${pad("Lines added")}${bar(added, scoreMax)}  +${added}`,
+    `${pad("Lines removed")}${bar(removed, scoreMax)}  -${removed}`,
+    `${pad("Errors")}${bar(m.errors.length, scoreMax)}  ${m.errors.length}`,
+    `${pad("Websites")}${bar(m.websites.length, scoreMax)}  ${m.websites.length}`,
+  ].join("\n");
+
+  const out: string[] = [];
+  out.push(`# After-Action Report: ${m.goal}`);
+  out.push("");
+  out.push(`**${OUTCOME_BADGE[m.outcome]}** — ${m.outcomeReason}`);
+  out.push("");
+  out.push(`| | |`);
+  out.push(`|---|---|`);
+  out.push(`| Iterations | ${m.iterations} of ${m.maxIters} |`);
+  out.push(`| Duration | ${formatDuration(m.durationMs)} |`);
+  out.push(`| Stop condition | ${m.condition || "—"} |`);
+  out.push(`| Verification | ${m.command ? "`" + m.command + "`" : "checker judgement (no command)"} |`);
+  out.push("");
+
+  out.push("## Scoreboard");
+  out.push("");
+  out.push("```text");
+  out.push(scoreboard);
+  out.push("```");
+  out.push("");
+
+  out.push("## Tool calls by type");
+  out.push("");
+  const pie = mermaidPie("Tool calls by type", m.toolCalls);
+  if (pie) {
+    out.push(pie);
+    out.push("");
+    out.push("| Tool | Calls |");
+    out.push("|---|---|");
+    for (const [k, v] of Object.entries(m.toolCalls).filter(([, v]) => v > 0).sort((a, b) => b[1] - a[1])) {
+      out.push(`| ${k} | ${v} |`);
+    }
+  } else {
+    out.push("_No tool calls recorded._");
+  }
+  out.push("");
+
+  out.push("## Lines of code changed");
+  out.push("");
+  if (m.loc) {
+    const bars = mermaidBar("Lines of code changed", ["Added", "Removed"], [added, removed], "Lines");
+    if (bars) out.push(bars);
+    else out.push("_No lines changed._");
+    out.push("");
+    out.push(`Net **+${added} / -${removed}** across **${m.loc.files}** file${m.loc.files === 1 ? "" : "s"}.`);
+  } else {
+    out.push("_Not a git workspace — line-change tracking unavailable._");
+  }
+  out.push("");
+
+  out.push("## Errors recorded");
+  out.push("");
+  if (m.errors.length) {
+    const perIterErrors = m.perIteration.map((it) => it.errors);
+    const xs = m.perIteration.map((it) => it.n);
+    const chart = mermaidBar("Errors recorded per iteration", xs, perIterErrors, "Errors");
+    if (chart) { out.push(chart); out.push(""); }
+    out.push("| Iter | Error |");
+    out.push("|---|---|");
+    for (const e of m.errors.slice(0, 50)) out.push(`| ${e.iter} | ${e.detail.replace(/\|/g, "\\|").slice(0, 160)} |`);
+    if (m.errors.length > 50) out.push(`| … | _${m.errors.length - 50} more_ |`);
+  } else {
+    out.push("_No errors recorded. 🎉_");
+  }
+  out.push("");
+
+  out.push("## Websites visited");
+  out.push("");
+  if (m.websites.length) {
+    out.push("| # | URL |");
+    out.push("|---|---|");
+    m.websites.forEach((u, i) => out.push(`| ${i + 1} | ${u.replace(/\|/g, "%7C")} |`));
+  } else {
+    out.push("_None._");
+  }
+  out.push("");
+
+  out.push("## Per-iteration log");
+  out.push("");
+  out.push("| Iter | Tools | Errors | Checker |");
+  out.push("|---|---|---|---|");
+  for (const it of m.perIteration) {
+    const verdict = `${it.done ? "✅ met" : "… not yet"} — ${(it.reason || "").replace(/\|/g, "\\|").slice(0, 120)}`;
+    out.push(`| ${it.n} | ${it.tools} | ${it.errors} | ${verdict} |`);
+  }
+  out.push("");
+
+  return out.join("\n");
+}

--- a/desktop/loop_report.ts
+++ b/desktop/loop_report.ts
@@ -69,7 +69,9 @@ export function extractUrls(text: string, cap = 50): string[] {
   const seen = new Set<string>();
   const re = /https?:\/\/[^\s"'`)<>\]}]+/gi;
   for (const m of (text || "").matchAll(re)) {
-    let u = m[0].replace(/[.,;:!?)\]]+$/, ""); // strip trailing sentence punctuation
+    const m0 = m[0];
+    if (!m0) continue;
+    let u = m0.replace(/[.,;:!?)\]]+$/, ""); // strip trailing sentence punctuation
     if (u.length > 200) u = u.slice(0, 200);
     const key = u.toLowerCase();
     if (seen.has(key)) continue;
@@ -129,6 +131,13 @@ export function formatDuration(ms: number): string {
 /** Quote+sanitize a label for a Mermaid string literal (no quotes/newlines/brackets). */
 function mlabel(s: string): string {
   return s.replace(/["\n\r[\]{}]/g, " ").replace(/\s+/g, " ").trim().slice(0, 32) || "?";
+}
+
+/** Escape arbitrary text for a single Markdown table cell. Backslashes are escaped FIRST — otherwise a
+ *  trailing "\" in the input would escape the cell's closing "|" and corrupt the row — then pipes, then
+ *  newlines are flattened (a table cell can't span lines). */
+function mdCell(s: string): string {
+  return (s || "").replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/[\r\n]+/g, " ");
 }
 
 /** A Mermaid pie chart, or "" when there's nothing to plot (an empty pie is invalid Mermaid). */
@@ -242,7 +251,7 @@ export function renderLoopReport(m: LoopMetrics): string {
     if (chart) { out.push(chart); out.push(""); }
     out.push("| Iter | Error |");
     out.push("|---|---|");
-    for (const e of m.errors.slice(0, 50)) out.push(`| ${e.iter} | ${e.detail.replace(/\|/g, "\\|").slice(0, 160)} |`);
+    for (const e of m.errors.slice(0, 50)) out.push(`| ${e.iter} | ${mdCell(e.detail.slice(0, 160))} |`);
     if (m.errors.length > 50) out.push(`| … | _${m.errors.length - 50} more_ |`);
   } else {
     out.push("_No errors recorded. 🎉_");
@@ -265,7 +274,7 @@ export function renderLoopReport(m: LoopMetrics): string {
   out.push("| Iter | Tools | Errors | Checker |");
   out.push("|---|---|---|---|");
   for (const it of m.perIteration) {
-    const verdict = `${it.done ? "✅ met" : "… not yet"} — ${(it.reason || "").replace(/\|/g, "\\|").slice(0, 120)}`;
+    const verdict = `${it.done ? "✅ met" : "… not yet"} — ${mdCell((it.reason || "").slice(0, 120))}`;
     out.push(`| ${it.n} | ${it.tools} | ${it.errors} | ${verdict} |`);
   }
   out.push("");

--- a/desktop/loop_report.ts
+++ b/desktop/loop_report.ts
@@ -12,6 +12,8 @@
 // run and calls `renderLoopReport` as the loop's LAST task; the file write is best-effort (goal_memory).
 // Everything here is unit-tested — the same discipline as loop_estimate.ts / goal_verdict.ts.
 
+import { formatTokens } from "./loop_estimate.ts";
+
 export interface IterStat {
   /** 1-based iteration number. */ n: number;
   /** tool calls the maker made this iteration. */ tools: number;
@@ -42,6 +44,12 @@ export interface LoopMetrics {
   /** unique http(s) URLs the maker touched (web fetch / search / links in tool details). */
   websites: string[];
   perIteration: IterStat[];
+  // P-GOAL.11 (ADR-0056): actual spend. null when no usage telemetry was observed.
+  spendUsd?: number | null;
+  /** peak context-window fill across the run (informational; not summed). */
+  peakContextTokens?: number | null;
+  /** the budget cap that was in force, if any (0/undefined = no cap). */
+  budgetUsd?: number;
 }
 
 // ── pure collectors (used by the backend's instrumentation) ───────────────────
@@ -118,6 +126,12 @@ export function bar(value: number, max: number, width = 20): string {
   return "█".repeat(filled) + "░".repeat(width - filled);
 }
 
+/** Dollars for the report: 2-dp, but a tiny non-zero spend shows "<$0.01" rather than "$0.00". */
+export function formatSpend(usd: number): string {
+  if (usd > 0 && usd < 0.01) return "<$0.01";
+  return `$${(Math.round(usd * 100) / 100).toFixed(2)}`;
+}
+
 /** "3m 12s" / "0.8s" / "1h 04m" — compact, no library. */
 export function formatDuration(ms: number): string {
   const s = Math.max(0, Math.round(ms / 1000));
@@ -174,7 +188,8 @@ const OUTCOME_BADGE: Record<LoopOutcome, string> = {
 export function summarizeLoop(m: LoopMetrics): string {
   const tools = Object.values(m.toolCalls).reduce((a, b) => a + b, 0);
   const loc = m.loc ? `+${m.loc.added}/-${m.loc.removed} LOC` : "LOC n/a";
-  return `${m.iterations} iter · ${tools} tool calls · ${loc} · ${m.errors.length} errors · ${m.websites.length} sites`;
+  const spend = m.spendUsd != null ? ` · ${formatSpend(m.spendUsd)}` : "";
+  return `${m.iterations} iter · ${tools} tool calls · ${loc} · ${m.errors.length} errors · ${m.websites.length} sites${spend}`;
 }
 
 /** Render the full After-Action Report markdown. Deterministic: the same metrics always produce the
@@ -204,6 +219,10 @@ export function renderLoopReport(m: LoopMetrics): string {
   out.push(`| Duration | ${formatDuration(m.durationMs)} |`);
   out.push(`| Stop condition | ${m.condition || "—"} |`);
   out.push(`| Verification | ${m.command ? "`" + m.command + "`" : "checker judgement (no command)"} |`);
+  if (m.spendUsd != null) {
+    const cap = m.budgetUsd && m.budgetUsd > 0 ? ` of ${formatSpend(m.budgetUsd)} cap` : "";
+    out.push(`| Spend | ${formatSpend(m.spendUsd)}${cap}${m.peakContextTokens ? ` · peak context ${formatTokens(m.peakContextTokens)}` : ""} |`);
+  }
   out.push("");
 
   out.push("## Scoreboard");

--- a/desktop/loop_runlog.test.ts
+++ b/desktop/loop_runlog.test.ts
@@ -1,0 +1,119 @@
+// desktop/loop_runlog.test.ts — P-GOAL.10 (ADR-0055): the cross-run evaluation ledger's pure core.
+
+import { describe, expect, test } from "bun:test";
+import { type LoopMetrics } from "./loop_report.ts";
+import {
+  aggregateRuns,
+  type LoopRunRecord,
+  parseRunLog,
+  runRecordLine,
+  summarizeRunStats,
+  toRunRecord,
+} from "./loop_runlog.ts";
+
+function metrics(over: Partial<LoopMetrics> = {}): LoopMetrics {
+  return {
+    goal: "make tests pass", condition: "npm test exits 0", command: "npm test",
+    outcome: "met", outcomeReason: "all pass", iterations: 3, maxIters: 6, durationMs: 120_000,
+    toolCalls: { shell: 5, edit: 3 }, loc: { added: 40, removed: 9, files: 2 },
+    errors: [{ iter: 1, detail: "x" }], websites: ["https://a.io"],
+    perIteration: [], ...over,
+  };
+}
+
+function rec(over: Partial<LoopRunRecord> = {}): LoopRunRecord {
+  return {
+    ts: 1000, id: "r", goal: "g", outcome: "met", outcomeReason: "ok", iterations: 2, maxIters: 6,
+    durationMs: 1000, tools: 4, toolsByType: { shell: 4 }, added: 0, removed: 0, hasLoc: false,
+    errors: 0, websites: 0, ...over,
+  };
+}
+
+describe("toRunRecord", () => {
+  test("projects LoopMetrics into a compact ledger record", () => {
+    const r = toRunRecord(metrics(), { id: "abc", ts: 42 });
+    expect(r).toMatchObject({
+      id: "abc", ts: 42, goal: "make tests pass", outcome: "met", iterations: 3,
+      tools: 8, toolsByType: { shell: 5, edit: 3 }, added: 40, removed: 9, hasLoc: true,
+      errors: 1, websites: 1, command: "npm test",
+    });
+  });
+  test("no git ⇒ hasLoc false, added/removed default to 0 (unknown, not zero)", () => {
+    const r = toRunRecord(metrics({ loc: null }), { id: "x", ts: 1 });
+    expect(r.hasLoc).toBe(false);
+    expect(r.added).toBe(0);
+  });
+});
+
+describe("runRecordLine / parseRunLog round-trip", () => {
+  test("a written line parses back to an equal record", () => {
+    const r = toRunRecord(metrics(), { id: "abc", ts: 42 });
+    const parsed = parseRunLog(runRecordLine(r) + "\n");
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]).toEqual(r);
+  });
+  test("skips blank and malformed lines, keeps the valid ones", () => {
+    const good = runRecordLine(rec({ id: "ok" }));
+    const log = `\n${good}\nnot json\n{"partial": true}\n${runRecordLine(rec({ id: "ok2" }))}\n`;
+    const parsed = parseRunLog(log);
+    expect(parsed.map((r) => r.id)).toEqual(["ok", "ok2"]);
+  });
+  test("empty content ⇒ no records", () => {
+    expect(parseRunLog("")).toEqual([]);
+  });
+});
+
+describe("aggregateRuns", () => {
+  test("success rate + avg iterations over only the succeeded runs", () => {
+    const s = aggregateRuns([
+      rec({ outcome: "met", iterations: 2 }),
+      rec({ outcome: "met", iterations: 4 }),
+      rec({ outcome: "stopped", iterations: 6, outcomeReason: "hit the cap" }),
+      rec({ outcome: "error", iterations: 1, outcomeReason: "loop error: boom" }),
+    ]);
+    expect(s.runs).toBe(4);
+    expect(s.succeeded).toBe(2);
+    expect(s.successRate).toBe(0.5);
+    expect(s.avgItersToSucceed).toBe(3); // (2+4)/2 — the stopped/error runs are excluded
+  });
+
+  test("sums tools/LOC/errors and merges tool-type tallies", () => {
+    const s = aggregateRuns([
+      rec({ tools: 4, toolsByType: { shell: 4 }, added: 10, removed: 2, errors: 1 }),
+      rec({ tools: 3, toolsByType: { shell: 1, edit: 2 }, added: 5, removed: 0, errors: 2 }),
+    ]);
+    expect(s.totalTools).toBe(7);
+    expect(s.toolsByType).toEqual({ shell: 5, edit: 2 });
+    expect(s.totalAdded).toBe(15);
+    expect(s.totalRemoved).toBe(2);
+    expect(s.totalErrors).toBe(3);
+  });
+
+  test("failure breakdown groups recurring blockers (digits collapsed), most-common first", () => {
+    const s = aggregateRuns([
+      rec({ outcome: "stopped", outcomeReason: "stopped: 3 of 5 tests fail" }),
+      rec({ outcome: "stopped", outcomeReason: "stopped: 1 of 5 tests fail" }),
+      rec({ outcome: "error", outcomeReason: "loop error: timeout" }),
+      rec({ outcome: "met", outcomeReason: "all pass" }), // excluded from blockers
+    ]);
+    expect(s.topBlockers[0]!.count).toBe(2);       // the two "N of 5 tests fail" collapse
+    expect(s.topBlockers[0]!.reason).toContain("tests fail");
+    expect(s.topBlockers).toHaveLength(2);          // tests-fail + timeout
+  });
+
+  test("empty history is all-zero, never divides by zero", () => {
+    const s = aggregateRuns([]);
+    expect(s).toMatchObject({ runs: 0, succeeded: 0, successRate: 0, avgItersToSucceed: 0, avgDurationMs: 0 });
+    expect(s.topBlockers).toEqual([]);
+  });
+});
+
+describe("summarizeRunStats", () => {
+  test("compact chip text", () => {
+    const s = aggregateRuns([rec({ outcome: "met", iterations: 3 }), rec({ outcome: "stopped", outcomeReason: "cap" })]);
+    expect(summarizeRunStats(s)).toBe("2 runs · 50% met · ~3.0 iters to win");
+  });
+  test("no runs", () => {
+    expect(summarizeRunStats(aggregateRuns([]))).toBe("no loop runs yet");
+  });
+});

--- a/desktop/loop_runlog.test.ts
+++ b/desktop/loop_runlog.test.ts
@@ -25,7 +25,7 @@ function rec(over: Partial<LoopRunRecord> = {}): LoopRunRecord {
   return {
     ts: 1000, id: "r", goal: "g", outcome: "met", outcomeReason: "ok", iterations: 2, maxIters: 6,
     durationMs: 1000, tools: 4, toolsByType: { shell: 4 }, added: 0, removed: 0, hasLoc: false,
-    errors: 0, websites: 0, ...over,
+    errors: 0, websites: 0, spendUsd: 0, hasSpend: false, ...over,
   };
 }
 
@@ -42,6 +42,11 @@ describe("toRunRecord", () => {
     const r = toRunRecord(metrics({ loc: null }), { id: "x", ts: 1 });
     expect(r.hasLoc).toBe(false);
     expect(r.added).toBe(0);
+  });
+  test("carries spend when observed; marks it unknown when absent (P-GOAL.11)", () => {
+    expect(toRunRecord(metrics({ spendUsd: 0.42 }), { id: "a", ts: 1 })).toMatchObject({ spendUsd: 0.42, hasSpend: true });
+    const noSpend = toRunRecord(metrics({ spendUsd: null }), { id: "b", ts: 1 });
+    expect(noSpend).toMatchObject({ spendUsd: 0, hasSpend: false });
   });
 });
 
@@ -87,6 +92,15 @@ describe("aggregateRuns", () => {
     expect(s.totalAdded).toBe(15);
     expect(s.totalRemoved).toBe(2);
     expect(s.totalErrors).toBe(3);
+  });
+
+  test("sums spend only over runs that reported it (P-GOAL.11)", () => {
+    const s = aggregateRuns([
+      rec({ spendUsd: 0.10, hasSpend: true }),
+      rec({ spendUsd: 0.25, hasSpend: true }),
+      rec({ spendUsd: 0, hasSpend: false }), // unknown spend — excluded, not counted as $0
+    ]);
+    expect(s.totalSpendUsd).toBeCloseTo(0.35, 10);
   });
 
   test("failure breakdown groups recurring blockers (digits collapsed), most-common first", () => {

--- a/desktop/loop_runlog.ts
+++ b/desktop/loop_runlog.ts
@@ -1,0 +1,161 @@
+// desktop/loop_runlog.ts
+//
+// P-GOAL.10 (ADR-0055): the cross-run EVALUATION surface for /goal loops. ADR-0054's After-Action
+// Report measures ONE run; loop-engineering's rubric (§9 Observability) also wants the team to read
+// trends across runs — "success metrics established", an "append-only run history". This is that
+// ledger: one compact JSON line per completed loop (append-only, under `.omp/loops/run-log.jsonl`,
+// the same durable home as goal-memory), plus a PURE aggregator that turns the history into stats a
+// user can act on — success rate, average iterations-to-success, failure breakdown by recurring blocker.
+//
+// Deliberately a flat JSONL file, NOT DuckDB: the desktop /goal loop persists to `.omp/loops/` markdown
+// (goal_memory) — this stays in that lightweight, air-gap-clean lane and never touches the frozen DuckDB
+// schema (invariant #10). PURE module: no I/O, no Date.now(); the backend stamps `ts`/`id` and writes.
+
+import { type LoopMetrics, type LoopOutcome, stallSignature } from "./loop_report.ts";
+
+/** One completed loop, compacted for the ledger. A superset of what the aggregator needs, so the raw
+ *  history stays inspectable (and a future richer view doesn't need a migration). */
+export interface LoopRunRecord {
+  ts: number;            // completion time (ms epoch), stamped by the backend
+  id: string;            // the loop id (shared with its memory + report files)
+  goal: string;
+  outcome: LoopOutcome;
+  outcomeReason: string;
+  iterations: number;
+  maxIters: number;
+  durationMs: number;
+  tools: number;                       // total tool calls
+  toolsByType: Record<string, number>;
+  added: number;                       // LOC added (0 when not a git repo)
+  removed: number;
+  hasLoc: boolean;                     // false ⇒ added/removed are "unknown", not "zero"
+  errors: number;
+  websites: number;
+  command?: string;
+}
+
+/** Project a P-GOAL.9 `LoopMetrics` into a ledger record. `id`/`ts` come from the backend (the same
+ *  loop id used for the memory + report files; `ts` because pure modules can't read the clock). */
+export function toRunRecord(m: LoopMetrics, meta: { id: string; ts: number }): LoopRunRecord {
+  const tools = Object.values(m.toolCalls).reduce((a, b) => a + b, 0);
+  return {
+    ts: meta.ts,
+    id: meta.id,
+    goal: m.goal,
+    outcome: m.outcome,
+    outcomeReason: m.outcomeReason,
+    iterations: m.iterations,
+    maxIters: m.maxIters,
+    durationMs: m.durationMs,
+    tools,
+    toolsByType: { ...m.toolCalls },
+    added: m.loc?.added ?? 0,
+    removed: m.loc?.removed ?? 0,
+    hasLoc: m.loc != null,
+    errors: m.errors.length,
+    websites: m.websites.length,
+    command: m.command,
+  };
+}
+
+/** Serialize a record to one JSONL line (no trailing newline — the writer adds it). */
+export function runRecordLine(r: LoopRunRecord): string {
+  return JSON.stringify(r);
+}
+
+/** Parse a run-log's JSONL content into records, skipping any malformed / non-record line (the ledger
+ *  is append-only and best-effort; one bad line must never poison the whole history). */
+export function parseRunLog(content: string): LoopRunRecord[] {
+  const out: LoopRunRecord[] = [];
+  for (const line of (content ?? "").split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+    try {
+      const o = JSON.parse(t) as Partial<LoopRunRecord>;
+      if (typeof o?.id !== "string" || typeof o?.goal !== "string" || typeof o?.outcome !== "string") continue;
+      out.push({
+        ts: Number(o.ts) || 0,
+        id: o.id,
+        goal: o.goal,
+        outcome: o.outcome as LoopOutcome,
+        outcomeReason: String(o.outcomeReason ?? ""),
+        iterations: Number(o.iterations) || 0,
+        maxIters: Number(o.maxIters) || 0,
+        durationMs: Number(o.durationMs) || 0,
+        tools: Number(o.tools) || 0,
+        toolsByType: (o.toolsByType && typeof o.toolsByType === "object") ? o.toolsByType as Record<string, number> : {},
+        added: Number(o.added) || 0,
+        removed: Number(o.removed) || 0,
+        hasLoc: o.hasLoc === true,
+        errors: Number(o.errors) || 0,
+        websites: Number(o.websites) || 0,
+        command: typeof o.command === "string" ? o.command : undefined,
+      });
+    } catch { /* skip a malformed line */ }
+  }
+  return out;
+}
+
+export interface RunStats {
+  runs: number;
+  succeeded: number;        // outcome === "met"
+  successRate: number;      // succeeded / runs (0 when no runs)
+  avgItersToSucceed: number; // mean iterations over SUCCEEDED runs (0 when none)
+  avgDurationMs: number;
+  totalTools: number;
+  toolsByType: Record<string, number>;
+  totalAdded: number;
+  totalRemoved: number;
+  totalErrors: number;
+  /** non-success runs grouped by recurring blocker (normalized reason), most-common first. */
+  topBlockers: { reason: string; count: number }[];
+}
+
+/** Aggregate a run history into the evaluation stats. Pure + deterministic. Blocker grouping reuses
+ *  `stallSignature` so "3 of 5 tests fail" and "2 of 5 tests fail" collapse to ONE recurring blocker;
+ *  the displayed `reason` is the first full reason seen for that signature. */
+export function aggregateRuns(records: LoopRunRecord[]): RunStats {
+  const runs = records.length;
+  const met = records.filter((r) => r.outcome === "met");
+  const toolsByType: Record<string, number> = {};
+  let totalTools = 0, totalAdded = 0, totalRemoved = 0, totalErrors = 0, totalDuration = 0;
+  for (const r of records) {
+    totalTools += r.tools;
+    totalAdded += r.added;
+    totalRemoved += r.removed;
+    totalErrors += r.errors;
+    totalDuration += r.durationMs;
+    for (const [k, v] of Object.entries(r.toolsByType)) toolsByType[k] = (toolsByType[k] ?? 0) + (Number(v) || 0);
+  }
+  // failure breakdown: group the non-met runs by normalized blocker signature
+  const blockers = new Map<string, { reason: string; count: number }>();
+  for (const r of records) {
+    if (r.outcome === "met") continue;
+    const sig = stallSignature(r.outcomeReason) || "(unspecified)";
+    const cur = blockers.get(sig);
+    if (cur) cur.count++;
+    else blockers.set(sig, { reason: r.outcomeReason || "(unspecified)", count: 1 });
+  }
+  const topBlockers = [...blockers.values()].sort((a, b) => b.count - a.count);
+  return {
+    runs,
+    succeeded: met.length,
+    successRate: runs ? met.length / runs : 0,
+    avgItersToSucceed: met.length ? met.reduce((a, r) => a + r.iterations, 0) / met.length : 0,
+    avgDurationMs: runs ? totalDuration / runs : 0,
+    totalTools,
+    toolsByType,
+    totalAdded,
+    totalRemoved,
+    totalErrors,
+    topBlockers,
+  };
+}
+
+/** A compact one-line eval summary for a chip/header, e.g. "12 runs · 75% met · ~3.2 iters to win". */
+export function summarizeRunStats(s: RunStats): string {
+  if (!s.runs) return "no loop runs yet";
+  const pct = Math.round(s.successRate * 100);
+  const iters = s.avgItersToSucceed ? ` · ~${s.avgItersToSucceed.toFixed(1)} iters to win` : "";
+  return `${s.runs} run${s.runs === 1 ? "" : "s"} · ${pct}% met${iters}`;
+}

--- a/desktop/loop_runlog.ts
+++ b/desktop/loop_runlog.ts
@@ -31,6 +31,8 @@ export interface LoopRunRecord {
   hasLoc: boolean;                     // false ⇒ added/removed are "unknown", not "zero"
   errors: number;
   websites: number;
+  spendUsd: number;                    // P-GOAL.11: actual dollars spent (0 when unknown)
+  hasSpend: boolean;                   // false ⇒ spendUsd is "unknown", not "$0"
   command?: string;
 }
 
@@ -54,6 +56,8 @@ export function toRunRecord(m: LoopMetrics, meta: { id: string; ts: number }): L
     hasLoc: m.loc != null,
     errors: m.errors.length,
     websites: m.websites.length,
+    spendUsd: m.spendUsd ?? 0,
+    hasSpend: m.spendUsd != null,
     command: m.command,
   };
 }
@@ -89,6 +93,8 @@ export function parseRunLog(content: string): LoopRunRecord[] {
         hasLoc: o.hasLoc === true,
         errors: Number(o.errors) || 0,
         websites: Number(o.websites) || 0,
+        spendUsd: Number(o.spendUsd) || 0,
+        hasSpend: o.hasSpend === true,
         command: typeof o.command === "string" ? o.command : undefined,
       });
     } catch { /* skip a malformed line */ }
@@ -107,6 +113,7 @@ export interface RunStats {
   totalAdded: number;
   totalRemoved: number;
   totalErrors: number;
+  totalSpendUsd: number;   // P-GOAL.11: summed actual spend over runs that reported it
   /** non-success runs grouped by recurring blocker (normalized reason), most-common first. */
   topBlockers: { reason: string; count: number }[];
 }
@@ -118,13 +125,14 @@ export function aggregateRuns(records: LoopRunRecord[]): RunStats {
   const runs = records.length;
   const met = records.filter((r) => r.outcome === "met");
   const toolsByType: Record<string, number> = {};
-  let totalTools = 0, totalAdded = 0, totalRemoved = 0, totalErrors = 0, totalDuration = 0;
+  let totalTools = 0, totalAdded = 0, totalRemoved = 0, totalErrors = 0, totalDuration = 0, totalSpendUsd = 0;
   for (const r of records) {
     totalTools += r.tools;
     totalAdded += r.added;
     totalRemoved += r.removed;
     totalErrors += r.errors;
     totalDuration += r.durationMs;
+    if (r.hasSpend) totalSpendUsd += r.spendUsd;
     for (const [k, v] of Object.entries(r.toolsByType)) toolsByType[k] = (toolsByType[k] ?? 0) + (Number(v) || 0);
   }
   // failure breakdown: group the non-met runs by normalized blocker signature
@@ -148,6 +156,7 @@ export function aggregateRuns(records: LoopRunRecord[]): RunStats {
     totalAdded,
     totalRemoved,
     totalErrors,
+    totalSpendUsd,
     topBlockers,
   };
 }

--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -2624,6 +2624,16 @@ async function runGoalLoop(
     }
     else if (e.type === "goal-done") { wrap.appendChild(el(`<div class="goal-banner ok">${icon("check", 14)} Goal met in ${e.iters} iteration${e.iters === 1 ? "" : "s"}. ${esc(e.reason)}</div>`)); scrollChat(); }
     else if (e.type === "goal-stop") { wrap.appendChild(el(`<div class="goal-banner stop">${icon("info", 14)} ${esc(e.reason)}</div>`)); scrollChat(); }
+    else if (e.type === "goal-report") {
+      // P-GOAL.9: the loop's last task — an After-Action Report (metrics + portable graphs). The durable
+      // record is on disk (Mermaid renders on GitHub/VS Code); in-app we show the summary + the report's
+      // text scoreboard/tables (our `marked` view has no Mermaid, so charts stay in the file).
+      const card = el(`<details class="goal-aar" open>
+        <summary>${icon("graph", 13)} After-Action Report · <b>${esc(e.summary)}</b>${e.path ? ` · <code>${esc(e.path)}</code>` : ""}</summary>
+        <div class="goal-aar-body">${renderMarkdown(e.markdown)}</div>
+      </details>`);
+      wrap.appendChild(card); scrollChat();
+    }
     else if (e.type === "done") { if (streamEl) streamEl.innerHTML = renderMarkdown(buf); }
   };
   try { await (stream ?? ((on: (e: ChatEvent) => void) => bridge.runGoal(opts, on)))(onEvent); }

--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -2289,6 +2289,7 @@ function openGoalForm(): void {
         <div class="goal-step-head"><span class="goal-step-n"></span><h4>Effort and grading</h4></div>
         <div class="goal-note">Cap how many rounds it may take, and pick who grades each round. A cheaper checker keeps cost low. ${goalInfoDot("Iterations and checker|Max iterations is a hard ceiling - the loop stops as soon as the condition holds. The checker is a separate model that grades each round; a small fast model is usually plenty.")}</div>
         <div class="goal-row"><label class="goal-lbl">Max iterations</label><input id="goalMax" class="prov-key goal-max" type="number" min="1" max="20" value="6" /></div>
+        <div class="goal-row"><label class="goal-lbl">Budget cap <span class="goal-opt">optional $ ceiling; stops the loop if spend hits it</span> ${goalInfoDot("Budget cap|A hard dollar ceiling on actual spend. The loop halts the moment the maker's running cost reaches it - the kill switch for unattended runs. Leave blank for no cap (max iterations still bounds the run).")}</label><input id="goalBudget" class="prov-key goal-max" type="number" min="0" step="0.25" placeholder="no cap" /></div>
         <div class="goal-row goal-checker">
           <label class="goal-lbl">${icon("spark", 12)} Checker model <span class="goal-opt">grades each round; a cheaper model is fine</span></label>
           <select id="goalChecker" class="prov-key goal-ckr"><option>loading…</option></select>
@@ -2381,7 +2382,8 @@ function openGoalForm(): void {
     const goal = ($("#goalGoal", ov) as HTMLTextAreaElement).value.trim();
     const command = ($("#goalCmd", ov) as HTMLInputElement).value.trim();
     const maxIters = Math.min(20, Math.max(1, Number(($("#goalMax", ov) as HTMLInputElement).value) || 6));
-    return { goal, command, maxIters };
+    const budgetUsd = Math.max(0, Number(($("#goalBudget", ov) as HTMLInputElement)?.value) || 0); // P-GOAL.11: 0 = no cap
+    return { goal, command, maxIters, budgetUsd };
   };
   // P-GOAL.6.1: live token estimate (lower-left), recomputed as the iteration count changes.
   ($("#goalMax", ov) as HTMLInputElement)?.addEventListener("input", () => updateGoalEstimate(ov));
@@ -2389,11 +2391,11 @@ function openGoalForm(): void {
   render(); // P-GOAL.8: apply guided/advanced mode + show the right step/buttons
   wireCmdSuggest(ov); // P-GOAL.8.1: custom verify-command type-ahead
   $("#goalRun", ov)?.addEventListener("click", async () => {
-    const { goal, command, maxIters } = readSpec();
+    const { goal, command, maxIters, budgetUsd } = readSpec();
     if (!goal) { showToast({ tone: "warn", title: "Add a goal", desc: "Describe what the loop should accomplish.", timeout: 2400 }); return; }
     await applyRunWith(ov); // P-GOAL.7: apply base model / thinking / skill / persona for this run
     close();
-    void runGoalLoop({ goal, condition: command || goal, command: command || undefined, maxIters });
+    void runGoalLoop({ goal, condition: command || goal, command: command || undefined, maxIters, budgetUsd });
   });
   $("#goalSave", ov)?.addEventListener("click", async () => {
     const { goal, command, maxIters } = readSpec();
@@ -2582,7 +2584,8 @@ async function loadLoopStats(ov: HTMLElement): Promise<void> {
   const iters = s.avgItersToSucceed ? `${s.avgItersToSucceed.toFixed(1)}` : "—";
   const dur = s.avgDurationMs ? formatLoopDur(s.avgDurationMs) : "—";
   const blocker = s.topBlockers[0];
-  const mix = Object.entries(s.toolsByType).sort((a, b) => b[1] - a[1]).slice(0, 4)
+  const spend = s.totalSpendUsd > 0 ? `<span class="gs-tool">spend <b>$${s.totalSpendUsd.toFixed(2)}</b></span>` : "";
+  const mix = spend + Object.entries(s.toolsByType).sort((a, b) => b[1] - a[1]).slice(0, 4)
     .map(([k, v]) => `<span class="gs-tool">${esc(k)} <b>${v}</b></span>`).join("");
   sec.innerHTML = `<div class="goal-stats" data-tone="${tone}">
     <div class="gs-head">${icon("graph", 13)} Loop history <span class="gs-sum">${esc(data!.summary)}</span></div>

--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -2192,6 +2192,9 @@ async function handleSkillFiles(fileList: FileList | File[], node: HTMLElement):
 let goalLoopRunning = false; // P-GOAL.2: true while a /goal loop streams, so Stop cancels the LOOP
 // P-GOAL.7: the usage ledger for the open goal modal (real per-model price + cache rate), fetched lazily.
 let goalLedger: Awaited<ReturnType<typeof bridge.usage>> | null = null;
+// P-GOAL.12 (ADR-0057): success criteria adopted from a Pre-Flight Audit, threaded to the checker on the
+// next run so it grades against the matured design (and reports back against it). Reset each modal open.
+let adoptedCriteria = "";
 // A launcher form (goal · optional verify command · max iterations), then a loop that streams maker
 // iterations with a separate checker's verdict each round. Every action is still gated server-side.
 
@@ -2261,6 +2264,7 @@ function openGoalForm(): void {
       <section class="goal-step" data-step="1">
         <div class="goal-step-head"><span class="goal-step-n"></span><h4>What should the agent accomplish?</h4></div>
         <div class="goal-note">Describe the end state in plain language. The clearer the target, the fewer rounds it takes. ${goalInfoDot("The goal|This is the objective the agent works toward each round. Be concrete about the finished result, e.g. 'all auth tests pass and the lint is clean.'")}</div>
+        <button type="button" class="btn-mini goal-preflight-btn" id="goalPreflight" data-tip="Pre-Flight Audit|Pause and design the loop first: pick a scope, answer a few prompt-engineering questions, fold in user/engineer feedback and past-run history, and get a readiness-scored Loop Design you can adopt as the goal." data-tip-side="right">${icon("shield", 12)} Pre-Flight Audit <span class="goal-opt">optional · design &amp; readiness check</span></button>
         <label class="goal-lbl">Goal</label>
         <textarea id="goalGoal" class="prov-key" rows="3" placeholder="e.g. Make all auth tests pass and fix any lint errors"></textarea>
       </section>
@@ -2383,7 +2387,7 @@ function openGoalForm(): void {
     const command = ($("#goalCmd", ov) as HTMLInputElement).value.trim();
     const maxIters = Math.min(20, Math.max(1, Number(($("#goalMax", ov) as HTMLInputElement).value) || 6));
     const budgetUsd = Math.max(0, Number(($("#goalBudget", ov) as HTMLInputElement)?.value) || 0); // P-GOAL.11: 0 = no cap
-    return { goal, command, maxIters, budgetUsd };
+    return { goal, command, maxIters, budgetUsd, criteria: adoptedCriteria || undefined }; // P-GOAL.12: matured checker criteria
   };
   // P-GOAL.6.1: live token estimate (lower-left), recomputed as the iteration count changes.
   ($("#goalMax", ov) as HTMLInputElement)?.addEventListener("input", () => updateGoalEstimate(ov));
@@ -2391,11 +2395,11 @@ function openGoalForm(): void {
   render(); // P-GOAL.8: apply guided/advanced mode + show the right step/buttons
   wireCmdSuggest(ov); // P-GOAL.8.1: custom verify-command type-ahead
   $("#goalRun", ov)?.addEventListener("click", async () => {
-    const { goal, command, maxIters, budgetUsd } = readSpec();
+    const { goal, command, maxIters, budgetUsd, criteria } = readSpec();
     if (!goal) { showToast({ tone: "warn", title: "Add a goal", desc: "Describe what the loop should accomplish.", timeout: 2400 }); return; }
     await applyRunWith(ov); // P-GOAL.7: apply base model / thinking / skill / persona for this run
     close();
-    void runGoalLoop({ goal, condition: command || goal, command: command || undefined, maxIters, budgetUsd });
+    void runGoalLoop({ goal, condition: command || goal, command: command || undefined, maxIters, budgetUsd, criteria });
   });
   $("#goalSave", ov)?.addEventListener("click", async () => {
     const { goal, command, maxIters } = readSpec();
@@ -2420,6 +2424,9 @@ function openGoalForm(): void {
   });
   // P-GOAL.10 (ADR-0055): the cross-run evaluation banner (success rate / avg iters / top blocker).
   void loadLoopStats(ov);
+  // P-GOAL.12 (ADR-0057): the optional Pre-Flight Audit (design + readiness before building the loop).
+  adoptedCriteria = "";
+  $("#goalPreflight", ov)?.addEventListener("click", () => openPreflight(ov));
   // P-GOAL.5: list saved automations (enable / run-now / delete).
   void renderAutomations(ov, close);
   // P-GOAL.6: populate the checker-model picker (auto recommendation + override).
@@ -2608,6 +2615,82 @@ function formatLoopDur(ms: number): string {
   return m < 60 ? `${m}m ${String(s % 60).padStart(2, "0")}s` : `${Math.floor(m / 60)}h ${String(m % 60).padStart(2, "0")}m`;
 }
 
+// P-GOAL.12 (ADR-0057): the Pre-Flight Audit — pause the builder, design the loop (scope + a short
+// prompt-engineering interview + user/PO + engineer feedback), fold in past-run history, and produce a
+// readiness-scored Loop Design report the user adopts as the goal (its criteria thread to the checker).
+async function openPreflight(goalOv: HTMLElement): Promise<void> {
+  const g = ($("#goalGoal", goalOv) as HTMLTextAreaElement)?.value.trim() ?? "";
+  const cmd = ($("#goalCmd", goalOv) as HTMLInputElement)?.value.trim() ?? "";
+  const ov = el(`<div class="scrim preflight-scrim"><div class="preflight-modal">
+    <div class="goal-modal-h"><span class="goal-h-title">${icon("shield", 15)} Pre-Flight Audit</span><button type="button" class="btn-mini" id="pfClose">Close</button></div>
+    <div class="goal-modal-sub">Design the loop before you build it — scope it, answer a few questions, fold in user/engineer feedback and past-run history, then adopt a readiness-scored Loop Design as your goal.</div>
+    <div class="pf-form">
+      <label class="goal-lbl">Scope <span class="goal-opt">where the loop runs</span></label>
+      <select id="pfScope" class="prov-key"><option value="workspace">current workspace</option></select>
+      <label class="goal-lbl">Objective</label>
+      <textarea id="pfGoal" class="prov-key" rows="2" placeholder="What should the loop accomplish?">${esc(g)}</textarea>
+      <div class="pf-grid">
+        <label class="goal-lbl pf-f"><span>Definition of done</span><textarea id="pfDone" class="prov-key" rows="2" placeholder="What does 'done' look like, concretely?"></textarea></label>
+        <label class="goal-lbl pf-f"><span>Verification command</span><input id="pfCmd" class="prov-key" placeholder="npm test && npm run lint" value="${esc(cmd)}" /></label>
+        <label class="goal-lbl pf-f"><span>Non-goals</span><textarea id="pfNon" class="prov-key" rows="2" placeholder="What must it NOT do?"></textarea></label>
+        <label class="goal-lbl pf-f"><span>Risky / off-limits</span><textarea id="pfRisk" class="prov-key" rows="2" placeholder="auth, payments, secrets, infra…"></textarea></label>
+        <label class="goal-lbl pf-f"><span>User / product-owner feedback</span><textarea id="pfFeed" class="prov-key" rows="2" placeholder="What does the product owner want?"></textarea></label>
+        <label class="goal-lbl pf-f"><span>Engineer notes</span><textarea id="pfEng" class="prov-key" rows="2" placeholder="Constraints, gotchas, the right approach…"></textarea></label>
+      </div>
+      <div class="pf-actions"><button class="btn-mini ok" id="pfRun">${icon("bolt", 12)} Run Pre-Flight Audit</button></div>
+    </div>
+    <div class="pf-result" id="pfResult" hidden></div>
+  </div></div>`);
+  document.body.appendChild(ov);
+  const close = () => ov.remove();
+  $("#pfClose", ov)?.addEventListener("click", close);
+  ov.addEventListener("click", (e) => { if (e.target === ov) close(); });
+
+  // scope picker — branches + worktrees (best-effort; falls back to "current workspace")
+  void bridge.loopScopes().then((s) => {
+    const sel = $("#pfScope", ov) as HTMLSelectElement | null; if (!sel || !s) return;
+    const opts = [`<option value="workspace">current workspace</option>`];
+    for (const b of s.branches) opts.push(`<option value="branch: ${esc(b)}">branch: ${esc(b)}${b === s.current ? " (current)" : ""}</option>`);
+    for (const w of s.worktrees) opts.push(`<option value="worktree: ${esc(w)}">worktree: ${esc(w)}</option>`);
+    sel.innerHTML = opts.join("");
+    if (s.current) sel.value = `branch: ${s.current}`;
+  });
+
+  let last: Awaited<ReturnType<typeof bridge.preflightAudit>> = null;
+  $("#pfRun", ov)?.addEventListener("click", async () => {
+    const val = (id: string) => ($(id, ov) as HTMLInputElement | HTMLTextAreaElement | null)?.value.trim() || undefined;
+    const spec = {
+      goal: val("#pfGoal") ?? "", scope: ($("#pfScope", ov) as HTMLSelectElement).value,
+      command: val("#pfCmd"), doneDefinition: val("#pfDone"), nonGoals: val("#pfNon"), risks: val("#pfRisk"),
+      feedback: val("#pfFeed"), engineerNotes: val("#pfEng"),
+      budgetUsd: Math.max(0, Number(($("#goalBudget", goalOv) as HTMLInputElement)?.value) || 0),
+      maxIters: Math.min(20, Math.max(1, Number(($("#goalMax", goalOv) as HTMLInputElement)?.value) || 6)),
+      checkerIsCheap: true,
+    };
+    if (!spec.goal) { showToast({ tone: "warn", title: "Add an objective", desc: "Describe what the loop should accomplish.", timeout: 2400 }); return; }
+    const btn = $("#pfRun", ov) as HTMLButtonElement; btn.disabled = true; btn.textContent = "Auditing…";
+    const res = $("#pfResult", ov) as HTMLElement; res.hidden = false;
+    res.innerHTML = `<div class="pf-loading">${icon("refresh", 13)} Interviewing the checker model + scoring readiness against past runs…</div>`;
+    last = await bridge.preflightAudit(spec).catch(() => null);
+    btn.disabled = false; btn.innerHTML = `${icon("bolt", 12)} Re-run`;
+    if (!last) { res.innerHTML = `<div class="pf-loading">Audit failed — check the model/connection and try again.</div>`; return; }
+    const lvl = last.readiness.level, tone = lvl === "L3" ? "ok" : lvl === "L2" ? "mid" : "low";
+    res.innerHTML = `<div class="pf-readiness" data-tone="${tone}">${icon("shield", 14)} <b>${esc(last.readiness.summary)}</b>${last.prior.total ? ` <span class="goal-opt">· ${last.prior.total} prior run${last.prior.total === 1 ? "" : "s"} on record, ${last.prior.relevant} relevant</span>` : ""}</div>
+      <div class="pf-report">${renderMarkdown(last.reportMd)}</div>
+      <div class="pf-adopt-row">${last.reportPath ? `<span class="goal-opt">saved <code>${esc(last.reportPath)}</code></span>` : ""}<button class="btn-mini ok" id="pfAdopt">${icon("check", 12)} Adopt as goal</button></div>`;
+    $("#pfAdopt", ov)?.addEventListener("click", () => {
+      if (!last) return;
+      ($("#goalGoal", goalOv) as HTMLTextAreaElement).value = last.maturedGoal;
+      const cmdEl = $("#goalCmd", goalOv) as HTMLInputElement | null, suggested = ($("#pfCmd", ov) as HTMLInputElement).value.trim();
+      if (cmdEl && !cmdEl.value.trim() && suggested) cmdEl.value = suggested;
+      adoptedCriteria = last.criteria || ""; // threads to the checker on the next run
+      updateGoalEstimate(goalOv);
+      close();
+      showToast({ tone: "ok", title: "Adopted into the goal", desc: "Tweak it in the Goal field, then Run — the checker will grade against your criteria.", timeout: 3400 });
+    });
+  });
+}
+
 async function renderAutomations(ov: HTMLElement, close: () => void): Promise<void> {
   const sec = $("#goalAutoSec", ov); if (!sec) return;
   const list = await bridge.automations();
@@ -2636,7 +2719,7 @@ async function renderAutomations(ov: HTMLElement, close: () => void): Promise<vo
   });
 }
 async function runGoalLoop(
-  opts: { goal: string; condition: string; command?: string; maxIters: number; resume?: string; budgetUsd?: number },
+  opts: { goal: string; condition: string; command?: string; maxIters: number; resume?: string; budgetUsd?: number; criteria?: string },
   stream?: (onEvent: (e: ChatEvent) => void) => Promise<void>, // P-GOAL.5: automation run-now reuses this renderer
   verb = "/goal",
 ): Promise<void> {

--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -2636,7 +2636,7 @@ async function renderAutomations(ov: HTMLElement, close: () => void): Promise<vo
   });
 }
 async function runGoalLoop(
-  opts: { goal: string; condition: string; command?: string; maxIters: number; resume?: string },
+  opts: { goal: string; condition: string; command?: string; maxIters: number; resume?: string; budgetUsd?: number },
   stream?: (onEvent: (e: ChatEvent) => void) => Promise<void>, // P-GOAL.5: automation run-now reuses this renderer
   verb = "/goal",
 ): Promise<void> {

--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -2254,6 +2254,7 @@ function openGoalForm(): void {
       <button type="button" class="goal-mode-toggle" id="goalModeToggle" data-tip="Advanced mode|Show every option on one screen, for power users. You can switch back to the guided walkthrough anytime." data-tip-side="bottom"></button>
     </div>
     <div class="goal-modal-sub">The agent iterates until a verifiable condition holds. A separate checker grades each round; the security gate scans every action.</div>
+    <div id="goalStatsSec"></div>
     <div id="goalResumeSec"></div>
     <div id="goalAutoSec"></div>
     <div class="goal-steps">
@@ -2415,6 +2416,8 @@ function openGoalForm(): void {
       void runGoalLoop({ goal: d.goal!, condition: d.cond || d.goal!, command: d.cmd || undefined, maxIters: 6, resume: d.rel });
     }));
   });
+  // P-GOAL.10 (ADR-0055): the cross-run evaluation banner (success rate / avg iters / top blocker).
+  void loadLoopStats(ov);
   // P-GOAL.5: list saved automations (enable / run-now / delete).
   void renderAutomations(ov, close);
   // P-GOAL.6: populate the checker-model picker (auto recommendation + override).
@@ -2566,6 +2569,42 @@ function updateGoalEstimate(ov: HTMLElement): void {
 
 // P-GOAL.5 (ADR-0047): render the saved-automations list inside the goal modal — each row shows its
 // cadence + last-run status, with an enable toggle, a run-now button, and delete.
+// P-GOAL.10 (ADR-0055): render the cross-run evaluation banner from the run-log ledger — success rate,
+// average iterations-to-success, the most-common blocker, and a tool-mix bar. Hidden until there's
+// history (a first-time user sees nothing extra).
+async function loadLoopStats(ov: HTMLElement): Promise<void> {
+  const sec = $("#goalStatsSec", ov); if (!sec) return;
+  const data = await bridge.loopRunStats().catch(() => null);
+  const s = data?.stats;
+  if (!s || s.runs === 0) { sec.innerHTML = ""; return; }
+  const pct = Math.round(s.successRate * 100);
+  const tone = pct >= 75 ? "ok" : pct >= 40 ? "mid" : "low";
+  const iters = s.avgItersToSucceed ? `${s.avgItersToSucceed.toFixed(1)}` : "—";
+  const dur = s.avgDurationMs ? formatLoopDur(s.avgDurationMs) : "—";
+  const blocker = s.topBlockers[0];
+  const mix = Object.entries(s.toolsByType).sort((a, b) => b[1] - a[1]).slice(0, 4)
+    .map(([k, v]) => `<span class="gs-tool">${esc(k)} <b>${v}</b></span>`).join("");
+  sec.innerHTML = `<div class="goal-stats" data-tone="${tone}">
+    <div class="gs-head">${icon("graph", 13)} Loop history <span class="gs-sum">${esc(data!.summary)}</span></div>
+    <div class="gs-grid">
+      <div class="gs-cell"><span class="gs-n">${pct}%</span><span class="gs-l">met</span></div>
+      <div class="gs-cell"><span class="gs-n">${esc(iters)}</span><span class="gs-l">avg iters to win</span></div>
+      <div class="gs-cell"><span class="gs-n">${esc(dur)}</span><span class="gs-l">avg duration</span></div>
+      <div class="gs-cell"><span class="gs-n">${s.totalTools}</span><span class="gs-l">tool calls</span></div>
+    </div>
+    ${mix ? `<div class="gs-mix">${mix}</div>` : ""}
+    ${blocker ? `<div class="gs-blocker">${icon("info", 11)} most-common stop: <span>${esc(blocker.reason.slice(0, 90))}</span>${blocker.count > 1 ? ` ·&nbsp;${blocker.count}×` : ""}</div>` : ""}
+  </div>`;
+}
+
+/** Compact duration for the eval banner (mirrors loop_report.formatDuration, kept local to the renderer). */
+function formatLoopDur(ms: number): string {
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  return m < 60 ? `${m}m ${String(s % 60).padStart(2, "0")}s` : `${Math.floor(m / 60)}h ${String(m % 60).padStart(2, "0")}m`;
+}
+
 async function renderAutomations(ov: HTMLElement, close: () => void): Promise<void> {
   const sec = $("#goalAutoSec", ov); if (!sec) return;
   const list = await bridge.automations();

--- a/desktop/renderer/bridge.ts
+++ b/desktop/renderer/bridge.ts
@@ -146,6 +146,8 @@ export type ChatEvent =
   | { type: "goal-check"; n: number; done: boolean; reason: string }
   | { type: "goal-done"; iters: number; reason: string }
   | { type: "goal-stop"; reason: string }
+  // P-GOAL.9 (ADR-0054): the loop's last task — an After-Action Report (metrics + portable graphs).
+  | { type: "goal-report"; path: string; summary: string; markdown: string }
   | { type: "done" };
 export interface GoalOpts { goal: string; condition: string; command?: string; maxIters: number; resume?: string }
 // P-GOAL.4: a stopped loop that can be resumed from its on-disk memory file.

--- a/desktop/renderer/bridge.ts
+++ b/desktop/renderer/bridge.ts
@@ -149,7 +149,7 @@ export type ChatEvent =
   // P-GOAL.9 (ADR-0054): the loop's last task — an After-Action Report (metrics + portable graphs).
   | { type: "goal-report"; path: string; summary: string; markdown: string }
   | { type: "done" };
-export interface GoalOpts { goal: string; condition: string; command?: string; maxIters: number; resume?: string; budgetUsd?: number }
+export interface GoalOpts { goal: string; condition: string; command?: string; maxIters: number; resume?: string; budgetUsd?: number; criteria?: string }
 // P-GOAL.4: a stopped loop that can be resumed from its on-disk memory file.
 export interface ResumableLoop { rel: string; goal: string; condition: string; command?: string; iterations: number; updatedAt: number }
 // P-GOAL.10 (ADR-0055): the cross-run evaluation surface (mirrors desktop/loop_runlog.ts).
@@ -165,6 +165,15 @@ export interface RunStats {
   totalErrors: number; totalSpendUsd: number; topBlockers: { reason: string; count: number }[];
 }
 export interface LoopRunStats { stats: RunStats; summary: string; recent: LoopRunRecord[] }
+// P-GOAL.12 (ADR-0057): the Pre-Flight Audit (mirrors desktop/loop_preflight.ts).
+export interface PreflightSpec {
+  goal: string; command?: string; scope?: string; budgetUsd?: number; maxIters?: number; checkerIsCheap?: boolean;
+  doneDefinition?: string; nonGoals?: string; risks?: string; feedback?: string;
+}
+export interface ReadinessCheck { key: string; label: string; ok: boolean; weight: number; nudge?: string }
+export interface ReadinessReport { level: "L0" | "L1" | "L2" | "L3"; score: number; checks: ReadinessCheck[]; summary: string }
+export interface PreflightResult { maturedGoal: string; criteria: string; reportMd: string; reportPath: string; readiness: ReadinessReport; prior: { total: number; relevant: number } }
+export interface LoopScopes { current: string; branches: string[]; worktrees: string[] }
 // P-GOAL.5: a scheduled automation — a saved /goal spec the in-process scheduler runs on a cadence.
 export type Cadence = { kind: "interval"; everyMin: number } | { kind: "daily"; hhmm: string };
 export interface Automation {
@@ -218,6 +227,8 @@ export interface LucidBridge {
   runGoal(opts: GoalOpts, onEvent: (e: ChatEvent) => void): Promise<void>;
   resumableLoops(): Promise<ResumableLoop[] | null>; // P-GOAL.4: loops that stopped without meeting their condition
   loopRunStats(): Promise<LoopRunStats | null>; // P-GOAL.10 (ADR-0055): cross-run evaluation stats + recent runs
+  loopScopes(): Promise<LoopScopes | null>;     // P-GOAL.12 (ADR-0057): branches/worktrees for the Pre-Flight scope picker
+  preflightAudit(spec: PreflightSpec): Promise<PreflightResult | null>; // P-GOAL.12: readiness + matured goal + design report
   // P-GOAL.5 (ADR-0047): scheduled automations — CRUD + arm/disarm + run-now (run-now streams goal events).
   automations(): Promise<Automation[] | null>;
   automationCreate(spec: AutomationSpec): Promise<Automation | null>;
@@ -403,6 +414,8 @@ export const bridge: LucidBridge = {
   runGoal: (opts, onEvent) => streamNdjson("/api/goal", opts, onEvent),
   resumableLoops: () => getData("/api/goal/resumable"),
   loopRunStats: () => getData("/api/goal/stats"),
+  loopScopes: () => getData("/api/goal/scopes"),
+  preflightAudit: (spec) => post("/api/goal/preflight", spec),
   automations: () => getData("/api/automations"),
   automationCreate: (spec) => post("/api/automations", spec),
   automationEnable: (id, enabled) => post("/api/automations/enable", { id, enabled }),

--- a/desktop/renderer/bridge.ts
+++ b/desktop/renderer/bridge.ts
@@ -149,19 +149,20 @@ export type ChatEvent =
   // P-GOAL.9 (ADR-0054): the loop's last task — an After-Action Report (metrics + portable graphs).
   | { type: "goal-report"; path: string; summary: string; markdown: string }
   | { type: "done" };
-export interface GoalOpts { goal: string; condition: string; command?: string; maxIters: number; resume?: string }
+export interface GoalOpts { goal: string; condition: string; command?: string; maxIters: number; resume?: string; budgetUsd?: number }
 // P-GOAL.4: a stopped loop that can be resumed from its on-disk memory file.
 export interface ResumableLoop { rel: string; goal: string; condition: string; command?: string; iterations: number; updatedAt: number }
 // P-GOAL.10 (ADR-0055): the cross-run evaluation surface (mirrors desktop/loop_runlog.ts).
 export interface LoopRunRecord {
   ts: number; id: string; goal: string; outcome: "met" | "stopped" | "cancelled" | "error"; outcomeReason: string;
   iterations: number; maxIters: number; durationMs: number; tools: number; toolsByType: Record<string, number>;
-  added: number; removed: number; hasLoc: boolean; errors: number; websites: number; command?: string;
+  added: number; removed: number; hasLoc: boolean; errors: number; websites: number;
+  spendUsd: number; hasSpend: boolean; command?: string;
 }
 export interface RunStats {
   runs: number; succeeded: number; successRate: number; avgItersToSucceed: number; avgDurationMs: number;
   totalTools: number; toolsByType: Record<string, number>; totalAdded: number; totalRemoved: number;
-  totalErrors: number; topBlockers: { reason: string; count: number }[];
+  totalErrors: number; totalSpendUsd: number; topBlockers: { reason: string; count: number }[];
 }
 export interface LoopRunStats { stats: RunStats; summary: string; recent: LoopRunRecord[] }
 // P-GOAL.5: a scheduled automation — a saved /goal spec the in-process scheduler runs on a cadence.

--- a/desktop/renderer/bridge.ts
+++ b/desktop/renderer/bridge.ts
@@ -152,6 +152,18 @@ export type ChatEvent =
 export interface GoalOpts { goal: string; condition: string; command?: string; maxIters: number; resume?: string }
 // P-GOAL.4: a stopped loop that can be resumed from its on-disk memory file.
 export interface ResumableLoop { rel: string; goal: string; condition: string; command?: string; iterations: number; updatedAt: number }
+// P-GOAL.10 (ADR-0055): the cross-run evaluation surface (mirrors desktop/loop_runlog.ts).
+export interface LoopRunRecord {
+  ts: number; id: string; goal: string; outcome: "met" | "stopped" | "cancelled" | "error"; outcomeReason: string;
+  iterations: number; maxIters: number; durationMs: number; tools: number; toolsByType: Record<string, number>;
+  added: number; removed: number; hasLoc: boolean; errors: number; websites: number; command?: string;
+}
+export interface RunStats {
+  runs: number; succeeded: number; successRate: number; avgItersToSucceed: number; avgDurationMs: number;
+  totalTools: number; toolsByType: Record<string, number>; totalAdded: number; totalRemoved: number;
+  totalErrors: number; topBlockers: { reason: string; count: number }[];
+}
+export interface LoopRunStats { stats: RunStats; summary: string; recent: LoopRunRecord[] }
 // P-GOAL.5: a scheduled automation — a saved /goal spec the in-process scheduler runs on a cadence.
 export type Cadence = { kind: "interval"; everyMin: number } | { kind: "daily"; hhmm: string };
 export interface Automation {
@@ -204,6 +216,7 @@ export interface LucidBridge {
   // P-GOAL.1 (ADR-0046): run a /goal loop — streams the same events plus goal-iter/check/done/stop.
   runGoal(opts: GoalOpts, onEvent: (e: ChatEvent) => void): Promise<void>;
   resumableLoops(): Promise<ResumableLoop[] | null>; // P-GOAL.4: loops that stopped without meeting their condition
+  loopRunStats(): Promise<LoopRunStats | null>; // P-GOAL.10 (ADR-0055): cross-run evaluation stats + recent runs
   // P-GOAL.5 (ADR-0047): scheduled automations — CRUD + arm/disarm + run-now (run-now streams goal events).
   automations(): Promise<Automation[] | null>;
   automationCreate(spec: AutomationSpec): Promise<Automation | null>;
@@ -388,6 +401,7 @@ export const bridge: LucidBridge = {
   sendPrompt: streamChat,
   runGoal: (opts, onEvent) => streamNdjson("/api/goal", opts, onEvent),
   resumableLoops: () => getData("/api/goal/resumable"),
+  loopRunStats: () => getData("/api/goal/stats"),
   automations: () => getData("/api/automations"),
   automationCreate: (spec) => post("/api/automations", spec),
   automationEnable: (id, enabled) => post("/api/automations/enable", { id, enabled }),

--- a/desktop/renderer/styles.css
+++ b/desktop/renderer/styles.css
@@ -617,6 +617,14 @@ body.resizing .sidebar,body.resizing .inspector{transition:none}
 .goal-banner{display:flex;align-items:center;gap:9px;font-size:13px;font-weight:600;padding:10px 13px;border-radius:11px}
 .goal-banner.ok{color:var(--green);background:color-mix(in srgb,var(--green) 14%,transparent);border:1px solid color-mix(in srgb,var(--green) 40%,var(--line))}
 .goal-banner.stop{color:var(--txt-2);background:var(--bg-2);border:1px solid var(--line)}
+/* P-GOAL.9: the After-Action Report card — collapsible, with the metrics summary in the header. */
+.goal-aar{margin-top:10px;border:1px solid var(--line);border-radius:11px;background:var(--bg-2);overflow:hidden}
+.goal-aar>summary{cursor:pointer;list-style:none;display:flex;align-items:center;gap:7px;font-size:12px;padding:9px 12px;color:var(--txt-2)}
+.goal-aar>summary::-webkit-details-marker{display:none}
+.goal-aar>summary b{font-weight:600;color:var(--txt-1)}
+.goal-aar>summary code{font-family:var(--mono);font-size:11px;color:var(--txt-4)}
+.goal-aar-body{padding:4px 14px 12px;border-top:1px solid var(--line);font-size:12.5px}
+.goal-aar-body pre{overflow:auto}
 /* The send button lives OUTSIDE the bordered .composer box (the expanding/scrolling input window),
    bottom-aligned beside it, so a long prompt's scroll region is just the text. */
 .composer-row{max-width:min(1080px,94vw);margin:0 auto;display:flex;align-items:flex-end;gap:8px}

--- a/desktop/renderer/styles.css
+++ b/desktop/renderer/styles.css
@@ -640,6 +640,26 @@ body.resizing .sidebar,body.resizing .inspector{transition:none}
 .gs-mix .gs-tool b{color:var(--txt-1)}
 .gs-blocker{display:flex;align-items:center;gap:5px;margin-top:8px;font-size:11px;color:var(--txt-4)}
 .gs-blocker span{color:var(--txt-3)}
+/* P-GOAL.12: Pre-Flight Audit — the optional design/readiness pass that pauses the builder. */
+.goal-preflight-btn{margin:0 0 8px;display:inline-flex;align-items:center;gap:6px}
+.preflight-modal{width:min(720px,94vw);max-height:90vh;overflow:auto;background:var(--bg-1);border:1px solid var(--line);border-radius:14px;padding:16px 18px;display:flex;flex-direction:column;gap:10px}
+.pf-form{display:flex;flex-direction:column;gap:8px}
+.pf-grid{display:grid;grid-template-columns:1fr 1fr;gap:10px}
+.pf-f{display:flex;flex-direction:column;gap:4px;font-size:11px;color:var(--txt-3)}
+.pf-f>span{font-weight:600;color:var(--txt-2)}
+.pf-actions{display:flex;justify-content:flex-end;margin-top:4px}
+.pf-result{border-top:1px solid var(--line);padding-top:10px;display:flex;flex-direction:column;gap:10px}
+.pf-loading{display:flex;align-items:center;gap:7px;font-size:12px;color:var(--txt-3)}
+.pf-readiness{display:flex;align-items:center;gap:7px;font-size:13px;padding:9px 12px;border-radius:10px;background:var(--bg-2);border:1px solid var(--line)}
+.pf-readiness[data-tone="ok"]{border-color:color-mix(in srgb,var(--green) 45%,var(--line));color:var(--green)}
+.pf-readiness[data-tone="mid"]{border-color:color-mix(in srgb,var(--amber) 40%,var(--line))}
+.pf-readiness[data-tone="low"]{border-color:color-mix(in srgb,var(--amber) 45%,var(--line));color:var(--amber)}
+.pf-readiness b{color:var(--txt-1)}
+.pf-readiness[data-tone="ok"] b{color:var(--green)}
+.pf-report{font-size:12.5px;max-height:42vh;overflow:auto;border:1px solid var(--line);border-radius:10px;padding:6px 14px;background:var(--bg-2)}
+.pf-report pre{overflow:auto}
+.pf-adopt-row{display:flex;align-items:center;justify-content:space-between;gap:10px}
+.pf-adopt-row code{font-family:var(--mono);font-size:11px;color:var(--txt-4)}
 /* The send button lives OUTSIDE the bordered .composer box (the expanding/scrolling input window),
    bottom-aligned beside it, so a long prompt's scroll region is just the text. */
 .composer-row{max-width:min(1080px,94vw);margin:0 auto;display:flex;align-items:flex-end;gap:8px}

--- a/desktop/renderer/styles.css
+++ b/desktop/renderer/styles.css
@@ -625,6 +625,21 @@ body.resizing .sidebar,body.resizing .inspector{transition:none}
 .goal-aar>summary code{font-family:var(--mono);font-size:11px;color:var(--txt-4)}
 .goal-aar-body{padding:4px 14px 12px;border-top:1px solid var(--line);font-size:12.5px}
 .goal-aar-body pre{overflow:auto}
+/* P-GOAL.10: the cross-run evaluation banner in the goal launcher. */
+.goal-stats{margin:4px 0 10px;border:1px solid var(--line);border-radius:11px;padding:10px 12px;background:var(--bg-2)}
+.goal-stats[data-tone="ok"]{border-color:color-mix(in srgb,var(--green) 38%,var(--line))}
+.goal-stats[data-tone="low"]{border-color:color-mix(in srgb,var(--amber) 38%,var(--line))}
+.gs-head{display:flex;align-items:center;gap:7px;font-size:12px;color:var(--txt-2);margin-bottom:8px}
+.gs-head .gs-sum{margin-left:auto;font-size:11px;color:var(--txt-4)}
+.gs-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:8px}
+.gs-cell{display:flex;flex-direction:column;align-items:center;gap:1px;padding:6px 4px;border-radius:8px;background:var(--bg-1)}
+.gs-cell .gs-n{font-size:16px;font-weight:600;color:var(--txt-1)}
+.gs-cell .gs-l{font-size:10px;color:var(--txt-4);text-align:center}
+.gs-mix{display:flex;flex-wrap:wrap;gap:6px;margin-top:8px}
+.gs-mix .gs-tool{font-size:10.5px;color:var(--txt-3);background:var(--bg-1);border:1px solid var(--line);border-radius:6px;padding:2px 7px}
+.gs-mix .gs-tool b{color:var(--txt-1)}
+.gs-blocker{display:flex;align-items:center;gap:5px;margin-top:8px;font-size:11px;color:var(--txt-4)}
+.gs-blocker span{color:var(--txt-3)}
 /* The send button lives OUTSIDE the bordered .composer box (the expanding/scrolling input window),
    bottom-aligned beside it, so a long prompt's scroll region is just the text. */
 .composer-row{max-width:min(1080px,94vw);margin:0 auto;display:flex;align-items:flex-end;gap:8px}

--- a/harness/scripts/demo_pgoal10.ts
+++ b/harness/scripts/demo_pgoal10.ts
@@ -1,0 +1,66 @@
+// harness/scripts/demo_pgoal10.ts
+//
+// P-GOAL.10 (ADR-0055): the /goal loop's cross-run EVALUATION ledger. Self-contained (no omp): drives
+// the pure run-log core end-to-end, proving:
+//   A. a completed loop (a P-GOAL.9 LoopMetrics) projects to a compact JSONL record and round-trips.
+//   B. aggregating a history yields the eval stats — success rate, avg iterations-to-success, summed
+//      tool/LOC/errors, and a failure breakdown that collapses recurring blockers across runs.
+//   C. a malformed line never poisons the history (append-only, best-effort).
+// Writes a real run-log.jsonl you can inspect.
+
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type LoopMetrics } from "../../desktop/loop_report.ts";
+import { aggregateRuns, parseRunLog, runRecordLine, summarizeRunStats, toRunRecord } from "../../desktop/loop_runlog.ts";
+
+const fail = (m: string): never => { console.error(`FAIL: ${m}`); process.exit(1); };
+const must = (c: boolean, m: string) => { if (!c) fail(m); };
+
+function m(over: Partial<LoopMetrics>): LoopMetrics {
+  return {
+    goal: "g", condition: "c", command: "npm test", outcome: "met", outcomeReason: "all pass",
+    iterations: 3, maxIters: 6, durationMs: 120_000, toolCalls: { shell: 5, edit: 2 },
+    loc: { added: 30, removed: 5, files: 2 }, errors: [], websites: [], perIteration: [], ...over,
+  };
+}
+
+// ── A. project + round-trip ────────────────────────────────────────────────────
+const runs: LoopMetrics[] = [
+  m({ outcome: "met", iterations: 2, outcomeReason: "all pass" }),
+  m({ outcome: "met", iterations: 4, outcomeReason: "all pass" }),
+  m({ outcome: "stopped", iterations: 6, outcomeReason: "stopped: 3 of 12 tests fail", toolCalls: { shell: 9, edit: 4 } }),
+  m({ outcome: "stopped", iterations: 6, outcomeReason: "stopped: 1 of 12 tests fail" }),
+  m({ outcome: "error", iterations: 1, outcomeReason: "loop error: provider timeout", loc: null }),
+];
+const lines = runs.map((mm, i) => runRecordLine(toRunRecord(mm, { id: `r${i}`, ts: 1000 + i })));
+const parsed = parseRunLog(lines.join("\n") + "\n");
+must(parsed.length === 5, `expected 5 records, got ${parsed.length}`);
+must(parsed[0]!.tools === 7 && parsed[2]!.tools === 13, "tool totals wrong after round-trip");
+console.log("== A. project + JSONL round-trip ==\n   ✓ 5 LoopMetrics → 5 records; tool totals preserved (7, 13)");
+
+// ── B. aggregate into eval stats ───────────────────────────────────────────────
+const s = aggregateRuns(parsed);
+console.log("\n== B. cross-run evaluation ==");
+must(s.runs === 5 && s.succeeded === 2, "run/success counts wrong");
+must(Math.abs(s.successRate - 0.4) < 1e-9, "success rate wrong");
+must(Math.abs(s.avgItersToSucceed - 3) < 1e-9, "avg iters-to-succeed wrong (should be (2+4)/2=3)");
+console.log(`   ✓ ${summarizeRunStats(s)}`);
+console.log(`   ✓ success rate ${Math.round(s.successRate * 100)}% · avg ${s.avgItersToSucceed.toFixed(1)} iters to win · ${s.totalTools} tool calls`);
+// the two "N of 12 tests fail" runs collapse into ONE recurring blocker; timeout is a second
+must(s.topBlockers[0]!.count === 2, `top blocker should aggregate the 2 tests-fail runs, got ${s.topBlockers[0]!.count}`);
+must(s.topBlockers.length === 2, `expected 2 distinct blockers, got ${s.topBlockers.length}`);
+console.log(`   ✓ failure breakdown: "${s.topBlockers[0]!.reason}" ×${s.topBlockers[0]!.count}, then "${s.topBlockers[1]!.reason}"`);
+
+// ── C. a malformed line is skipped, not fatal ──────────────────────────────────
+const poisoned = `${lines[0]}\nthis is not json\n{"half":true}\n${lines[1]}\n`;
+must(parseRunLog(poisoned).length === 2, "malformed lines must be skipped, valid ones kept");
+console.log("\n== C. resilience ==\n   ✓ malformed/partial lines skipped; valid history preserved");
+
+// ── artifact ───────────────────────────────────────────────────────────────────
+const dir = mkdtempSync(join(tmpdir(), "pgoal10-"));
+const out = join(dir, "run-log.jsonl");
+writeFileSync(out, lines.join("\n") + "\n", "utf8");
+must(parseRunLog(readFileSync(out, "utf8")).length === 5, "artifact did not round-trip");
+console.log(`\n== artifact ==\n   wrote ${out} (5 runs)`);
+console.log("\ndemo-P-GOAL.10 OK");

--- a/harness/scripts/demo_pgoal11.ts
+++ b/harness/scripts/demo_pgoal11.ts
@@ -1,0 +1,63 @@
+// harness/scripts/demo_pgoal11.ts
+//
+// P-GOAL.11 (ADR-0056): the /goal loop's live SPEND meter + budget KILL SWITCH. Self-contained (no omp):
+// drives the pure budget core + report/ledger integration, proving:
+//   A. per-turn peak cost sums into total spend; context tokens track as a peak (never summed).
+//   B. the kill switch trips at/above a positive cap and never on "no cap".
+//   C. spend flows into the After-Action Report and the cross-run ledger/eval.
+// Models the runGoal accounting loop turn-by-turn so the demo mirrors the real wiring.
+
+import { addTurnSpend, newLoopSpend, normalizeBudget, overBudget } from "../../desktop/loop_budget.ts";
+import { type LoopMetrics, renderLoopReport } from "../../desktop/loop_report.ts";
+import { aggregateRuns, parseRunLog, runRecordLine, toRunRecord } from "../../desktop/loop_runlog.ts";
+
+const fail = (m: string): never => { console.error(`FAIL: ${m}`); process.exit(1); };
+const must = (c: boolean, m: string) => { if (!c) fail(m); };
+
+// ── A + B. simulate a loop with a $0.30 cap; each turn reports growing per-turn cost ────────────
+const cap = normalizeBudget("0.30");
+must(cap === 0.3, "budget normalize wrong");
+// per-turn PEAK cost (USD) and PEAK context tokens, as usage_update would report them
+const turns = [
+  { peakCost: 0.08, peakCtx: 12_000 },
+  { peakCost: 0.11, peakCtx: 21_000 },
+  { peakCost: 0.14, peakCtx: 28_000 }, // running total after this = 0.33 → over the 0.30 cap
+  { peakCost: 0.09, peakCtx: 30_000 }, // must never run
+];
+let spend = newLoopSpend();
+let stoppedAt = 0;
+for (let i = 0; i < turns.length; i++) {
+  spend = addTurnSpend(spend, turns[i]!.peakCost, turns[i]!.peakCtx);
+  if (overBudget(spend.usd, cap)) { stoppedAt = i + 1; break; }
+}
+console.log("== A+B. spend meter + kill switch ==");
+must(stoppedAt === 3, `loop should stop on turn 3 when spend crosses the cap, got ${stoppedAt}`);
+must(Math.abs(spend.usd - 0.33) < 1e-9, `total spend should be 0.33, got ${spend.usd}`);
+must(spend.peakContextTokens === 28_000, `peak context should be 28000 (peak, not summed), got ${spend.peakContextTokens}`);
+console.log(`   ✓ stopped on turn ${stoppedAt}: spent $${spend.usd.toFixed(2)} ≥ $${cap.toFixed(2)} cap (turn 4 never ran)`);
+console.log(`   ✓ peak context ${spend.peakContextTokens} tokens (high-water mark, not 91000 summed)`);
+must(!overBudget(999, 0), "a zero cap must never trip the kill switch");
+console.log("   ✓ no cap (0) ⇒ kill switch never trips");
+
+// ── C. spend surfaces in the AAR + the cross-run ledger ─────────────────────────
+const metrics: LoopMetrics = {
+  goal: "refactor the parser", condition: "tests pass", command: "npm test",
+  outcome: "stopped", outcomeReason: `stopped: budget cap $0.30 reached (spent $0.33)`,
+  iterations: 3, maxIters: 6, durationMs: 240_000,
+  toolCalls: { shell: 7, edit: 5 }, loc: { added: 60, removed: 12, files: 3 },
+  errors: [], websites: [], perIteration: [],
+  spendUsd: spend.usd, peakContextTokens: spend.peakContextTokens, budgetUsd: cap,
+};
+const md = renderLoopReport(metrics);
+must(md.includes("| Spend | $0.33 of $0.30 cap"), "AAR must show spend vs cap");
+must(md.includes("peak context 28k"), "AAR must show peak context");
+console.log("\n== C. report + ledger integration ==");
+console.log("   ✓ After-Action Report shows: Spend $0.33 of $0.30 cap · peak context 28k");
+
+const rec = toRunRecord(metrics, { id: "z", ts: 1 });
+must(rec.spendUsd === 0.33 && rec.hasSpend === true, "ledger record must carry spend");
+const stats = aggregateRuns(parseRunLog(runRecordLine(rec) + "\n" + runRecordLine(toRunRecord({ ...metrics, spendUsd: 0.10 }, { id: "y", ts: 2 })) + "\n"));
+must(Math.abs(stats.totalSpendUsd - 0.43) < 1e-9, `cross-run total spend should be 0.43, got ${stats.totalSpendUsd}`);
+console.log(`   ✓ run-log round-trips spend; cross-run eval totals $${stats.totalSpendUsd.toFixed(2)} across ${stats.runs} runs`);
+
+console.log("\ndemo-P-GOAL.11 OK");

--- a/harness/scripts/demo_pgoal12.ts
+++ b/harness/scripts/demo_pgoal12.ts
@@ -1,0 +1,81 @@
+// harness/scripts/demo_pgoal12.ts
+//
+// P-GOAL.12 (ADR-0057): the Pre-Flight Audit. Self-contained (no omp): drives the pure core end-to-end —
+//   A. readiness scoring is GATED L0→L3 (a long goal can't buy L3 without the safety-bearing four).
+//   B. history awareness — prior runs of a similar loop are surfaced so context isn't lost.
+//   C. the prompt-engineering interview matures the goal (model JSON parsed; user values win), folds in
+//      user/PO + engineer feedback, and emits explicit success criteria the checker grades against.
+//   D. a repeatable Loop Design report is rendered (and written) ready to adopt as the goal.
+
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type LoopRunRecord } from "../../desktop/loop_runlog.ts";
+import {
+  assessReadiness,
+  maturedGoalFrom,
+  mergeMatured,
+  parsePreflightJson,
+  type PreflightSpec,
+  relevantPriorRuns,
+  renderLoopDesign,
+  successCriteria,
+  summarizePriorRuns,
+} from "../../desktop/loop_preflight.ts";
+
+const fail = (m: string): never => { console.error(`FAIL: ${m}`); process.exit(1); };
+const must = (c: boolean, m: string) => { if (!c) fail(m); };
+
+// ── A. gated readiness L0→L3 ───────────────────────────────────────────────────
+console.log("== A. readiness is gated L0→L3 ==");
+const base: PreflightSpec = { goal: "Make all auth tests pass and fix lint" };
+must(assessReadiness(base).level === "L0", "bare objective should be L0");
+must(assessReadiness({ ...base, doneDefinition: "42 auth tests green" }).level === "L1", "objective+done = L1");
+must(assessReadiness({ ...base, doneDefinition: "all tests green", command: "npm test" }).level === "L2", "+verify = L2");
+const l3spec: PreflightSpec = { ...base, doneDefinition: "42 auth tests green", command: "npm test && npm run lint", budgetUsd: 2, scope: "branch: feat/auth", checkerIsCheap: true };
+const l3 = assessReadiness(l3spec);
+must(l3.level === "L3", "safety-bearing four lift to L3");
+must(assessReadiness({ ...l3spec, command: undefined }).level !== "L3", "no verify command can't be L3 (Verifier Theater)");
+console.log(`   ✓ L0 → L1 → L2 → L3 gated; L3 score ${l3.score}/100; missing-verify is capped below L3`);
+
+// ── B. history awareness ───────────────────────────────────────────────────────
+console.log("\n== B. history awareness (don't lose past context) ==");
+const history: LoopRunRecord[] = [
+  { ts: 3, id: "c", goal: "fix auth tests and lint", outcome: "stopped", outcomeReason: "stopped: 3 lint errors remain", iterations: 6, maxIters: 6, durationMs: 1, tools: 9, toolsByType: {}, added: 0, removed: 0, hasLoc: false, errors: 1, websites: 0, spendUsd: 0.42, hasSpend: true },
+  { ts: 2, id: "b", goal: "update the changelog", outcome: "met", outcomeReason: "done", iterations: 2, maxIters: 6, durationMs: 1, tools: 3, toolsByType: {}, added: 0, removed: 0, hasLoc: false, errors: 0, websites: 0, spendUsd: 0.05, hasSpend: true },
+];
+const relevant = relevantPriorRuns(history, base.goal, 3);
+must(relevant.length === 1 && relevant[0]!.id === "c", "the auth-tests run is relevant; the changelog run is not");
+must(summarizePriorRuns(relevant).includes("3 lint errors"), "history digest carries the prior blocker");
+console.log(`   ✓ surfaced the relevant prior run: "${relevant[0]!.outcomeReason}" — so the new loop won't re-discover it`);
+
+// ── C. interview maturation + criteria + feedback ──────────────────────────────
+console.log("\n== C. interview → matured goal + success criteria ==");
+const userSpec: PreflightSpec = { ...base, command: "npm test", feedback: "no flaky tests", engineerNotes: "use the existing fixture loader" };
+// model returns JSON; user-provided command wins, model fills the blanks
+const modelOut = `{"maturedGoal":"Make the 42 auth tests pass and the lint clean, without touching payments.","definitionOfDone":"npm test and npm run lint both exit 0","suggestedCommand":"make test","nonGoals":"refactor unrelated modules"}`;
+const fields = parsePreflightJson(modelOut);
+const matured = mergeMatured(userSpec, fields);
+must(matured.command === "npm test", "user command wins over the model suggestion");
+must(matured.doneDefinition === "npm test and npm run lint both exit 0", "model fills the done blank");
+const crit = successCriteria(matured);
+must(crit.includes("Honor (product-owner): no flaky tests"), "criteria carries PO feedback");
+must(crit.includes("Honor (engineer): use the existing fixture loader"), "criteria carries engineer notes");
+console.log("   ✓ matured goal + criteria the checker grades against:");
+for (const line of crit.split("\n")) console.log(`     · ${line}`);
+
+// ── D. the repeatable Loop Design report ───────────────────────────────────────
+console.log("\n== D. Loop Design report ==");
+const finalSpec: PreflightSpec = { ...matured, scope: "branch: feat/auth", budgetUsd: 2, maxIters: 6, checkerIsCheap: true };
+const report = assessReadiness(finalSpec);
+const md = renderLoopDesign(finalSpec, report, fields.maturedGoal ?? maturedGoalFrom(finalSpec), { total: history.length, relevant });
+for (const needle of ["# Loop Design", "## Matured goal", "## Prior runs", "2 prior loop runs on record", "| User / PO feedback |", "| Engineer notes |", "## Readiness checklist"]) {
+  must(md.includes(needle), `report missing ${needle}`);
+}
+const dir = mkdtempSync(join(tmpdir(), "pgoal12-"));
+const out = join(dir, "loop.preflight.md");
+writeFileSync(out, md, "utf8");
+console.log(`   ✓ report carries readiness, matured goal, prior-run history, feedback, and a checklist`);
+console.log(`   wrote ${out}`);
+
+console.log("\ndemo-P-GOAL.12 OK");

--- a/harness/scripts/demo_pgoal9.ts
+++ b/harness/scripts/demo_pgoal9.ts
@@ -1,0 +1,95 @@
+// harness/scripts/demo_pgoal9.ts
+//
+// P-GOAL.9 (ADR-0054): the /goal loop's After-Action Report + termination guards.
+// Self-contained (no omp/network): drives the PURE report core end-to-end, proving:
+//   A. the AAR renders every metric the user asked for — Tool Calls (by type), LOC (added/removed),
+//      Errors Recorded, and Websites Visited — with portable Mermaid graphs + a text scoreboard.
+//   B. the convergence-stall signature collapses a recurring blocker across rounds (#2 Infinite Fix Loop).
+//   C. the report degrades honestly (no invalid empty charts) when a run did nothing.
+// It writes a real report.md you can open to see the graphs render on GitHub / VS Code.
+
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type LoopMetrics,
+  normalizeToolName,
+  renderLoopReport,
+  stallSignature,
+  summarizeLoop,
+} from "../../desktop/loop_report.ts";
+
+const fail = (m: string): never => { console.error(`FAIL: ${m}`); process.exit(1); };
+const must = (cond: boolean, m: string) => { if (!cond) fail(m); };
+
+// ── A. A realistic finished loop → full After-Action Report ────────────────────
+const metrics: LoopMetrics = {
+  goal: "Make all auth tests pass and fix lint",
+  condition: "npm test && npm run lint exits 0",
+  command: "npm test && npm run lint",
+  outcome: "met",
+  outcomeReason: "all 42 tests pass, lint clean",
+  iterations: 4,
+  maxIters: 6,
+  durationMs: 7 * 60_000 + 24_000,
+  toolCalls: { shell: 14, edit: 9, read: 6, search: 4, "web-fetch": 2 },
+  loc: { added: 213, removed: 88, files: 7 },
+  errors: [
+    { iter: 1, detail: "shell: command failed — exit 1 (TypeError in token.ts)" },
+    { iter: 2, detail: "edit: rejected — file outside workspace" },
+  ],
+  websites: ["https://nodejs.org/api/test.html", "https://eslint.org/docs/latest/rules/no-unused-vars"],
+  perIteration: [
+    { n: 1, tools: 8, errors: 1, done: false, reason: "5 of 42 tests fail" },
+    { n: 2, tools: 9, errors: 1, done: false, reason: "2 of 42 tests fail" },
+    { n: 3, tools: 10, errors: 0, done: false, reason: "tests pass; 3 lint errors remain" },
+    { n: 4, tools: 8, errors: 0, done: true, reason: "all 42 tests pass, lint clean" },
+  ],
+};
+
+const md = renderLoopReport(metrics);
+console.log("== After-Action Report — required sections & graphs ==");
+for (const [label, needle] of [
+  ["Tool Calls (by type) chart", "pie showData title Tool calls by type"],
+  ["Tool Calls table", "| shell | 14 |"],
+  ["LOC Changed graph", "bar [213, 88]"],
+  ["LOC net summary", "+213 / -88"],
+  ["Errors Recorded chart", "Errors recorded per iteration"],
+  ["Errors table row", "exit 1 (TypeError"],
+  ["Websites Visited", "https://eslint.org/docs/latest/rules/no-unused-vars"],
+  ["Scoreboard", "Tool calls"],
+  ["Per-iteration log", "## Per-iteration log"],
+] as const) {
+  must(md.includes(needle), `report missing ${label} (${needle})`);
+  console.log(`   ✓ ${label}`);
+}
+console.log(`   summary: ${summarizeLoop(metrics)}`);
+
+// ── B. Tool-name normalization + convergence-stall signature ───────────────────
+console.log("\n== termination guards ==");
+must(normalizeToolName("Bash") === "shell" && normalizeToolName("WebSearch") === "web-search", "tool normalization wrong");
+console.log("   ✓ raw omp kinds group into stable types (Bash→shell, WebSearch→web-search)");
+// the same blocker phrased with different numbers must collapse to ONE signature (→ stall detected)
+const sigs = ["3 of 42 tests fail", "2 of 42 tests fail", "1 of 42 tests fail"].map(stallSignature);
+must(sigs[0] === sigs[1] && sigs[1] === sigs[2], "stall signature failed to collapse a recurring blocker");
+console.log("   ✓ recurring blocker collapses across rounds → loop stops 'not converging' (no infinite fix loop)");
+
+// ── C. Honest degradation: a no-op run emits no invalid empty charts ───────────
+const empty: LoopMetrics = {
+  goal: "noop", condition: "c", outcome: "stopped", outcomeReason: "no progress for two iterations",
+  iterations: 1, maxIters: 6, durationMs: 1200, toolCalls: {}, loc: null, errors: [], websites: [],
+  perIteration: [{ n: 1, tools: 0, errors: 0, done: false, reason: "no actions taken" }],
+};
+const emptyMd = renderLoopReport(empty);
+must(emptyMd.includes("_No tool calls recorded._"), "no-op report should state no tool calls");
+must(emptyMd.includes("Not a git workspace"), "no-op report should note LOC unavailable");
+must(!/```mermaid\s*```/.test(emptyMd) && !emptyMd.includes("pie showData title Tool calls by type\n```"), "no-op report emitted an invalid empty chart");
+console.log("\n== honest degradation ==\n   ✓ a no-op run renders text fallbacks, never an empty/invalid Mermaid block");
+
+// ── write a real artifact to inspect ───────────────────────────────────────────
+const dir = mkdtempSync(join(tmpdir(), "pgoal9-"));
+const out = join(dir, "loop.report.md");
+writeFileSync(out, md, "utf8");
+console.log(`\n== artifact ==\n   wrote ${out}`);
+console.log("   open it on GitHub / in VS Code to see the pie + bar charts render.");
+console.log("\ndemo-P-GOAL.9 OK");


### PR DESCRIPTION
## Summary

Reviewed our `/goal` loop against Cobus Greyling's [loop-engineering](https://github.com/cobusgreyling/loop-engineering) playbook and shipped four increments closing the gaps it exposed — sharpest for **long-running / unattended** loops.

---

## P-GOAL.9 — After-Action Report + termination guards (ADR-0054)
Every run ends with a deterministic AAR (portable **Mermaid** graphs: tool calls by type, LOC ±, errors/iteration, sites) + a text scoreboard, written to `.omp/loops/*.report.md`. Plus **convergence-stall** + **tool-failure** guards, and the resume-slice fix (*State Rot*).

## P-GOAL.10 — cross-run evaluation: run-log + stats (ADR-0055)
Append-only `.omp/loops/run-log.jsonl`; `aggregateRuns` → success rate, avg iterations-to-win, failure breakdown. Surfaced as an evaluation banner in the launcher. Flat JSONL — no DuckDB schema touch.

## P-GOAL.11 — live spend meter + budget kill switch (ADR-0056)
Sums each maker turn's peak cost; the moment running spend crosses an optional `$` cap, the loop **aborts mid-turn** and stops — *Token Burn* defused. Spend flows into the AAR, run-log, and a launcher "Budget cap" field.

## P-GOAL.12 — the Pre-Flight Audit (ADR-0057)
An optional **"Pre-Flight Audit"** button above the Goal input that *pauses the builder* and designs the loop first — adapting loop-engineering's `loop-audit` rubric from "is this repo ready?" to "is THIS loop well-formed?":
- **Scope** picker (branch / worktree) + a short **prompt-engineering interview** (definition-of-done, non-goals, risks) with **user/product-owner feedback** and **engineer notes**.
- **History awareness** — reads the run-log and surfaces prior runs of a similar loop (their AARs in `.omp/loops/`) so context isn't lost.
- **Gated readiness L0→L3** — L3 ("unattended-capable") *requires* the safety-bearing four (verify command, budget, scope, cheap checker), so a verbose goal can't buy L3 without a real verifier.
- Emits a repeatable **Loop Design report** (`.omp/loops/*.preflight.md`); **"Adopt as goal"** fills the Goal field and threads the matured **success criteria to the small checker**, which now grades against them and reports which are met/unmet.
- This closes a **recursive self-improvement loop**: each run's AAR + run-log feed the next loop's Pre-Flight, with user + engineer input.

---

## Testing
- **+65 unit tests** across `loop_report`, `loop_runlog`, `loop_budget`, `loop_preflight`, `saveGoalReport`. `bun test desktop` → **216 pass / 0 fail**.
- `make demo-P-GOAL.9 / .10 / .11 / .12` — self-contained (no omp), all green; each writes a real artifact.
- **Typecheck clean** across all three desktop/root tsconfigs (root strict + `noUncheckedIndexedAccess`, renderer w/ electron types, server) — verified by running them.
- Prompt prefix untouched; the matured goal is always shown for review/edit before it runs (human in the loop).

## Deferred (clean follow-ons)
Escalation ping on unattended stop; a budget + criteria field for scheduled automations; an optional multi-turn interview.

See **ADR-0054 / 0055 / 0056 / 0057** in `DECISIONS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)