### PR TITLE
P-RAG.1 + AskSage diagnostics/resilience + per-website egress approval (ADR-0058-0062)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -4537,3 +4537,84 @@ chunks are retrieval context, never semantic memory).
 ADR-0007 (AskSage adapter + `/query` RAG this extends); ADR-0012 (compartments/classification); ADR-0019
 (gate/quarantine + Security-panel surfacing); ADR-0050 / P-GOAL.8 (the guided-walkthrough UI pattern
 reused); CLAUDE.md invariants #2/#3/#5/#10 + keystone #2.
+
+## ADR-0054 - P-RAG.1: the local knowledge spine (scan-gated ingest + offline cosine retrieval)
+
+**Date:** 2026-06-24
+**Status:** Accepted - BUILT.
+**Increment:** P-RAG.1 (first build increment under ADR-0053).
+
+### Context
+
+ADR-0053 scoped the Knowledge module as one large increment (schema + PDF parse + WASM embedder +
+retrieval + Knowledge popup + injection). Building all of that in one session is exactly the
+half-finished-increment failure CLAUDE.md warns against, and the heaviest pieces (bundling ONNX weights,
+`unpdf`, live multimodal captioning) need network / real environments that cannot be verified
+deterministically in this dev host. So P-RAG.1 is narrowed to the load-bearing, air-gap-clean,
+fully-testable CORE - the data + security + retrieval spine - and the heavy/UI pieces move to follow-ons.
+
+### Decision - what P-RAG.1 builds (server-side, no new runtime deps)
+
+1. **Separate `knowledge.duckdb`** (ADR-0053 decision #3). `Db.open(path, migrationsDir?)` gained an
+   optional second arg selecting the migration set; it defaults to the core memory schema, so every
+   existing caller is unchanged. The knowledge store passes its own dir
+   (`harness/knowledge/migrations`), so migration `0010_knowledge_vectors.sql` applies ONLY to
+   knowledge.duckdb and never to `agent_obs.duckdb` (invariant #10; frozen migrations untouched).
+2. **Migration 0010** - `kb_datasets` (id, name, classification U|CUI, source local|asksage,
+   embedding_model, dim) + `kb_chunks` (chunk_id, dataset_id FK, artifact_id soft-ref, source_path,
+   ordinal, text, trust_label, `embedding FLOAT[]`, dim). The 0010 number keeps project migration
+   numbering globally unique even though this is a distinct database.
+3. **`chunk.ts`** - pure, deterministic, overlapping, boundary-preferring text chunker.
+4. **`embedder.ts`** - an `Embedder` INTERFACE (`{id, dim, embed()}`) plus `HashEmbedder`, a
+   deterministic, dependency-free hashed-bag-of-words embedder (L2-normalized). The pipeline depends on
+   the interface, NOT a model, so the spine is testable and air-gap-clean today; P-RAG.1b drops in the
+   real WASM `bge-small-en-v1.5` (384-dim) behind the same interface with weights bundled.
+5. **`ingest.ts` `ingestText`** - the security keystone: chunk -> SCAN each chunk fail-closed
+   (`scanAndDecide`/DEFAULT_POLICY, same seam as persona/skill import) -> embed ONLY clean chunks ->
+   store with their trust label. A blocked chunk (quarantined, suspicious-over-threshold, OR
+   scanner-unavailable) is NEVER embedded and NEVER stored. An `onBlock` audit hook lets the desktop
+   layer `recordBlock()` without this harness module importing the desktop security log (clean layering).
+6. **Retrieval** - `KnowledgeStore.retrieve()` brute-forces top-k by DuckDB's built-in
+   `list_cosine_distance` (no vss/HNSW extension - air-gap clean). `wrapRetrieved()` renders hits inside
+   `UNTRUSTED_CONTENT_START/END` for late, delimited injection (invariant #5/#6).
+
+### Vectors are inlined as numeric SQL list literals (not bound params)
+
+The `@duckdb/node-api` binding rejects a JS array bound as a parameter ("Cannot create values of type
+ANY"). Probed: `list_cosine_distance(embedding, [<literal>])` works with no cast, on both INSERT and
+SELECT. Embedding components are machine-generated finite floats (never user text), and `floatList()`
+throws on any non-finite component, so inlining is safe and keeps retrieval in SQL.
+
+### Deferred (explicit, so the boundary is honest)
+
+- **P-RAG.1b** - real WASM text embedder (`@huggingface/transformers`, `bge-small-en-v1.5`) with weights
+  bundled as extraResources; `unpdf` PDF->text; wire both behind the existing `Embedder` interface.
+- **P-RAG.1c** - the Knowledge popup (guided + advanced, P-GOAL.8 pattern) for the LOCAL path, a
+  `knowledge.duckdb` at a fixed app path, desktop `recordBlock` wiring via `onBlock`, and per-turn
+  retrieval injection mirroring the dataset selector (ADR-0053 decision #4).
+- **P-RAG.2** images/multimodal; **P-RAG.3** AskSage dataset training; **P-RAG.4** ranking/citations + HNSW.
+- New `EventName`s (`knowledge_ingested`/`chunk_embedded`/`knowledge_retrieved`) remain deferred - a
+  `contracts.ts` change is its own increment (ADR-0053); the spine reuses existing block-audit plumbing.
+
+### Verification
+
+`bun test harness/knowledge` 20/20 (chunk bounds/overlap/determinism; embedder shape/normalization/
+ranking; store CRUD + cosine ranking + dim-mismatch-throws + dataset scoping; ingest clean-stores /
+poison-blocked-never-stored / dead-scanner-fails-closed / delimited-wrap). Full harness 493, desktop 326,
+typecheck clean (3 cfgs). `make demo-P-RAG.1` (`demo_prag1.ts`) proves the property against the REAL
+scanner sidecar + a real temp knowledge.duckdb: clean doc stored, Trojan-Source (bidi U+202E + zero-width
+U+200B) note blocked and never stored, cosine retrieval returns the relevant chunk first, injection
+delimited.
+
+### Invariants preserved
+
+#2 (TS-only - no new Python; the scanner stays the only Python) - #3/#5 (every chunk scanned fail-closed,
+stored with a trust label, injected only delimited + late) - #9 (stable Snowflake `*_id` for
+datasets/chunks) - #10 (a new numbered migration in its own set; frozen ones untouched; `Db.open` change
+is additive) - keystone #2 (RAG chunks are retrieval context, never auto-promoted into semantic memory).
+
+### Relates to
+
+ADR-0053 (the RAG scope/plan this first-builds); ADR-0045/P-SKILL.1 (the scan-gate import seam reused);
+ADR-0012 (classification); ADR-0019 (gate/quarantine surfacing); CLAUDE.md invariants #2/#3/#5/#9/#10 +
+keystone #2.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -4788,3 +4788,59 @@ is maker != checker (a different/smaller model), echoing the `/goal` separation.
 ADR-0046 (`/goal` maker/checker loop reused), ADR-0048 (distinct recommended checker model + `complete()`
 model override), ADR-0027 (the thinking stream surfaced to the UI), ADR-0055 (the idle-cap bump + AskSage
 non-streamed adapter this compensates for), `model_families.ts` / `checker_model.ts`.
+
+## ADR-0057 - P-RESIL.1: AskSage call resilience (retry transient 5xx + MALFORMED_FUNCTION_CALL)
+
+**Date:** 2026-06-24
+**Status:** Accepted - BUILT.
+**Increment:** P-RESIL.1.
+
+### Context
+
+Live `[ASKSAGE_DIAG]` capture (developer mode, ADR-0055) showed two transient failures burning whole agent
+turns - and 100k-200k INPUT tokens each - for zero output:
+- **HTTP 504** from the gov gateway (overloaded/slow on big requests).
+- Gemini **`finishReason: MALFORMED_FUNCTION_CALL`** with an EMPTY body: the model tried to emit a tool
+  call, failed to form valid arguments, and returned nothing. Our adapter parsed it as `empty-response`,
+  so omp got an empty turn and the loop wasted a step (often repeatedly).
+
+Both are usually TRANSIENT (a 504 clears; a malformed call is stochastic at temperature), so a bounded
+retry recovers the turn instead of wasting it.
+
+### Decision
+
+In `callAnthropic` and `callGoogle` (asksage_stream.ts), wrap the fetch + parse in a bounded retry loop:
+`MAX_ATTEMPTS = 3` with short backoff `[800ms, 2000ms]`. Retry when:
+- the fetch throws (network blip) and it was NOT a user abort,
+- the HTTP status is **retriable** (`429` or `5xx`),
+- (Gemini only) `finishReason === "MALFORMED_FUNCTION_CALL"` AND the parse yielded no text and no tool call.
+
+Do NOT retry: success, 4xx client errors (except 429), or a user **Stop** (the abort signal short-circuits
+the loop AND the backoff - `backoff()` rejects immediately on abort, so Stop never waits out a delay).
+Each retry is logged (`retry:true`, `attempt`) so the diagnostics show the recovery. A persistent failure
+still throws after the 3rd attempt (unchanged terminal behavior). A persistent malformed call is now
+labelled `anomaly: "malformed-function-call"` (distinct from a plain `empty-response`) for the Logs panel.
+
+### Why bounded + short
+
+Three attempts with sub-2s backoff bounds the added latency (worst case ~2.8s) and the extra gov-gateway
+load, while clearing the common one-off glitch. It is deliberately NOT an unbounded retry (that would mask
+a real outage and hammer a rate-limited gateway). The auto-continue checker (ADR-0056) covers the
+DIFFERENT case where the model legitimately stops short.
+
+### Verification
+
+5 new tests (asksage_stream.test.ts, 20 total): 504-then-success retries once and recovers;
+MALFORMED-then-valid-tool-call recovers; persistent 504 gives up after exactly 3 attempts and errors; a
+4xx is not retried; a first-try success makes exactly one request. Full harness 506, typecheck clean.
+
+### Invariants preserved
+
+#2 (TS-only) - #3/#4 (retries change nothing about the gate: every recovered tool call is still scanned
+in-process) - the frozen prompt prefix is untouched. Retries are abort-aware so Stop (ADR-0055) still
+cancels instantly.
+
+### Relates to
+
+ADR-0007/0051/0055 (the AskSage adapter + diagnostics this hardens), ADR-0056 (auto-continue, the
+complementary fix for legitimate short-stops), CLAUDE.md #2/#3/#4.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -4688,6 +4688,17 @@ flagged with a raw snippet; HTTP-error diag + stream error). Full harness 500, d
 clean (3 cfgs), renderer bundles. `make demo-P-ASKSAGE.1` proves wrapped replies are recovered, empty
 turns are flagged, and diagnostics are off by default.
 
+### Follow-ups from live testing
+
+- **Stop now actually stops AskSage.** `SimpleStreamOptions.signal` carries omp's AbortSignal, aborted on
+  session/cancel. The adapter ignored `_options`, so a non-streamed AskSage fetch (one long request per
+  turn) kept running after Stop and the turn hung. Threaded `options.signal` into every fetch
+  (anthropic/google/query) and, on abort, settle with a clean `done`/stop (no error toast). Native-provider
+  models (GPT, public Claude) were already cancellable by omp; this closes the AskSage gap.
+- **Developer Logs are live + readable.** The 4s poll now re-fetches `/api/dev` while the Logs tab is open
+  (AskSage rows + transcripts no longer go stale mid-turn). Turn transcripts and AskSage calls render
+  newest-first with a US-Eastern (`America/New_York`, auto EST/EDT) timestamp column.
+
 ### Invariants preserved
 
 #2 (TS-only) - #3/#4 (every tool call the adapter surfaces is still scanned by the in-process gate;

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -4538,7 +4538,7 @@ ADR-0007 (AskSage adapter + `/query` RAG this extends); ADR-0012 (compartments/c
 (gate/quarantine + Security-panel surfacing); ADR-0050 / P-GOAL.8 (the guided-walkthrough UI pattern
 reused); CLAUDE.md invariants #2/#3/#5/#10 + keystone #2.
 
-## ADR-0054 - P-RAG.1: the local knowledge spine (scan-gated ingest + offline cosine retrieval)
+## ADR-0058 - P-RAG.1: the local knowledge spine (scan-gated ingest + offline cosine retrieval)
 
 **Date:** 2026-06-24
 **Status:** Accepted - BUILT.
@@ -4619,7 +4619,7 @@ ADR-0053 (the RAG scope/plan this first-builds); ADR-0045/P-SKILL.1 (the scan-ga
 ADR-0012 (classification); ADR-0019 (gate/quarantine surfacing); CLAUDE.md invariants #2/#3/#5/#9/#10 +
 keystone #2.
 
-## ADR-0055 - P-ASKSAGE.1: AskSage tool-loop diagnostics + tolerant response extraction
+## ADR-0059 - P-ASKSAGE.1: AskSage tool-loop diagnostics + tolerant response extraction
 
 **Date:** 2026-06-24
 **Status:** Accepted - BUILT.
@@ -4710,7 +4710,7 @@ is metadata + a truncated snippet to stderr, developer-mode-gated, never persist
 ADR-0007 (the AskSage adapter), ADR-0051 (tool use added to the Claude+Gemini routes - the path this
 hardens), ADR-0009 Phase D (the developer Logs panel reused), CLAUDE.md invariants #2/#3/#4/#6.
 
-## ADR-0056 - Turn wellness-check + auto-continue ("is the big model still awake?") (SCOPE/PLAN)
+## ADR-0060 - Turn wellness-check + auto-continue ("is the big model still awake?") (SCOPE/PLAN)
 
 **Date:** 2026-06-24
 **Status:** Proposed - scope + plan only; no behavior code yet. Splits into P-CONTINUE.1..2.
@@ -4720,7 +4720,7 @@ hardens), ADR-0009 Phase D (the developer Logs panel reused), CLAUDE.md invarian
 
 Long turns can stop SHORT, and the user has to notice and type "continue":
 - **Idle stall:** the non-streamed AskSage gov gateway emits nothing for minutes during a big call; the
-  idle cap (now 5 min, ADR-0055 follow-up) ends the turn ("gave up on the provider"). Native streaming
+  idle cap (now 5 min, ADR-0059 follow-up) ends the turn ("gave up on the provider"). Native streaming
   models rarely hit this - they emit tokens every few seconds.
 - **Cut off:** the model stops mid-task (stopReason length/truncated, or it just ends early).
 
@@ -4786,10 +4786,10 @@ is maker != checker (a different/smaller model), echoing the `/goal` separation.
 ### Relates to
 
 ADR-0046 (`/goal` maker/checker loop reused), ADR-0048 (distinct recommended checker model + `complete()`
-model override), ADR-0027 (the thinking stream surfaced to the UI), ADR-0055 (the idle-cap bump + AskSage
+model override), ADR-0027 (the thinking stream surfaced to the UI), ADR-0059 (the idle-cap bump + AskSage
 non-streamed adapter this compensates for), `model_families.ts` / `checker_model.ts`.
 
-## ADR-0057 - P-RESIL.1: AskSage call resilience (retry transient 5xx + MALFORMED_FUNCTION_CALL)
+## ADR-0061 - P-RESIL.1: AskSage call resilience (retry transient 5xx + MALFORMED_FUNCTION_CALL)
 
 **Date:** 2026-06-24
 **Status:** Accepted - BUILT.
@@ -4797,7 +4797,7 @@ non-streamed adapter this compensates for), `model_families.ts` / `checker_model
 
 ### Context
 
-Live `[ASKSAGE_DIAG]` capture (developer mode, ADR-0055) showed two transient failures burning whole agent
+Live `[ASKSAGE_DIAG]` capture (developer mode, ADR-0059) showed two transient failures burning whole agent
 turns - and 100k-200k INPUT tokens each - for zero output:
 - **HTTP 504** from the gov gateway (overloaded/slow on big requests).
 - Gemini **`finishReason: MALFORMED_FUNCTION_CALL`** with an EMPTY body: the model tried to emit a tool
@@ -4825,7 +4825,7 @@ labelled `anomaly: "malformed-function-call"` (distinct from a plain `empty-resp
 
 Three attempts with sub-2s backoff bounds the added latency (worst case ~2.8s) and the extra gov-gateway
 load, while clearing the common one-off glitch. It is deliberately NOT an unbounded retry (that would mask
-a real outage and hammer a rate-limited gateway). The auto-continue checker (ADR-0056) covers the
+a real outage and hammer a rate-limited gateway). The auto-continue checker (ADR-0060) covers the
 DIFFERENT case where the model legitimately stops short.
 
 ### Verification
@@ -4837,15 +4837,15 @@ MALFORMED-then-valid-tool-call recovers; persistent 504 gives up after exactly 3
 ### Invariants preserved
 
 #2 (TS-only) - #3/#4 (retries change nothing about the gate: every recovered tool call is still scanned
-in-process) - the frozen prompt prefix is untouched. Retries are abort-aware so Stop (ADR-0055) still
+in-process) - the frozen prompt prefix is untouched. Retries are abort-aware so Stop (ADR-0059) still
 cancels instantly.
 
 ### Relates to
 
-ADR-0007/0051/0055 (the AskSage adapter + diagnostics this hardens), ADR-0056 (auto-continue, the
+ADR-0007/0051/0059 (the AskSage adapter + diagnostics this hardens), ADR-0060 (auto-continue, the
 complementary fix for legitimate short-stops), CLAUDE.md #2/#3/#4.
 
-## ADR-0058 - P-EGRESS.1: per-website approval for the agent's network-reaching tools
+## ADR-0062 - P-EGRESS.1: per-website approval for the agent's network-reaching tools
 
 **Date:** 2026-06-24
 **Status:** Accepted - BUILT.
@@ -4918,4 +4918,4 @@ deciding is not a stalled turn.
 ### Relates to
 
 ADR-0027/P-ACP.3 (the tool-permission forwarding this extends), ADR-0019 (the content gate this complements
-with an egress gate), ADR-0055 (the diagnostics that surfaced the browser flailing). CLAUDE.md #3/#4.
+with an egress gate), ADR-0059 (the diagnostics that surfaced the browser flailing). CLAUDE.md #3/#4.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -4618,3 +4618,81 @@ is additive) - keystone #2 (RAG chunks are retrieval context, never auto-promote
 ADR-0053 (the RAG scope/plan this first-builds); ADR-0045/P-SKILL.1 (the scan-gate import seam reused);
 ADR-0012 (classification); ADR-0019 (gate/quarantine surfacing); CLAUDE.md invariants #2/#3/#5/#9/#10 +
 keystone #2.
+
+## ADR-0055 - P-ASKSAGE.1: AskSage tool-loop diagnostics + tolerant response extraction
+
+**Date:** 2026-06-24
+**Status:** Accepted - BUILT.
+**Increment:** P-ASKSAGE.1.
+
+### Context
+
+Live UI testing surfaced a real defect the mocked tests could not: AskSage **Claude** and **Gemini**
+models run tools (files get partially written) but then the agentic loop "gives up too soon" - no retry,
+no visible reasoning, half-done work. The same prompts complete fine on the public (non-AskSage) models.
+AskSage **GPT** is noticeably better. That last fact is the key clue: GPT goes through omp's NATIVE
+`openai-completions` provider (real streaming, omp's battle-tested loop), while Claude/Gemini go through
+our custom NON-streamed `streamSimple` adapter (`asksage_stream.ts`, ADR-0007/0051). So the early
+termination is isolated to our adapter.
+
+Most likely mechanism, and it is silent: each `streamSimple` call is one HTTP round-trip = one assistant
+turn; omp drives the loop. If a follow-up response is parsed to EMPTY text + ZERO tool calls - because
+the AskSage proxy wrapped the body in a shape our strict parser does not read - we emit a clean
+`done`/`stop` with empty content, and omp concludes the model finished. The mock hand-builds the standard
+Anthropic/Gemini shapes, so it never exercises a wrapped/odd live shape.
+
+The user chose "add diagnostics first" (cannot reach the live gov gateway from the dev host), so this
+increment makes the loop OBSERVABLE and adds the one safe robustness fix.
+
+### Decision - per-call diagnostics (env-gated), surfaced in the developer Logs panel
+
+`asksage_stream.ts` emits one `[ASKSAGE_DIAG] {json}` line per call to stderr when
+`LUCID_ASKSAGE_DEBUG` is set. Each record carries the request summary (route, model, maxTokens, tool
+names sent, message count) and the parsed response (HTTP status, top-level response keys, `via` = which
+shape matched, text length, tool-call names, stopReason, usage). The give-up smoking gun is called out
+explicitly: when an OK response yields empty text AND no tool calls, the record gets
+`anomaly: "empty-response"` plus a truncated raw snippet; a `length`/`MAX_TOKENS` finish gets
+`anomaly: "truncated"`. HTTP and fetch errors are logged with a raw snippet too.
+
+`acp_backend.ts` enables `LUCID_ASKSAGE_DEBUG` in the omp child (inherited at spawn) **when developer
+mode is on** - zero overhead otherwise - and its `onStderr` parses `[ASKSAGE_DIAG]` lines into a bounded
+in-memory ring (last 200), echoing them to the dev-server console. `/api/dev` exposes the ring (developer
+mode only); the renderer's **Logs -> AskSage tool calls** accordion shows one row per call and
+auto-opens, with a chip, when any anomaly/error is present.
+
+### Decision - tolerant response extraction (the one safe fix)
+
+`anthropicBlocks()` / `googleParts()` locate the content blocks/parts tolerantly: the standard shape
+first (`content[]` / `candidates[0].content.parts`), then known wrappers (`response.content`,
+`message.content`, OpenAI-style `choices[0].message` with `tool_calls`, or a plain string under
+`response`/`message`/`completion`/`text`/`answer`). Fallbacks fire ONLY when the strict parse finds
+nothing, so they can only RECOVER content that would otherwise be dropped (turning a premature empty stop
+into a real turn), never change a good parse. `via` records which path matched, so a live test reveals
+the real wire format rather than guessing.
+
+### Deliberately deferred (pending the live diagnostics)
+
+- Relaying the model's THINKING blocks (no reasoning is currently shown) - needs the live shape first.
+- Raising/overriding `max_tokens` if `truncated` turns out to be the cause (diagnostics will say).
+- Confirming omp re-invokes `streamSimple` after each tool result for a custom provider (the per-call
+  log makes the invocation count visible). If it does not loop, that is a deeper omp-integration fix.
+- A live gov-gateway tool round-trip remains the manual check this dev host cannot run.
+
+### Verification
+
+`asksage_stream.test.ts` 14/14 (the original 7 + 7 new: tolerant `response.content` / OpenAI-`choices` /
+wrapped-Gemini recovery; diag off without the env; diag records request+parse; `empty-response` anomaly
+flagged with a raw snippet; HTTP-error diag + stream error). Full harness 500, desktop 326, typecheck
+clean (3 cfgs), renderer bundles. `make demo-P-ASKSAGE.1` proves wrapped replies are recovered, empty
+turns are flagged, and diagnostics are off by default.
+
+### Invariants preserved
+
+#2 (TS-only) - #3/#4 (every tool call the adapter surfaces is still scanned by the in-process gate;
+diagnostics never bypass it) - the frozen prompt prefix is untouched (no prompt bytes changed). Logging
+is metadata + a truncated snippet to stderr, developer-mode-gated, never persisted to the store.
+
+### Relates to
+
+ADR-0007 (the AskSage adapter), ADR-0051 (tool use added to the Claude+Gemini routes - the path this
+hardens), ADR-0009 Phase D (the developer Logs panel reused), CLAUDE.md invariants #2/#3/#4/#6.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -4844,3 +4844,78 @@ cancels instantly.
 
 ADR-0007/0051/0055 (the AskSage adapter + diagnostics this hardens), ADR-0056 (auto-continue, the
 complementary fix for legitimate short-stops), CLAUDE.md #2/#3/#4.
+
+## ADR-0058 - P-EGRESS.1: per-website approval for the agent's network-reaching tools
+
+**Date:** 2026-06-24
+**Status:** Accepted - BUILT.
+**Increment:** P-EGRESS.1.
+
+### Context
+
+Live testing showed the agent autonomously navigating to arbitrary internet sites with omp's `browser`
+tool (improvising a base64 upload of an audio file). In a security/provenance product, silent egress to
+unknown hosts is a real risk (exfiltration, SSRF, fetching hostile content). The gate scans tool-call
+CONTENT for hidden Unicode but does not govern WHERE the agent reaches. The user asked for a
+prompt-before-each-external-fetch flow with rich, persisted choices.
+
+Root cause of the silent browsing: omp's `tools.approvalMode` defaults to **`yolo`** (auto-approve all
+tiers). But `tools.approval` (per-tool policy) is **honored in every approval mode** - so a per-tool
+`prompt` override forces omp to request permission even under yolo.
+
+### Decision - omp config forces a prompt; the desktop owns the dialog
+
+`acp_config.yml` sets `tools.approval: { browser: prompt, web_search: prompt, web: prompt, fetch: prompt }`.
+omp then sends `session/request_permission` for those tools. `acp_backend.onRequest` recognises an egress
+request - by tool name OR by the call carrying an external `http(s)` URL (omp may report `browser` with a
+generic kind, so name alone can miss it) - and, instead of the Agent-mode auto-approve, runs `askEgress`:
+the per-website approval dialog. A standing decision can still auto-allow without prompting. Fail-closed:
+no live UI / timeout (5 min) ⇒ the egress is BLOCKED.
+
+### Decision - the five choices, and what they persist (egress_policy.ts)
+
+The dialog offers four "Yes" and a "No", each mapped to a pure `EgressChoice` folded into a machine-level
+store (`~/.omp/lucid-egress.json`):
+- **allow-once** - approve this call, remember nothing.
+- **allow-site** - approve + auto-allow this host forever (`allowHosts`).
+- **ask-site** - approve, but PIN this host to always-prompt (`alwaysAskHosts`) - overrides danger mode.
+- **danger** ("danger is my middle name") - global allow-all egress (`dangerMode`).
+- **deny** - block; persist nothing.
+
+`egressVerdict(store, url)` is fail-closed: `alwaysAsk` pin → prompt; allow-listed host → allow; danger →
+allow; everything else (incl. an unparseable URL) → prompt. The decision logic is pure and unit-tested;
+the chosen omp option (allow/deny) is resolved from omp's own `options`, so we never invent option ids.
+
+### Decision - the dialog (the user's spec)
+
+The card shows the **target URL prominently** with a **copy button**, a security note, and a **"Check this
+site with Cloudflare Radar"** button that copies the URL and opens `https://radar.cloudflare.com/scan` in a
+browser so the user can vet the site before allowing. Then the five choices, stacked. Amber-accented (it's
+a network-egress gate, distinct from the standard Ask-mode card).
+
+### Scope / deferred (P-EGRESS.2)
+
+`web_search` (a search QUERY, no host) currently falls into the dialog as allow-once/danger/deny - the
+per-site options are no-ops without a host; a query-aware variant is deferred. A Security-panel view of
+egress decisions (and a "forget this site" / "exit danger mode" control) is deferred. Domain-allowlist
+import and per-project (not just per-host) scoping are deferred.
+
+### Verification
+
+13 unit tests (egress_policy.test.ts): host extraction (URL / bare / junk), fail-closed verdict,
+allow-list, danger mode, ask-site pin overriding danger, and choice-folding round-trips. Desktop 339,
+typecheck clean, bundle OK; the dialog rendering was visually verified in the dev server. The LIVE
+omp-permission round-trip (does omp emit request_permission for `browser` with the URL in rawInput?) is
+the manual check - the config + the name-OR-url detection are built to handle either shape.
+
+### Invariants preserved
+
+#3/#4 (the gate is unchanged - it still scans every tool call; this adds an egress GATE on top, never
+bypasses the content gate) - fail-closed (no UI / timeout ⇒ block) - the frozen prompt prefix is
+untouched. Permission still parks the JSON-RPC response and pauses the idle clock (P-ACP.3), so a human
+deciding is not a stalled turn.
+
+### Relates to
+
+ADR-0027/P-ACP.3 (the tool-permission forwarding this extends), ADR-0019 (the content gate this complements
+with an egress gate), ADR-0055 (the diagnostics that surfaced the browser flailing). CLAUDE.md #3/#4.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -4658,7 +4658,9 @@ explicitly: when an OK response yields empty text AND no tool calls, the record 
 mode is on** - zero overhead otherwise - and its `onStderr` parses `[ASKSAGE_DIAG]` lines into a bounded
 in-memory ring (last 200), echoing them to the dev-server console. `/api/dev` exposes the ring (developer
 mode only); the renderer's **Logs -> AskSage tool calls** accordion shows one row per call and
-auto-opens, with a chip, when any anomaly/error is present.
+auto-opens, with a chip, when any anomaly/error is present. Because the child reads the env only at
+spawn, toggling developer mode (`POST /api/dev`) calls `backend.restart()` on a real change, so the
+diagnostics take effect immediately with no app restart (the same respawn pattern as an API-key change).
 
 ### Decision - tolerant response extraction (the one safe fix)
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -4709,3 +4709,82 @@ is metadata + a truncated snippet to stderr, developer-mode-gated, never persist
 
 ADR-0007 (the AskSage adapter), ADR-0051 (tool use added to the Claude+Gemini routes - the path this
 hardens), ADR-0009 Phase D (the developer Logs panel reused), CLAUDE.md invariants #2/#3/#4/#6.
+
+## ADR-0056 - Turn wellness-check + auto-continue ("is the big model still awake?") (SCOPE/PLAN)
+
+**Date:** 2026-06-24
+**Status:** Proposed - scope + plan only; no behavior code yet. Splits into P-CONTINUE.1..2.
+**Context increment:** P-CONTINUE (planning).
+
+### Context
+
+Long turns can stop SHORT, and the user has to notice and type "continue":
+- **Idle stall:** the non-streamed AskSage gov gateway emits nothing for minutes during a big call; the
+  idle cap (now 5 min, ADR-0055 follow-up) ends the turn ("gave up on the provider"). Native streaming
+  models rarely hit this - they emit tokens every few seconds.
+- **Cut off:** the model stops mid-task (stopReason length/truncated, or it just ends early).
+
+The user's idea: when a turn looks unfinished, have a SMALL, FAST model of the SAME family "check on the
+big guy" - read the chat history, decide if the work is actually done, and if not, automatically push the
+big model for another turn to finish, showing the check in the thinking panel. This is the `/goal`
+maker/checker pattern (ADR-0046) applied to chat continuation, reusing `complete()` with a model override
+(ADR-0048) and the existing thinking stream (ADR-0027).
+
+### Decision - the loop
+
+After a chat turn ENDS, if it looks potentially INCOMPLETE, run a CHECKER (cheap same-family model) on the
+last user request + the assistant's final message. The checker returns COMPLETE or INCOMPLETE + a one-line
+"what remains". If INCOMPLETE and under a cap, auto-send a continuation prompt to the BIG model on the same
+session; surface the whole thing in the thinking panel. Stop when the checker says COMPLETE or the cap hits.
+
+### Decision - when to trigger (conservative, cost-aware)
+
+Run the checker ONLY when there's a real cut-off signal: the turn **idle-stalled**, OR stopReason was
+**length/truncated**. Do NOT run on: a user-cancelled turn (Stop), an empty/errored turn, a `/goal` loop
+turn (it has its own checker), or a turn that ended with a normal `end_turn` and no truncation (default:
+assume complete - no checker, no cost). P-CONTINUE.2 may add a heuristic "looks mid-task" trigger
+(unclosed code fence, ends on "Let me.../Next I'll...").
+
+### Decision - checker model (same family, smaller)
+
+Map the active model to its fast/small SAME-family sibling: Gemini Pro -> Gemini Flash; Claude Sonnet/Opus
+-> Claude Haiku; GPT-big -> GPT-mini. Reuse `model_families.ts` + `recommendCheckerModel`
+(`checker_model.ts`). For AskSage models, keep the checker on the AskSage route of the SAME family (gov
+compliance - never route gov content to a non-gov checker). Fall back to the same model if no smaller
+sibling exists. The checker runs via `complete(system, user, { model })` - a throwaway session that never
+pollutes the chat (ADR-0048).
+
+### Decision - the verdict is fail-closed
+
+The checker is prompted to answer strictly `COMPLETE` / `INCOMPLETE` + reason + what-remains. Parsing
+mirrors `parseGoalVerdict` (`goal_verdict.ts`): empty/garbled/ambiguous => treat as COMPLETE. Better to
+under-continue than to loop forever. A hard cap `maxAutoContinue` (default 2) bounds it regardless.
+
+### Decision - UX
+
+Show the check live in the THINKING panel: "Checking whether the last turn finished... the response looks
+cut off; asking the model to continue (what remains: ...)". The auto-sent continuation renders as a normal
+assistant turn with a subtle "auto-continued" marker so the user knows it was the wellness-check, not them.
+A Settings toggle (default ON, with the cap shown) lets users disable it. Continuation prompt: "Continue
+and finish what you were doing - <what remains>. Do not repeat work you already completed."
+
+### Phasing
+
+- **P-CONTINUE.1** - core: detect cut-off (stall / length), pick the same-family checker, run it via
+  `complete()`, auto-send ONE continuation on INCOMPLETE, fail-closed verdict, cap + Settings toggle,
+  thinking-panel surfacing.
+- **P-CONTINUE.2** - heuristic "looks mid-task" trigger, sharper "what remains" extraction, multi-continue
+  tuning, and per-provider rate-limit backoff (don't hammer a 429'd gov gateway).
+
+### Invariants preserved
+
+#3/#4 (continuation turns + the checker's view still pass the in-process gate - every tool call scanned;
+the checker only ever sees gate-clean assistant text) - #5 (no untrusted text enters the frozen prefix) -
+keystone #2 (the checker is ephemeral judgment via `complete()`, never promoted to memory). The checker
+is maker != checker (a different/smaller model), echoing the `/goal` separation.
+
+### Relates to
+
+ADR-0046 (`/goal` maker/checker loop reused), ADR-0048 (distinct recommended checker model + `complete()`
+model override), ADR-0027 (the thinking stream surfaced to the UI), ADR-0055 (the idle-cap bump + AskSage
+non-streamed adapter this compensates for), `model_families.ts` / `checker_model.ts`.

--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,10 @@ demo-P-TPS.1: ## P-TPS.1 (ADR-0044): streaming output-token readout — output-o
 demo-P-SKILL.1: ## P-SKILL.1 (ADR-0045): gated skill import — clean .md writes to .omp/skills/, poisoned blocks at the gate
 	$(BUN) run harness/scripts/demo_pskill1.ts
 
+.PHONY: demo-P-RAG.1
+demo-P-RAG.1: ## P-RAG.1 (ADR-0054): local knowledge spine — scan-gated ingest, fail-closed block, offline cosine retrieval, delimited injection
+	$(BUN) run harness/scripts/demo_prag1.ts
+
 .PHONY: dashboards
 dashboards: ## Materialize dashboard CSVs from a DuckDB into observable/docs/data (DB=path)
 	$(BUN) run harness/scripts/materialize_dashboards.ts $(DB) observable/docs/data

--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,10 @@ demo-P-SKILL.1: ## P-SKILL.1 (ADR-0045): gated skill import — clean .md writes
 demo-P-RAG.1: ## P-RAG.1 (ADR-0054): local knowledge spine — scan-gated ingest, fail-closed block, offline cosine retrieval, delimited injection
 	$(BUN) run harness/scripts/demo_prag1.ts
 
+.PHONY: demo-P-ASKSAGE.1
+demo-P-ASKSAGE.1: ## P-ASKSAGE.1 (ADR-0055): AskSage tool-loop diagnostics + tolerant extraction — wrapped replies recovered, empty turns flagged
+	$(BUN) run harness/scripts/demo_paskage1.ts
+
 .PHONY: dashboards
 dashboards: ## Materialize dashboard CSVs from a DuckDB into observable/docs/data (DB=path)
 	$(BUN) run harness/scripts/materialize_dashboards.ts $(DB) observable/docs/data

--- a/Makefile
+++ b/Makefile
@@ -159,11 +159,11 @@ demo-P-SKILL.1: ## P-SKILL.1 (ADR-0045): gated skill import — clean .md writes
 	$(BUN) run harness/scripts/demo_pskill1.ts
 
 .PHONY: demo-P-RAG.1
-demo-P-RAG.1: ## P-RAG.1 (ADR-0054): local knowledge spine — scan-gated ingest, fail-closed block, offline cosine retrieval, delimited injection
+demo-P-RAG.1: ## P-RAG.1 (ADR-0058): local knowledge spine — scan-gated ingest, fail-closed block, offline cosine retrieval, delimited injection
 	$(BUN) run harness/scripts/demo_prag1.ts
 
 .PHONY: demo-P-ASKSAGE.1
-demo-P-ASKSAGE.1: ## P-ASKSAGE.1 (ADR-0055): AskSage tool-loop diagnostics + tolerant extraction — wrapped replies recovered, empty turns flagged
+demo-P-ASKSAGE.1: ## P-ASKSAGE.1 (ADR-0059): AskSage tool-loop diagnostics + tolerant extraction — wrapped replies recovered, empty turns flagged
 	$(BUN) run harness/scripts/demo_paskage1.ts
 
 .PHONY: dashboards

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2135,7 +2135,11 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
   real change) so the debug env takes effect with NO app restart. Also ADDED the missing Developer-mode
   toggle to Settings (Settings → Developer) — the #devModeToggle handler existed but no card rendered it,
   so dev mode (and thus the Logs panel + these diagnostics) was unreachable from the UI; live-verified the
-  card renders, toggles on/off, and respawns cleanly. 7 new tests (asksage_stream 14 total); harness 500 ·
+  card renders, toggles on/off, and respawns cleanly. ALSO added the missing #railLogs rail button (its
+  loadDev() un-hide existed but no button was rendered) AND fixed focusInspector so an explicit Logs/Memory
+  click from the collapsed metrics rail is no longer hijacked to Security by the ADR-0021 active-blocks
+  override — live-verified the Logs button appears in dev mode and opens the Developer-logs panel (AskSage
+  accordion at top). 7 new tests (asksage_stream 14 total); harness 500 ·
   desktop 326 · typecheck clean · bundle OK. demo-P-ASKSAGE.1 proves recover/flag/off-by-default.
 - **stubbed:** thinking-block relay (no reasoning shown yet) and a max_tokens override are DEFERRED until
   the live diagnostics say which failure it is; whether omp re-invokes streamSimple after each tool result

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2216,3 +2216,14 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
   or a hard per-turn cap (user deferred the timeout).
 - **next:** user reproduces a long-turn hang with developer mode ON and pastes the `[TURN_DIAG]` lines from
   the dev-server terminal; that pins wedge vs clobber vs disconnect and the fix follows.
+
+---
+**P-EGRESS.1 UI polish: docked, subdued, de-duplicated egress dialog (ADR-0058)**
+- **shipped:** per UX feedback — the egress approval card now DOCKS directly above the prompt bar (egressDock
+  in .composer-wrap) instead of inline in the chat; restyled subdued to match the app (outline buttons, no
+  bright magenta fills, thin amber accent, app text styles); the choices were de-duplicated from 5 to 4
+  ("ask me every time" had the same outcome as "Allow once" — both ask again next time — so it was dropped):
+  Allow once / Always allow this site / Always allow every site (amber-tinted = the risky one) / Block. On
+  answer the docked card removes itself + a brief toast. typecheck clean · bundle OK · egress tests 13 ·
+  card visually verified in the dev server.
+- **next:** remaining selected threads — tool curation, lossy streaming ([TURN_DIAG]), P-CONTINUE.1.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2199,3 +2199,20 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
   recovery path meanwhile.
 - **next:** capture omp's terminal output during a wedge; determine if it's every AskSage turn or only
   long multi-tool ones; consider a server-side per-turn timeout in acp_backend.prompt() as a backstop.
+
+---
+**Turn-lifecycle diagnostics + listener-clobber guard (debugging the AskSage long-turn hang, ADR-0055)**
+- **shipped:** user confirmed long multi-tool AskSage turns hang with done never reaching the browser (blank
+  till reload). Added `[TURN_DIAG]` logging (developer mode → dev-server console): prompt.start /
+  prompt.resolved|stalled|error (with chars, enqueueErr, listenerIntact) / complete.end (clobberAvoided) /
+  chat-stream-write-failed. This disambiguates the three hypotheses on the NEXT hang: omp wedge (no
+  prompt.resolved line ever), listener clobber (listenerIntact=false), or browser disconnect (enqueueErr>0 /
+  write failed). Also: sink now swallows onEvent throws (counts enqueueErr) so a closed browser stream can't
+  break the server turn; and complete() no longer restores the shared this.listener if a chat turn took it
+  over mid-completion (clobberAvoided) — a real orphan bug for overlapping turns. typecheck · desktop 326 ·
+  bundle OK.
+- **stubbed:** root cause still unconfirmed pending a live `[TURN_DIAG]` capture; if it's the omp wedge
+  (session/prompt never resolving while events trickle, so the 2-min idle never fires) the fix is upstream
+  or a hard per-turn cap (user deferred the timeout).
+- **next:** user reproduces a long-turn hang with developer mode ON and pastes the `[TURN_DIAG]` lines from
+  the dev-server terminal; that pins wedge vs clobber vs disconnect and the fix follows.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2132,7 +2132,10 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
   only turn a premature empty stop into a real turn; (3) acp_backend sets the env in DEVELOPER MODE,
   onStderr rings the diagnostics (last 200) + echoes to console; (4) renderer Logs → "AskSage tool calls"
   accordion (auto-opens + chip on any anomaly); toggling developer mode respawns omp (backend.restart on a
-  real change) so the debug env takes effect with NO app restart. 7 new tests (asksage_stream 14 total); harness 500 ·
+  real change) so the debug env takes effect with NO app restart. Also ADDED the missing Developer-mode
+  toggle to Settings (Settings → Developer) — the #devModeToggle handler existed but no card rendered it,
+  so dev mode (and thus the Logs panel + these diagnostics) was unreachable from the UI; live-verified the
+  card renders, toggles on/off, and respawns cleanly. 7 new tests (asksage_stream 14 total); harness 500 ·
   desktop 326 · typecheck clean · bundle OK. demo-P-ASKSAGE.1 proves recover/flag/off-by-default.
 - **stubbed:** thinking-block relay (no reasoning shown yet) and a max_tokens override are DEFERRED until
   the live diagnostics say which failure it is; whether omp re-invokes streamSimple after each tool result

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2093,3 +2093,26 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
   Gemini) is the manual check; parametersJsonSchema assumes AskSage's Gemini proxy is current (omp uses it for
   real Gemini).
 - **next:** live end-to-end tool run on the gov gateway for both providers.
+
+---
+## P-RAG.1: the local knowledge spine (ADR-0054, first build under ADR-0053)
+- **shipped:** the air-gap-clean RAG core, server-side, no new runtime deps. `Db.open(path, migrationsDir?)`
+  parameterized (additive; every existing caller unchanged) so a SEPARATE `knowledge.duckdb` gets its own
+  migration set (ADR-0053 #3); migration `0010_knowledge_vectors.sql` (kb_datasets U|CUI/local|asksage +
+  kb_chunks with `embedding FLOAT[]` + trust_label) applies ONLY to it, never agent_obs.duckdb. New
+  `harness/knowledge/`: pure `chunk.ts` (overlapping, boundary-preferring, deterministic); `embedder.ts`
+  (an `Embedder` interface + deterministic dependency-free `HashEmbedder`, so the spine is testable offline
+  and the real WASM bge drops in later behind the same seam); `store.ts` (dataset/chunk CRUD + brute-force
+  `list_cosine_distance` retrieval, vectors inlined as numeric SQL list literals since the node binding
+  can't bind a JS array param); `ingest.ts` `ingestText` (chunk -> scanAndDecide fail-closed -> embed only
+  clean -> store; blocked chunk never embedded/stored, audited via an `onBlock` hook = clean layering) +
+  `wrapRetrieved` (UNTRUSTED_CONTENT delimited, invariant #5). 20 new tests; bun test harness 493 · desktop
+  326 · typecheck clean (3 cfgs). `make demo-P-RAG.1` proves it against the REAL scanner + a temp
+  knowledge.duckdb: clean doc stored, Trojan-Source (bidi/zero-width) note blocked + never stored, cosine
+  retrieval returns the relevant chunk first, injection delimited.
+- **stubbed:** the embedder is the deterministic `HashEmbedder`, NOT a real model (P-RAG.1b: WASM
+  `bge-small-en-v1.5` + bundled weights + `unpdf` PDF parse). No Knowledge UI / per-turn injection wiring yet
+  (P-RAG.1c). New EventNames deferred (a contracts change is its own increment). No live multimodal.
+- **next:** P-RAG.1b (real WASM embedder + PDF parse behind the `Embedder` seam, weights bundled as
+  extraResources), then P-RAG.1c (Knowledge popup guided+advanced for the local path, fixed-path
+  knowledge.duckdb, desktop recordBlock via onBlock, retrieval injection mirroring the dataset selector).

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2182,3 +2182,20 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
   watchdog added (a single gov-gateway call can exceed 60s, so a silence-timeout would false-settle).
 - **next:** capture omp's own logs during a wedge to see why session/prompt doesn't resolve; consider an
   omp issue/upstream fix or a per-turn server-side timeout in acp_backend.prompt().
+
+---
+**Chat reconciles full reply on `done` (follow-up to ADR-0055)**
+- **shipped:** live AskSage turns sometimes completed server-side (captured in the turns log) yet the chat
+  showed only the first tool call and no answer until a browser reload (which then lost the live tool chips
+  + time/token stats). The server-side `assistant` accumulator and the browser stream are fed by the same
+  listener, so a completed turn HAS the full text. Now `prompt()` emits `{type:"done", text: assistant}`
+  and the renderer reconciles: on done, if the server's full text is longer than what streamed, it replaces
+  buf — so the complete final answer always renders when the turn settles, even if live token chunks were
+  lost. typecheck clean · desktop 326 · bundle OK.
+- **stubbed:** this only helps when `done` REACHES the browser. The deeper failure — omp not resolving
+  session/prompt at all (a genuine wedge: the model finished per the stderr diag + turns log, but the ACP
+  turn never closes) and intermediate tool_call/agent_message events dropping mid-stream — is an
+  omp-integration issue that needs omp's own logs to root-cause. Stop (client abort, prior commit) is the
+  recovery path meanwhile.
+- **next:** capture omp's terminal output during a wedge; determine if it's every AskSage turn or only
+  long multi-tool ones; consider a server-side per-turn timeout in acp_backend.prompt() as a backstop.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2131,7 +2131,8 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
   OpenAI choices[].message, plain-string message) — fires ONLY when the strict parse is empty, so it can
   only turn a premature empty stop into a real turn; (3) acp_backend sets the env in DEVELOPER MODE,
   onStderr rings the diagnostics (last 200) + echoes to console; (4) renderer Logs → "AskSage tool calls"
-  accordion (auto-opens + chip on any anomaly). 7 new tests (asksage_stream 14 total); harness 500 ·
+  accordion (auto-opens + chip on any anomaly); toggling developer mode respawns omp (backend.restart on a
+  real change) so the debug env takes effect with NO app restart. 7 new tests (asksage_stream 14 total); harness 500 ·
   desktop 326 · typecheck clean · bundle OK. demo-P-ASKSAGE.1 proves recover/flag/off-by-default.
 - **stubbed:** thinking-block relay (no reasoning shown yet) and a max_tokens override are DEFERRED until
   the live diagnostics say which failure it is; whether omp re-invokes streamSimple after each tool result

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2148,3 +2148,19 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
 - **next:** the user re-tests live with developer mode on; read the AskSage-calls diagnostics (look for
   `empty-response`/`truncated`/error rows + the `via`/raw shape) and fix the confirmed root cause
   (likely either a wrapper shape to parse, a max_tokens bump, or relaying thinking).
+
+---
+**AskSage Stop fix + live, readable Logs (follow-ups to P-ASKSAGE.1, ADR-0055)**
+- **shipped:** (1) STOP now cancels AskSage turns — omp passes options.signal (AbortSignal, aborted on
+  session/cancel) but the adapter ignored it, so a non-streamed AskSage fetch ran on after Stop and the
+  turn hung; threaded signal into every fetch (anthropic/google/query) + settle cleanly (done/stop, no
+  error) on abort. (2) Developer Logs poll live — refresh() re-fetches /api/dev while the Logs tab is open,
+  so AskSage rows + transcripts update mid-turn instead of only on tab-switch/refresh. (3) Turn transcripts
+  + AskSage calls now render NEWEST-FIRST with a US-Eastern (auto EST/EDT) timestamp column. 1 new abort
+  test (asksage_stream 15); harness 501 · desktop 326 · typecheck clean · bundle OK; live-verified the
+  transcript order + EDT stamps.
+- **stubbed:** the native-provider hang (public Claude/Opus "searching the codebase" that wouldn't stop) is
+  NOT this fix — that path is omp-native and was already cancellable; if it recurs it's a separate
+  gate/omp-level investigation. Live gov-gateway Stop round-trip still the manual check.
+- **next:** user re-tests live: AskSage rows should populate without a refresh, Stop should end a hung
+  AskSage turn, transcripts newest-first with ET times. Then read the diagnostics for the give-up root cause.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2095,7 +2095,7 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
 - **next:** live end-to-end tool run on the gov gateway for both providers.
 
 ---
-## P-RAG.1: the local knowledge spine (ADR-0054, first build under ADR-0053)
+## P-RAG.1: the local knowledge spine (ADR-0058, first build under ADR-0053)
 - **shipped:** the air-gap-clean RAG core, server-side, no new runtime deps. `Db.open(path, migrationsDir?)`
   parameterized (additive; every existing caller unchanged) so a SEPARATE `knowledge.duckdb` gets its own
   migration set (ADR-0053 #3); migration `0010_knowledge_vectors.sql` (kb_datasets U|CUI/local|asksage +
@@ -2118,7 +2118,7 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
   knowledge.duckdb, desktop recordBlock via onBlock, retrieval injection mirroring the dataset selector).
 
 ---
-## P-ASKSAGE.1: AskSage tool-loop diagnostics + tolerant extraction (ADR-0055)
+## P-ASKSAGE.1: AskSage tool-loop diagnostics + tolerant extraction (ADR-0059)
 - **shipped:** live UI testing showed AskSage Claude/Gemini run tools but the loop "gives up too soon"
   (half-done files, no retry, no visible reasoning) while public models + AskSage GPT do fine — GPT uses
   omp's NATIVE openai-completions provider, Claude/Gemini use our non-streamed streamSimple adapter, so
@@ -2150,7 +2150,7 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
   (likely either a wrapper shape to parse, a max_tokens bump, or relaying thinking).
 
 ---
-**AskSage Stop fix + live, readable Logs (follow-ups to P-ASKSAGE.1, ADR-0055)**
+**AskSage Stop fix + live, readable Logs (follow-ups to P-ASKSAGE.1, ADR-0059)**
 - **shipped:** (1) STOP now cancels AskSage turns — omp passes options.signal (AbortSignal, aborted on
   session/cancel) but the adapter ignored it, so a non-streamed AskSage fetch ran on after Stop and the
   turn hung; threaded signal into every fetch (anthropic/google/query) + settle cleanly (done/stop, no
@@ -2166,7 +2166,7 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
   AskSage turn, transcripts newest-first with ET times. Then read the diagnostics for the give-up root cause.
 
 ---
-**Stop reliably recovers a wedged turn (client-side abort) — follow-up to ADR-0055**
+**Stop reliably recovers a wedged turn (client-side abort) — follow-up to ADR-0059**
 - **shipped:** live AskSage Claude-45-Sonnet-Gov trace showed a HEALTHY adapter loop (read→write→end_turn,
   msgs 27→29→31, all ok via:content, no anomalies) yet the chat UI hung showing only the first tool call
   and Stop didn't recover it. Root cause: the turn settles only when bridge.sendPrompt's NDJSON stream
@@ -2184,7 +2184,7 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
   omp issue/upstream fix or a per-turn server-side timeout in acp_backend.prompt().
 
 ---
-**Chat reconciles full reply on `done` (follow-up to ADR-0055)**
+**Chat reconciles full reply on `done` (follow-up to ADR-0059)**
 - **shipped:** live AskSage turns sometimes completed server-side (captured in the turns log) yet the chat
   showed only the first tool call and no answer until a browser reload (which then lost the live tool chips
   + time/token stats). The server-side `assistant` accumulator and the browser stream are fed by the same
@@ -2201,7 +2201,7 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
   long multi-tool ones; consider a server-side per-turn timeout in acp_backend.prompt() as a backstop.
 
 ---
-**Turn-lifecycle diagnostics + listener-clobber guard (debugging the AskSage long-turn hang, ADR-0055)**
+**Turn-lifecycle diagnostics + listener-clobber guard (debugging the AskSage long-turn hang, ADR-0059)**
 - **shipped:** user confirmed long multi-tool AskSage turns hang with done never reaching the browser (blank
   till reload). Added `[TURN_DIAG]` logging (developer mode → dev-server console): prompt.start /
   prompt.resolved|stalled|error (with chars, enqueueErr, listenerIntact) / complete.end (clobberAvoided) /
@@ -2218,7 +2218,7 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
   the dev-server terminal; that pins wedge vs clobber vs disconnect and the fix follows.
 
 ---
-**P-EGRESS.1 UI polish: docked, subdued, de-duplicated egress dialog (ADR-0058)**
+**P-EGRESS.1 UI polish: docked, subdued, de-duplicated egress dialog (ADR-0062)**
 - **shipped:** per UX feedback — the egress approval card now DOCKS directly above the prompt bar (egressDock
   in .composer-wrap) instead of inline in the chat; restyled subdued to match the app (outline buttons, no
   bright magenta fills, thin amber accent, app text styles); the choices were de-duplicated from 5 to 4

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2116,3 +2116,27 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
 - **next:** P-RAG.1b (real WASM embedder + PDF parse behind the `Embedder` seam, weights bundled as
   extraResources), then P-RAG.1c (Knowledge popup guided+advanced for the local path, fixed-path
   knowledge.duckdb, desktop recordBlock via onBlock, retrieval injection mirroring the dataset selector).
+
+---
+## P-ASKSAGE.1: AskSage tool-loop diagnostics + tolerant extraction (ADR-0055)
+- **shipped:** live UI testing showed AskSage Claude/Gemini run tools but the loop "gives up too soon"
+  (half-done files, no retry, no visible reasoning) while public models + AskSage GPT do fine — GPT uses
+  omp's NATIVE openai-completions provider, Claude/Gemini use our non-streamed streamSimple adapter, so
+  the bug is isolated there. Most likely silent cause: a follow-up reply parsed to empty text + 0 tool
+  calls → omp thinks the model finished. Fix: (1) per-call diagnostics in asksage_stream.ts — one
+  `[ASKSAGE_DIAG] {json}` line per call (env LUCID_ASKSAGE_DEBUG) capturing request (route/model/maxTokens/
+  tools/msgs) + parsed response (status/respKeys/via/textLen/toolCalls/stopReason/usage), with an explicit
+  `empty-response`/`truncated` anomaly + raw snippet on the give-up path; (2) tolerant extraction
+  (anthropicBlocks/googleParts) that recovers content from wrapped shapes (response.content,
+  OpenAI choices[].message, plain-string message) — fires ONLY when the strict parse is empty, so it can
+  only turn a premature empty stop into a real turn; (3) acp_backend sets the env in DEVELOPER MODE,
+  onStderr rings the diagnostics (last 200) + echoes to console; (4) renderer Logs → "AskSage tool calls"
+  accordion (auto-opens + chip on any anomaly). 7 new tests (asksage_stream 14 total); harness 500 ·
+  desktop 326 · typecheck clean · bundle OK. demo-P-ASKSAGE.1 proves recover/flag/off-by-default.
+- **stubbed:** thinking-block relay (no reasoning shown yet) and a max_tokens override are DEFERRED until
+  the live diagnostics say which failure it is; whether omp re-invokes streamSimple after each tool result
+  for a custom provider is now observable (the per-call log) but unconfirmed live. Tolerant fallbacks are
+  for SHAPES NOT YET CONFIRMED against the real gateway (conservative — only recover, never override).
+- **next:** the user re-tests live with developer mode on; read the AskSage-calls diagnostics (look for
+  `empty-response`/`truncated`/error rows + the `via`/raw shape) and fix the confirmed root cause
+  (likely either a wrapper shape to parse, a max_tokens bump, or relaying thinking).

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2164,3 +2164,21 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
   gate/omp-level investigation. Live gov-gateway Stop round-trip still the manual check.
 - **next:** user re-tests live: AskSage rows should populate without a refresh, Stop should end a hung
   AskSage turn, transcripts newest-first with ET times. Then read the diagnostics for the give-up root cause.
+
+---
+**Stop reliably recovers a wedged turn (client-side abort) — follow-up to ADR-0055**
+- **shipped:** live AskSage Claude-45-Sonnet-Gov trace showed a HEALTHY adapter loop (read→write→end_turn,
+  msgs 27→29→31, all ok via:content, no anomalies) yet the chat UI hung showing only the first tool call
+  and Stop didn't recover it. Root cause: the turn settles only when bridge.sendPrompt's NDJSON stream
+  ends; if omp never resolves session/prompt (turn-finalization wedge — the model finished but omp didn't
+  close the stream), reader.read() blocks forever and the UI is stuck. Fix: streamNdjson takes an
+  AbortSignal; a module-level chatAbort controller wraps the chat stream; cancelChat() now aborts it
+  (client read ends → sendPrompt resolves → the send finally settles the UI) AND posts the server cancel.
+  So Stop ALWAYS recovers the UI even when omp is wedged. typecheck clean · desktop 326 · bundle OK.
+- **stubbed:** the underlying wedge (omp not resolving session/prompt after a custom-provider turn ends, and
+  only the first tool_call reaching the desktop over ACP while the model loop ran ahead) is an
+  omp-integration issue not root-caused here — the adapter is provably healthy (stderr diag), the gap is in
+  omp's ACP session/update + prompt-completion emission for the custom streamSimple provider. No client
+  watchdog added (a single gov-gateway call can exceed 60s, so a silence-timeout would false-settle).
+- **next:** capture omp's own logs during a wedge to see why session/prompt doesn't resolve; consider an
+  omp issue/upstream fix or a per-turn server-side timeout in acp_backend.prompt().

--- a/desktop/acp_backend.ts
+++ b/desktop/acp_backend.ts
@@ -380,7 +380,11 @@ class Backend {
   // ACP request has no timeout, so without this a rate-limited / hung turn leaves the UI
   // on "Thinking…" forever. Resets on every event, so a legitimately long turn is fine —
   // only TOTAL silence for this long trips it.
-  private static readonly IDLE_MS = 120_000;
+  // 5 min. Native providers stream tokens every few seconds so they almost never trip this; the headroom
+  // is for the NON-STREAMED AskSage gov gateway, where a single big call emits nothing for minutes and a
+  // 2-min cap false-stalled live turns ("gave up on the provider"). The auto-continue checker (ADR-0056)
+  // will eventually turn a stall into a wellness-check + resume rather than a dead end.
+  private static readonly IDLE_MS = 300_000;
 
   /** Run one turn, streaming events to onEvent; resolves after `done`. Captures the
    *  assistant reply so the personalization distiller can learn from the turn (P9.2).
@@ -392,7 +396,7 @@ class Backend {
     let onStall: (e: Error) => void = () => {};
     // While a permission is awaiting the user (Ask mode), pause the idle/stall clock — a human
     // deciding is not a stalled turn (askUser has its own fail-closed timeout).
-    const arm = () => { if (idle) clearTimeout(idle); if (this.pendingPerms > 0) return; idle = setTimeout(() => { stalled = true; onStall(new Error("the model did not respond for 2 minutes — the provider may be rate-limited (check your hourly budget) or the turn stalled. Try again.")); }, Backend.IDLE_MS); };
+    const arm = () => { if (idle) clearTimeout(idle); if (this.pendingPerms > 0) return; idle = setTimeout(() => { stalled = true; onStall(new Error("the model went quiet for 5 minutes — the provider may be rate-limited (check your hourly budget) or the turn stalled. Try again.")); }, Backend.IDLE_MS); };
     let enqueueErr = 0; // counts browser-stream write failures (orphaned/closed client stream)
     const sink = (e: ChatEvent) => { arm(); if (e.type === "token") assistant += e.text; try { onEvent(e); } catch { enqueueErr++; } };
     this.listener = sink;

--- a/desktop/acp_backend.ts
+++ b/desktop/acp_backend.ts
@@ -418,7 +418,9 @@ class Backend {
       this.pendingPerms = 0;
     }
     this.listener = null;
-    onEvent({ type: "done" });
+    // Carry the FULL accumulated reply on `done` so the UI can reconcile a lossy live stream (if some
+    // token chunks didn't reach the browser, the turn still renders the complete final answer on settle).
+    onEvent({ type: "done", text: assistant });
     void learnFromTurn(text, assistant, (sys, usr) => this.complete(sys, usr)); // best-effort; the model extractor (opt-in) uses complete()
     // ADR-0009 Phase B (issue #12): capture the turn for traceability. Sanitized + sha only,
     // GUI-side (can't co-write DuckDB); fully guarded so it never affects the chat.

--- a/desktop/acp_backend.ts
+++ b/desktop/acp_backend.ts
@@ -25,7 +25,7 @@ import { appendGoalIteration, finishGoalMemory, type GoalMemory, resumeGoalMemor
 import { type Automation, listAutomations, nextDueAutomation, updateAutomation } from "./automations.ts";
 import { type EgressChoice, egressDecision, recordEgress } from "./egress_policy.ts";
 
-// P-EGRESS.1 (ADR-0058): the network-reaching tools omp is told to PROMPT for (acp_config.yml). When omp
+// P-EGRESS.1 (ADR-0062): the network-reaching tools omp is told to PROMPT for (acp_config.yml). When omp
 // requests permission for one of these, the desktop shows the per-website approval dialog instead of
 // silently auto-approving in Agent mode.
 const EGRESS_TOOLS = new Set(["browser", "web_search", "web", "fetch", "navigate"]);
@@ -144,7 +144,7 @@ class Backend {
 
   private emit(e: ChatEvent): void { this.listener?.(e); }
 
-  // P-ASKSAGE.1 (ADR-0055): a bounded ring of AskSage tool-loop diagnostics, parsed from the omp child's
+  // P-ASKSAGE.1 (ADR-0059): a bounded ring of AskSage tool-loop diagnostics, parsed from the omp child's
   // `[ASKSAGE_DIAG]` stderr lines. Surfaced (developer-mode only) in the Logs panel so the non-streamed
   // AskSage tool loop — and the "empty-response → gives up early" anomaly — is observable from a UI test.
   private asksageDiag: Array<Record<string, unknown>> = [];
@@ -175,7 +175,7 @@ class Backend {
         // authoring model + the attribution identity + the edited workspace. Set BEFORE spawn (env is
         // copied at exec; the child can't see later changes).
         this.applyAttributionEnv();
-        // P-ASKSAGE.1 (ADR-0055): enable AskSage tool-loop diagnostics in the omp child when developer
+        // P-ASKSAGE.1 (ADR-0059): enable AskSage tool-loop diagnostics in the omp child when developer
         // mode is on (the child inherits process.env at spawn). Off otherwise — zero overhead in normal use.
         if (loadSettings().developerMode) process.env.LUCID_ASKSAGE_DEBUG = "1"; else delete process.env.LUCID_ASKSAGE_DEBUG;
         // ADR-0033: also append the build / anti-over-refusal policy so the chat model doesn't decline
@@ -231,7 +231,7 @@ class Backend {
             const tc = params?.toolCall ?? params?.tool_call ?? {};
             const toolName = [tc.kind, tc.title, tc.name, tc.toolName, params?.tool, params?.toolName].filter(Boolean).join(" ").toLowerCase();
             const target = egressTarget(tc);
-            // P-EGRESS.1 (ADR-0058): a network-reaching tool — matched by name OR by carrying an external
+            // P-EGRESS.1 (ADR-0062): a network-reaching tool — matched by name OR by carrying an external
             // http(s) URL (omp may report the browser tool with a generic kind, so name alone can miss it).
             // Unless a standing decision already allows the target, force the per-website approval dialog —
             // EVEN in Agent mode (egress is never silently auto-approved). Fail-closed: no live UI ⇒ deny.
@@ -254,7 +254,7 @@ class Backend {
         };
         acp.onStderr = (chunk) => {
           for (const line of chunk.split("\n")) {
-            // P-ASKSAGE.1 (ADR-0055): capture AskSage call diagnostics into the ring + echo to the dev
+            // P-ASKSAGE.1 (ADR-0059): capture AskSage call diagnostics into the ring + echo to the dev
             // server console for terminal visibility. Best-effort parse — a malformed line is ignored.
             const di = line.indexOf("[ASKSAGE_DIAG]");
             if (di !== -1) {
@@ -370,7 +370,7 @@ class Backend {
     });
   }
 
-  /** P-EGRESS.1 (ADR-0058): forward an EGRESS request as the per-website approval dialog (the rich
+  /** P-EGRESS.1 (ADR-0062): forward an EGRESS request as the per-website approval dialog (the rich
    *  options + the target URL for the Cloudflare-Radar check). The user's choice is persisted to the
    *  egress store, then mapped back to omp's own allow/deny option. Fail-closed: timeout ⇒ deny. */
   private askEgress(params: any, opts: any[], target: string): Promise<any> {
@@ -445,7 +445,7 @@ class Backend {
   // only TOTAL silence for this long trips it.
   // 5 min. Native providers stream tokens every few seconds so they almost never trip this; the headroom
   // is for the NON-STREAMED AskSage gov gateway, where a single big call emits nothing for minutes and a
-  // 2-min cap false-stalled live turns ("gave up on the provider"). The auto-continue checker (ADR-0056)
+  // 2-min cap false-stalled live turns ("gave up on the provider"). The auto-continue checker (ADR-0060)
   // will eventually turn a stall into a wellness-check + resume rather than a dead end.
   private static readonly IDLE_MS = 300_000;
 

--- a/desktop/acp_backend.ts
+++ b/desktop/acp_backend.ts
@@ -128,6 +128,14 @@ class Backend {
   /** Recent AskSage call diagnostics (most-recent last), capped. Empty unless developer mode is on. */
   asksageDiagnostics(): Array<Record<string, unknown>> { return this.asksageDiag.slice(-100); }
 
+  // Turn-lifecycle diagnostics (developer mode). Prints to the dev-server console so a hung long
+  // multi-tool turn reveals WHERE it stalls: did prompt() resolve (server finished, browser orphaned) or
+  // never resolve (omp wedge)? did complete() clobber the chat listener? did the browser stream break?
+  private turnDiag(msg: string): void {
+    if (!loadSettings().developerMode) return;
+    try { console.error(`[TURN_DIAG] ${msg}`); } catch { /* never break a turn on a log */ }
+  }
+
   private async start(): Promise<void> {
     if (this.acp) return;
     if (!this.starting) {
@@ -385,9 +393,11 @@ class Backend {
     // While a permission is awaiting the user (Ask mode), pause the idle/stall clock — a human
     // deciding is not a stalled turn (askUser has its own fail-closed timeout).
     const arm = () => { if (idle) clearTimeout(idle); if (this.pendingPerms > 0) return; idle = setTimeout(() => { stalled = true; onStall(new Error("the model did not respond for 2 minutes — the provider may be rate-limited (check your hourly budget) or the turn stalled. Try again.")); }, Backend.IDLE_MS); };
-    const sink = (e: ChatEvent) => { arm(); if (e.type === "token") assistant += e.text; onEvent(e); };
+    let enqueueErr = 0; // counts browser-stream write failures (orphaned/closed client stream)
+    const sink = (e: ChatEvent) => { arm(); if (e.type === "token") assistant += e.text; try { onEvent(e); } catch { enqueueErr++; } };
     this.listener = sink;
     this.askActive = true; // permission requests in THIS turn may be forwarded to the UI (Ask mode)
+    this.turnDiag(`prompt.start session=${this.sessionId}`);
     try {
       await this.ensureSession();
       // Assemble the user-turn preamble (never the frozen prefix; invariant #5/#6). Issue #54:
@@ -408,7 +418,9 @@ class Backend {
         this.acp!.request("session/prompt", { sessionId: this.sessionId, prompt: [{ type: "text", text: body }] }),
         stall,
       ]);
+      this.turnDiag(`prompt.resolved session=${this.sessionId} chars=${assistant.length} enqueueErr=${enqueueErr} listenerIntact=${this.listener === sink}`);
     } catch (e) {
+      this.turnDiag(`prompt.${stalled ? "stalled" : "error"} session=${this.sessionId} chars=${assistant.length} enqueueErr=${enqueueErr} listenerIntact=${this.listener === sink} msg=${String((e as any)?.message ?? e).slice(0, 80)}`);
       onEvent({ type: "token", text: `\n[${stalled ? "stalled" : "agent unavailable"}: ${String((e as any)?.message ?? e)}]` });
     } finally {
       if (idle) clearTimeout(idle);
@@ -620,6 +632,7 @@ class Backend {
       let text = "";
       let idle: ReturnType<typeof setTimeout> | undefined;
       let onStall: (e: Error) => void = () => {};
+      let myListener: ((e: ChatEvent) => void) | null = null;
       try {
         const s: any = await this.acp!.request("session/new", { cwd: currentWorkspace(), mcpServers: mcpServersForAcp() });
         sid = s?.sessionId ?? s?.id ?? null;
@@ -630,7 +643,8 @@ class Backend {
         if (opts.model) await this.acp!.request("session/set_config_option", { sessionId: sid, configId: "model", value: opts.model }).catch(() => {});
         const IDLE = opts.idleMs ?? 60_000;
         const arm = () => { if (idle) clearTimeout(idle); idle = setTimeout(() => onStall(new Error("stall")), IDLE); };
-        this.listener = (e) => { arm(); if (e.type === "token") text += e.text; };
+        myListener = (e: ChatEvent) => { arm(); if (e.type === "token") text += e.text; };
+        this.listener = myListener;
         arm();
         const stall = new Promise<never>((_, reject) => { onStall = reject; });
         await Promise.race([
@@ -641,7 +655,12 @@ class Backend {
       } catch { return text; }
       finally {
         if (idle) clearTimeout(idle);
-        this.listener = prev;
+        // Only restore if WE are still the active listener. If a chat turn started while this throwaway
+        // completion ran (long ones overlap), `this.listener` is now that turn's sink — restoring `prev`
+        // here would orphan it (drop its events → blank chat until reload). Leave it alone in that case.
+        const clobber = myListener !== null && this.listener !== myListener;
+        this.turnDiag(`complete.end clobberAvoided=${clobber} chars=${text.length}`);
+        if (!clobber) this.listener = prev;
         if (sid) this.acp!.request("session/close", { sessionId: sid }).catch(() => {});
       }
     });

--- a/desktop/acp_backend.ts
+++ b/desktop/acp_backend.ts
@@ -29,14 +29,14 @@ import { type EgressChoice, egressDecision, recordEgress } from "./egress_policy
 // requests permission for one of these, the desktop shows the per-website approval dialog instead of
 // silently auto-approving in Agent mode.
 const EGRESS_TOOLS = new Set(["browser", "web_search", "web", "fetch", "navigate"]);
-// The dialog's choices. Each maps to an EgressChoice the store folds in; all the "Yes" variants approve
-// the call to omp, "deny" blocks it.
+// The dialog's choices — clear and non-overlapping. ("allow once" and an "ask every time" pin had the
+// same outcome — both ask again next time — so the pin was dropped.) Each maps to an EgressChoice the
+// store folds in; the "allow" variants approve the call to omp, "deny" blocks it.
 const EGRESS_OPTIONS: { optionId: string; name: string; kind?: string }[] = [
-  { optionId: "egress:allow-once", name: "Yes - allow this, just this once", kind: "allow" },
-  { optionId: "egress:allow-site", name: "Yes - and don't ask again for this website", kind: "allow" },
-  { optionId: "egress:ask-site", name: "Yes - but ask me every time for this website", kind: "allow" },
-  { optionId: "egress:danger", name: "Yes - danger is my middle name (allow all sites)", kind: "allow" },
-  { optionId: "egress:deny", name: "No - block this", kind: "reject" },
+  { optionId: "egress:allow-once", name: "Allow once", kind: "allow" },
+  { optionId: "egress:allow-site", name: "Always allow this site", kind: "allow" },
+  { optionId: "egress:danger", name: "Always allow every site", kind: "danger" },
+  { optionId: "egress:deny", name: "Block", kind: "reject" },
 ];
 /** Pull the URL (browser) or query (web_search) an egress tool call targets, from its rawInput/title. */
 function egressTarget(tc: any): string | null {

--- a/desktop/acp_backend.ts
+++ b/desktop/acp_backend.ts
@@ -23,6 +23,29 @@ import { recommendCheckerModel, resolveCheckerModel, type ModelOption } from "./
 import { parseGoalVerdict } from "./goal_verdict.ts";
 import { appendGoalIteration, finishGoalMemory, type GoalMemory, resumeGoalMemory, startGoalMemory } from "./goal_memory.ts";
 import { type Automation, listAutomations, nextDueAutomation, updateAutomation } from "./automations.ts";
+import { type EgressChoice, egressDecision, recordEgress } from "./egress_policy.ts";
+
+// P-EGRESS.1 (ADR-0058): the network-reaching tools omp is told to PROMPT for (acp_config.yml). When omp
+// requests permission for one of these, the desktop shows the per-website approval dialog instead of
+// silently auto-approving in Agent mode.
+const EGRESS_TOOLS = new Set(["browser", "web_search", "web", "fetch", "navigate"]);
+// The dialog's choices. Each maps to an EgressChoice the store folds in; all the "Yes" variants approve
+// the call to omp, "deny" blocks it.
+const EGRESS_OPTIONS: { optionId: string; name: string; kind?: string }[] = [
+  { optionId: "egress:allow-once", name: "Yes - allow this, just this once", kind: "allow" },
+  { optionId: "egress:allow-site", name: "Yes - and don't ask again for this website", kind: "allow" },
+  { optionId: "egress:ask-site", name: "Yes - but ask me every time for this website", kind: "allow" },
+  { optionId: "egress:danger", name: "Yes - danger is my middle name (allow all sites)", kind: "allow" },
+  { optionId: "egress:deny", name: "No - block this", kind: "reject" },
+];
+/** Pull the URL (browser) or query (web_search) an egress tool call targets, from its rawInput/title. */
+function egressTarget(tc: any): string | null {
+  const ri = tc?.rawInput ?? tc?.input ?? {};
+  for (const k of ["url", "href", "uri", "link"]) if (typeof ri[k] === "string" && ri[k].trim()) return ri[k].trim();
+  if (typeof ri.query === "string" && ri.query.trim()) return ri.query.trim();
+  const m = /(https?:\/\/[^\s)]+)/i.exec(String(tc?.title ?? ""));
+  return m ? m[1]! : (String(tc?.title ?? "").trim() || null);
+}
 
 const REPO = join(import.meta.dir, "..");
 // Absolute so the gate loads from THIS repo even when omp runs in another workspace.
@@ -49,7 +72,7 @@ export type ChatEvent =
   | { type: "tool"; name: string; detail: string }
   | { type: "subagent"; id: string; agent: string; title: string; assignments: string[] }
   | { type: "block"; tool: string; reason: string; severity: string; findings: string; id?: string; quarantined?: boolean }
-  | { type: "permission"; id: string; tool: string; detail: string; options: { optionId: string; name: string; kind?: string }[] }
+  | { type: "permission"; id: string; tool: string; detail: string; options: { optionId: string; name: string; kind?: string }[]; url?: string; egress?: boolean }
   | { type: "usage"; used: number; size: number; cost: number }
   // P-GOAL.1 (ADR-0046): /goal loop events — an iteration begins, the separate checker's verdict,
   // the loop met its condition, or it stopped (cap / no-progress).
@@ -205,6 +228,22 @@ class Backend {
         acp.onRequest = async (m, params) => {
           if (m === "session/request_permission") {
             const opts: any[] = params?.options ?? [];
+            const tc = params?.toolCall ?? params?.tool_call ?? {};
+            const toolName = [tc.kind, tc.title, tc.name, tc.toolName, params?.tool, params?.toolName].filter(Boolean).join(" ").toLowerCase();
+            const target = egressTarget(tc);
+            // P-EGRESS.1 (ADR-0058): a network-reaching tool — matched by name OR by carrying an external
+            // http(s) URL (omp may report the browser tool with a generic kind, so name alone can miss it).
+            // Unless a standing decision already allows the target, force the per-website approval dialog —
+            // EVEN in Agent mode (egress is never silently auto-approved). Fail-closed: no live UI ⇒ deny.
+            const isEgress = [...EGRESS_TOOLS].some((t) => toolName.includes(t)) || (!!target && /^https?:\/\//i.test(target));
+            if (isEgress) {
+              if (target && egressDecision(target) === "allow") {
+                const a = opts.find((o) => /allow/i.test(o.kind ?? o.optionId ?? "")) ?? opts[0];
+                return a ? { outcome: { outcome: "selected", optionId: a.optionId } } : { outcome: { outcome: "cancelled" } };
+              }
+              if (this.askActive && this.listener) return this.askEgress(params, opts, target ?? toolName);
+              return { outcome: { outcome: "cancelled" } }; // no UI to ask → block the egress
+            }
             // Ask mode (and only inside a live chat turn): hand the decision to the user.
             if (this.permissionMode === "ask" && this.askActive && this.listener) return this.askUser(params, opts);
             // Agent / Plan: auto-approve.
@@ -328,6 +367,30 @@ class Backend {
       const settle = (outcome: any) => { clearTimeout(t); this.permPending.delete(id); this.pendingPerms = Math.max(0, this.pendingPerms - 1); resolve(outcome); };
       const t = setTimeout(() => settle({ outcome: { outcome: "cancelled" } }), Backend.PERM_MS); // fail-closed
       this.permPending.set(id, (optionId) => settle(optionId ? { outcome: { outcome: "selected", optionId } } : { outcome: { outcome: "cancelled" } }));
+    });
+  }
+
+  /** P-EGRESS.1 (ADR-0058): forward an EGRESS request as the per-website approval dialog (the rich
+   *  options + the target URL for the Cloudflare-Radar check). The user's choice is persisted to the
+   *  egress store, then mapped back to omp's own allow/deny option. Fail-closed: timeout ⇒ deny. */
+  private askEgress(params: any, opts: any[], target: string): Promise<any> {
+    const id = `perm_${++this.permSeq}`;
+    const tc = params?.toolCall ?? params?.tool_call ?? {};
+    this.pendingPerms++;
+    this.emit({ type: "permission", id, tool: String(tc.kind ?? "browser"), detail: target, url: target, egress: true, options: EGRESS_OPTIONS });
+    const allowOpt = opts.find((o) => /allow/i.test(o.kind ?? o.optionId ?? "")) ?? opts[0];
+    const denyOpt = opts.find((o) => /(deny|reject|cancel|no)/i.test(o.kind ?? o.optionId ?? ""));
+    const approve = () => allowOpt ? { outcome: { outcome: "selected", optionId: allowOpt.optionId } } : { outcome: { outcome: "cancelled" } };
+    const block = () => denyOpt ? { outcome: { outcome: "selected", optionId: denyOpt.optionId } } : { outcome: { outcome: "cancelled" } };
+    return new Promise((resolve) => {
+      const settle = (outcome: any) => { clearTimeout(t); this.permPending.delete(id); this.pendingPerms = Math.max(0, this.pendingPerms - 1); resolve(outcome); };
+      const t = setTimeout(() => settle(block()), Backend.PERM_MS); // fail-closed → block egress
+      this.permPending.set(id, (optionId) => {
+        const choice = String(optionId ?? "").replace(/^egress:/, "") as EgressChoice;
+        if (!optionId || choice === "deny") { settle(block()); return; }
+        try { recordEgress(target, choice); } catch { /* best-effort persistence */ }
+        settle(approve());
+      });
     });
   }
   /** Resolve a parked permission from the UI. `optionId` null/empty ⇒ deny (cancelled). */

--- a/desktop/acp_backend.ts
+++ b/desktop/acp_backend.ts
@@ -17,7 +17,7 @@ import { learnFromTurn, recallPreamble } from "./personal.ts";
 import { buildUserTurnPreamble } from "./preamble.ts";
 import { recordTurns } from "./turns_log.ts";
 import { recordBlock } from "./security_log.ts";
-import { asksageOnly, attribution, checkerModel, lastModel, mcpServersForAcp, setCheckerModel, setLastModel } from "./settings_store.ts";
+import { asksageOnly, attribution, checkerModel, lastModel, load as loadSettings, mcpServersForAcp, setCheckerModel, setLastModel } from "./settings_store.ts";
 import { managedConfig } from "./managed_config.ts";
 import { recommendCheckerModel, resolveCheckerModel, type ModelOption } from "./checker_model.ts";
 import { parseGoalVerdict } from "./goal_verdict.ts";
@@ -121,6 +121,13 @@ class Backend {
 
   private emit(e: ChatEvent): void { this.listener?.(e); }
 
+  // P-ASKSAGE.1 (ADR-0055): a bounded ring of AskSage tool-loop diagnostics, parsed from the omp child's
+  // `[ASKSAGE_DIAG]` stderr lines. Surfaced (developer-mode only) in the Logs panel so the non-streamed
+  // AskSage tool loop — and the "empty-response → gives up early" anomaly — is observable from a UI test.
+  private asksageDiag: Array<Record<string, unknown>> = [];
+  /** Recent AskSage call diagnostics (most-recent last), capped. Empty unless developer mode is on. */
+  asksageDiagnostics(): Array<Record<string, unknown>> { return this.asksageDiag.slice(-100); }
+
   private async start(): Promise<void> {
     if (this.acp) return;
     if (!this.starting) {
@@ -137,6 +144,9 @@ class Backend {
         // authoring model + the attribution identity + the edited workspace. Set BEFORE spawn (env is
         // copied at exec; the child can't see later changes).
         this.applyAttributionEnv();
+        // P-ASKSAGE.1 (ADR-0055): enable AskSage tool-loop diagnostics in the omp child when developer
+        // mode is on (the child inherits process.env at spawn). Off otherwise — zero overhead in normal use.
+        if (loadSettings().developerMode) process.env.LUCID_ASKSAGE_DEBUG = "1"; else delete process.env.LUCID_ASKSAGE_DEBUG;
         // ADR-0033: also append the build / anti-over-refusal policy so the chat model doesn't decline
         // a buildable task (e.g. "make a game/graphics/music in one HTML file") by mis-reading its scope.
         const appendedPolicy = `${DELEGATION_POLICY}\n\n${BUILD_POLICY}`;
@@ -197,6 +207,21 @@ class Backend {
         };
         acp.onStderr = (chunk) => {
           for (const line of chunk.split("\n")) {
+            // P-ASKSAGE.1 (ADR-0055): capture AskSage call diagnostics into the ring + echo to the dev
+            // server console for terminal visibility. Best-effort parse — a malformed line is ignored.
+            const di = line.indexOf("[ASKSAGE_DIAG]");
+            if (di !== -1) {
+              const jstart = line.indexOf("{", di);
+              if (jstart !== -1) {
+                try {
+                  const rec = JSON.parse(line.slice(jstart));
+                  this.asksageDiag.push({ at: Date.now(), ...rec });
+                  if (this.asksageDiag.length > 200) this.asksageDiag.shift();
+                  console.error(line.slice(di)); // surface in the dev server / Electron log
+                } catch { /* not valid JSON — ignore */ }
+              }
+              continue;
+            }
             const m = /\[BLOCKED tool_call:(\w+)\].*?severity=(\w+).*?findings=([^\s]+)/.exec(line);
             if (m) {
               // The authoritative security-gate block. Persist it GUI-side (the gate's own omp

--- a/desktop/dev.ts
+++ b/desktop/dev.ts
@@ -236,7 +236,7 @@ const server = Bun.serve({
           const next = !!b.enabled;
           const changed = loadSettings().developerMode !== next;
           const data = setDeveloperMode(next);
-          // P-ASKSAGE.1 (ADR-0055): the omp child reads LUCID_ASKSAGE_DEBUG only at spawn. Respawn on a
+          // P-ASKSAGE.1 (ADR-0059): the omp child reads LUCID_ASKSAGE_DEBUG only at spawn. Respawn on a
           // real change so toggling developer mode takes effect immediately (no app restart) — the fresh
           // omp picks up / drops the debug env. Same pattern as an API-key change (backend.restart()).
           if (changed) backend.restart();

--- a/desktop/dev.ts
+++ b/desktop/dev.ts
@@ -517,9 +517,13 @@ const server = Bun.serve({
       if (p === "/api/chat" && req.method === "POST") {
         const { text } = await readBody<{ text?: unknown }>(req);
         const enc = new TextEncoder();
+        let writeFailed = false;
         const stream = new ReadableStream({
           async start(controller) {
-            await backend.prompt(String(text ?? ""), (e) => { try { controller.enqueue(enc.encode(JSON.stringify(e) + "\n")); } catch { /* stream closed */ } });
+            await backend.prompt(String(text ?? ""), (e) => {
+              try { controller.enqueue(enc.encode(JSON.stringify(e) + "\n")); }
+              catch { if (!writeFailed && loadSettings().developerMode) { writeFailed = true; console.error("[TURN_DIAG] chat stream write failed (browser disconnected) — server turn continues"); } }
+            });
             try { controller.close(); } catch { /* already closed */ }
           },
         });

--- a/desktop/dev.ts
+++ b/desktop/dev.ts
@@ -232,8 +232,8 @@ const server = Bun.serve({
       // (returns null when off); POST {enabled} flips the mode. Read-only, metadata-only.
       if (p === "/api/dev") {
         if (req.method === "POST") { const b = await readBody<{ enabled?: unknown }>(req); return json({ ok: true, data: setDeveloperMode(!!b.enabled) }); }
-        if (!loadSettings().developerMode) return json({ ok: true, data: { enabled: false, snapshot: null, blocks: { quarantined: [], approved: [], total: 0 }, turns: [] } });
-        return json({ ok: true, data: { enabled: true, snapshot: await devSnapshot(), blocks: liveBlocks(), turns: recentTurns() } });
+        if (!loadSettings().developerMode) return json({ ok: true, data: { enabled: false, snapshot: null, blocks: { quarantined: [], approved: [], total: 0 }, turns: [], asksage: [] } });
+        return json({ ok: true, data: { enabled: true, snapshot: await devSnapshot(), blocks: liveBlocks(), turns: recentTurns(), asksage: backend.asksageDiagnostics() } });
       }
       // Light, fast re-read of the provider rate-limit budget (omp's agent.db).
       // Used by the front-end's manual refresh + 5-minute auto-poll.

--- a/desktop/dev.ts
+++ b/desktop/dev.ts
@@ -231,7 +231,17 @@ const server = Bun.serve({
       // ADR-0009 Phase D: developer-mode logging view. GET is gated server-side on developerMode
       // (returns null when off); POST {enabled} flips the mode. Read-only, metadata-only.
       if (p === "/api/dev") {
-        if (req.method === "POST") { const b = await readBody<{ enabled?: unknown }>(req); return json({ ok: true, data: setDeveloperMode(!!b.enabled) }); }
+        if (req.method === "POST") {
+          const b = await readBody<{ enabled?: unknown }>(req);
+          const next = !!b.enabled;
+          const changed = loadSettings().developerMode !== next;
+          const data = setDeveloperMode(next);
+          // P-ASKSAGE.1 (ADR-0055): the omp child reads LUCID_ASKSAGE_DEBUG only at spawn. Respawn on a
+          // real change so toggling developer mode takes effect immediately (no app restart) — the fresh
+          // omp picks up / drops the debug env. Same pattern as an API-key change (backend.restart()).
+          if (changed) backend.restart();
+          return json({ ok: true, data });
+        }
         if (!loadSettings().developerMode) return json({ ok: true, data: { enabled: false, snapshot: null, blocks: { quarantined: [], approved: [], total: 0 }, turns: [], asksage: [] } });
         return json({ ok: true, data: { enabled: true, snapshot: await devSnapshot(), blocks: liveBlocks(), turns: recentTurns(), asksage: backend.asksageDiagnostics() } });
       }

--- a/desktop/egress_policy.test.ts
+++ b/desktop/egress_policy.test.ts
@@ -1,4 +1,4 @@
-// desktop/egress_policy.test.ts — pure egress decision + choice-folding (P-EGRESS.1, ADR-0058).
+// desktop/egress_policy.test.ts — pure egress decision + choice-folding (P-EGRESS.1, ADR-0062).
 
 import { describe, expect, test } from "bun:test";
 import { applyEgressChoice, egressVerdict, extractHost, type EgressStore } from "./egress_policy.ts";

--- a/desktop/egress_policy.test.ts
+++ b/desktop/egress_policy.test.ts
@@ -1,0 +1,66 @@
+// desktop/egress_policy.test.ts — pure egress decision + choice-folding (P-EGRESS.1, ADR-0058).
+
+import { describe, expect, test } from "bun:test";
+import { applyEgressChoice, egressVerdict, extractHost, type EgressStore } from "./egress_policy.ts";
+
+describe("extractHost", () => {
+  test("pulls the lowercased hostname from a URL", () => {
+    expect(extractHost("https://Example.com/path?q=1")).toBe("example.com");
+    expect(extractHost("http://sub.host.io:8080/x")).toBe("sub.host.io");
+  });
+  test("tolerates a scheme-less / bare host", () => {
+    expect(extractHost("example.com/a")).toBe("example.com");
+    expect(extractHost("EXAMPLE.COM")).toBe("example.com");
+  });
+  test("returns null for junk", () => {
+    expect(extractHost("")).toBeNull();
+    expect(extractHost("   ")).toBeNull();
+  });
+});
+
+describe("egressVerdict (fail-closed to prompt)", () => {
+  test("unknown host prompts", () => {
+    expect(egressVerdict({}, "https://evil.test/x")).toBe("prompt");
+  });
+  test("an allow-listed host is auto-allowed", () => {
+    const s: EgressStore = { allowHosts: ["docs.python.org"] };
+    expect(egressVerdict(s, "https://docs.python.org/3/library")).toBe("allow");
+    expect(egressVerdict(s, "https://other.com")).toBe("prompt");
+  });
+  test("danger mode allows everything...", () => {
+    expect(egressVerdict({ dangerMode: true }, "https://anything.test")).toBe("allow");
+  });
+  test("...except hosts pinned to always-ask (override danger)", () => {
+    const s: EgressStore = { dangerMode: true, alwaysAskHosts: ["bank.example"] };
+    expect(egressVerdict(s, "https://bank.example/login")).toBe("prompt");
+    expect(egressVerdict(s, "https://elsewhere.test")).toBe("allow");
+  });
+  test("an unparseable URL prompts (can't reason about an unnamed site)", () => {
+    expect(egressVerdict({ dangerMode: true }, "")).toBe("prompt");
+  });
+});
+
+describe("applyEgressChoice (pure, never mutates)", () => {
+  test("allow-site adds the host and clears any ask-pin", () => {
+    const s = applyEgressChoice({ alwaysAskHosts: ["a.com"] }, "https://a.com/x", "allow-site");
+    expect(s.allowHosts).toContain("a.com");
+    expect(s.alwaysAskHosts).not.toContain("a.com");
+  });
+  test("ask-site pins the host to always-prompt and clears any allow", () => {
+    const s = applyEgressChoice({ allowHosts: ["a.com"] }, "https://a.com/x", "ask-site");
+    expect(s.alwaysAskHosts).toContain("a.com");
+    expect(s.allowHosts).not.toContain("a.com");
+    expect(egressVerdict(s, "https://a.com")).toBe("prompt");
+  });
+  test("danger flips global allow-all", () => {
+    expect(applyEgressChoice({}, "https://a.com", "danger").dangerMode).toBe(true);
+  });
+  test("allow-once and deny persist nothing", () => {
+    expect(applyEgressChoice({}, "https://a.com", "allow-once")).toEqual({ dangerMode: false, allowHosts: [], alwaysAskHosts: [] });
+    expect(applyEgressChoice({}, "https://a.com", "deny")).toEqual({ dangerMode: false, allowHosts: [], alwaysAskHosts: [] });
+  });
+  test("a full round-trip: allow-site then the same host auto-allows", () => {
+    const s = applyEgressChoice({}, "https://grant.ed/path", "allow-site");
+    expect(egressVerdict(s, "https://grant.ed/other")).toBe("allow");
+  });
+});

--- a/desktop/egress_policy.ts
+++ b/desktop/egress_policy.ts
@@ -1,0 +1,80 @@
+// desktop/egress_policy.ts
+//
+// P-EGRESS.1 (ADR-0058): per-website approval for the agent's network-reaching tools (browser,
+// web_search). In a security/provenance product, an agent autonomously browsing arbitrary internet
+// sites is a real risk, so omp is configured to PROMPT for those tools (acp_config.yml `tools.approval`),
+// and this module decides — per the user's standing choices — whether a given URL is auto-allowed or
+// needs the approval dialog. Fail-closed: anything not explicitly allowed PROMPTS.
+//
+// The four "Yes" choices the dialog offers map to:
+//   allow-once  → approve this call, remember nothing.
+//   allow-site  → approve + auto-allow this host from now on.
+//   ask-site    → approve, but ALWAYS ask for this host again (pins it to prompt, even under danger mode).
+//   danger      → "danger is my middle name": auto-allow ALL egress from now on (except ask-site pins).
+//   deny        → block this call (no persistence).
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const FILE = join(homedir(), ".omp", "lucid-egress.json");
+
+export type EgressChoice = "allow-once" | "allow-site" | "ask-site" | "danger" | "deny";
+export type EgressVerdict = "allow" | "prompt";
+
+export interface EgressStore {
+  dangerMode?: boolean;       // global allow-all egress
+  allowHosts?: string[];      // hosts auto-allowed
+  alwaysAskHosts?: string[];  // hosts that ALWAYS prompt (override danger mode)
+}
+
+/** Lowercase host of a URL, or null if it isn't a parseable absolute URL. Used as the per-site key. */
+export function extractHost(url: string): string | null {
+  if (!url) return null;
+  try { return new URL(url).hostname.toLowerCase() || null; }
+  catch {
+    // tolerate a bare host or scheme-less URL ("example.com/path")
+    const m = /^(?:[a-z]+:\/\/)?([^/:\s]+)/i.exec(url.trim());
+    return m ? m[1]!.toLowerCase() : null;
+  }
+}
+
+/** Pure decision: does this URL auto-allow, or must we PROMPT? Fail-closed to prompt on anything unknown
+ *  (including an unparseable URL — we can't reason about a site we can't name). `ask-site` pins win over
+ *  danger mode, honoring an explicit "always ask me for this one". */
+export function egressVerdict(store: EgressStore, url: string): EgressVerdict {
+  const host = extractHost(url);
+  if (!host) return "prompt";
+  if ((store.alwaysAskHosts ?? []).includes(host)) return "prompt";
+  if ((store.allowHosts ?? []).includes(host)) return "allow";
+  if (store.dangerMode) return "allow";
+  return "prompt";
+}
+
+/** Pure update: fold a user's choice for `url` into the store. Returns a NEW store (never mutates). */
+export function applyEgressChoice(store: EgressStore, url: string, choice: EgressChoice): EgressStore {
+  const host = extractHost(url);
+  const allow = new Set(store.allowHosts ?? []);
+  const ask = new Set(store.alwaysAskHosts ?? []);
+  let danger = store.dangerMode ?? false;
+  switch (choice) {
+    case "allow-site": if (host) { allow.add(host); ask.delete(host); } break;
+    case "ask-site": if (host) { ask.add(host); allow.delete(host); } break; // pin to always-prompt
+    case "danger": danger = true; break;
+    case "allow-once": case "deny": break; // no persistence
+  }
+  return { dangerMode: danger, allowHosts: [...allow], alwaysAskHosts: [...ask] };
+}
+
+// ── thin persistence (machine-level, like settings) ─────────────────────────────────────────────────
+export function loadEgress(): EgressStore {
+  try { return existsSync(FILE) ? JSON.parse(readFileSync(FILE, "utf8")) : {}; } catch { return {}; }
+}
+function saveEgress(s: EgressStore): void {
+  try { writeFileSync(FILE, JSON.stringify(s, null, 2), "utf8"); } catch { /* best-effort; never break a turn */ }
+}
+
+/** Read-side: is this URL allowed without asking? */
+export function egressDecision(url: string): EgressVerdict { return egressVerdict(loadEgress(), url); }
+/** Write-side: persist the user's choice (allow-once/deny are no-ops on disk). */
+export function recordEgress(url: string, choice: EgressChoice): void { saveEgress(applyEgressChoice(loadEgress(), url, choice)); }

--- a/desktop/egress_policy.ts
+++ b/desktop/egress_policy.ts
@@ -1,6 +1,6 @@
 // desktop/egress_policy.ts
 //
-// P-EGRESS.1 (ADR-0058): per-website approval for the agent's network-reaching tools (browser,
+// P-EGRESS.1 (ADR-0062): per-website approval for the agent's network-reaching tools (browser,
 // web_search). In a security/provenance product, an agent autonomously browsing arbitrary internet
 // sites is a real risk, so omp is configured to PROMPT for those tools (acp_config.yml `tools.approval`),
 // and this module decides — per the user's standing choices — whether a given URL is auto-allowed or

--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -1713,10 +1713,11 @@ function devHtml(d: import("./bridge.ts").DevView | null): string {
     text: r.textLen ?? "",
     calls: Array.isArray(r.toolCalls) ? (r.toolCalls as string[]).join(", ") : "",
     stop: String(r.stopReason ?? ""),
+    finish: String(r.finish ?? ""),
     flag: r.anomaly ? `⚠ ${r.anomaly}` : r.ok === false ? `✕ ${String(r.error ?? "error").slice(0, 60)}` : "ok",
   }));
   h += accordion("dev.asksage", "AskSage tool calls", "non-streamed loop · developer diagnostics",
-    table([{ key: "when", label: "when", mono: true }, { key: "route", label: "route" }, { key: "model", label: "model", mono: true }, { key: "via", label: "parsed via", mono: true }, { key: "text", label: "txt", mono: true }, { key: "calls", label: "tool calls" }, { key: "stop", label: "stop", mono: true }, { key: "flag", label: "flag", pill: true }], askRows as unknown as Record<string, unknown>[]),
+    table([{ key: "when", label: "when", mono: true }, { key: "route", label: "route" }, { key: "model", label: "model", mono: true }, { key: "via", label: "parsed via", mono: true }, { key: "text", label: "txt", mono: true }, { key: "calls", label: "tool calls" }, { key: "stop", label: "loop", mono: true }, { key: "finish", label: "raw", mono: true }, { key: "flag", label: "flag", pill: true }], askRows as unknown as Record<string, unknown>[]),
     OPEN.has("dev.asksage") || askAnoms > 0, askAnoms ? `${ask.length} · ${askAnoms}⚠` : String(ask.length));
   h += accordion("dev.telemetry", "Telemetry stream", "recent · metadata only",
     table([{ key: "event", label: "event" }, { key: "run_id", label: "run", mono: true }, { key: "session_id", label: "session", mono: true }, { key: "created_at", label: "at", mono: true }], tel),

--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -1679,9 +1679,18 @@ function securityHtml(d: SecuritySnapshot | null): string {
 }
 
 // ── ADR-0009 Phase D: developer Logs view (read-only; metadata only) ──────────────
+// Format an ISO/epoch timestamp as US Eastern time (auto EST/EDT) — "Jun 24, 3:45 PM EDT".
+function estTime(ts: string | number | undefined | null): string {
+  if (ts === undefined || ts === null || ts === "") return "";
+  const d = new Date(ts);
+  if (isNaN(d.getTime())) return "";
+  try {
+    return d.toLocaleString("en-US", { timeZone: "America/New_York", month: "short", day: "numeric", hour: "numeric", minute: "2-digit", hour12: true, timeZoneName: "short" });
+  } catch { return d.toISOString(); }
+}
 function devHtml(d: import("./bridge.ts").DevView | null): string {
   let h = `<div class="sec-intro"><div class="sec-intro-h"><span class="sec-pulse">${icon("logs", 17)}</span><b>Developer logs</b></div>
-    <div class="sec-intro-d">Read-only telemetry, run lineage, transcripts, and audit trails from this machine - sanitized, no raw prompt or file content (the raw is referenced by sha only).</div></div>`;
+    <div class="sec-intro-d">Read-only telemetry, run lineage, transcripts, and audit trails from this machine - sanitized, no raw prompt or file content (the raw is referenced by sha only). Newest first; times in US Eastern.</div></div>`;
   if (!d || !d.enabled) { h += `<div class="empty">Developer mode is off. Turn it on in <b>Settings → Developer mode</b> to see the telemetry stream, run lineage, transcripts, and the audit trail.</div>`; return h; }
   const tel = d.snapshot?.telemetry ?? [], runs = d.snapshot?.runs ?? [], exp = d.snapshot?.exports ?? [], blk = d.blocks?.quarantined ?? [], turns = d.turns ?? [];
   const ask = d.asksage ?? [];
@@ -1697,6 +1706,7 @@ function devHtml(d: import("./bridge.ts").DevView | null): string {
   // P-ASKSAGE.1 (ADR-0055): AskSage tool-loop diagnostics. One row per non-streamed call. An `anomaly`
   // (empty-response / truncated) or an error is the smoking gun for the loop "giving up too soon".
   const askRows = ask.slice().reverse().map((r) => ({
+    when: estTime(r.at as number),
     route: String(r.route ?? ""),
     model: String(r.model ?? "").replace(/^.*\//, ""),
     via: String(r.via ?? (r.ok === false ? "-" : "")),
@@ -1706,14 +1716,15 @@ function devHtml(d: import("./bridge.ts").DevView | null): string {
     flag: r.anomaly ? `⚠ ${r.anomaly}` : r.ok === false ? `✕ ${String(r.error ?? "error").slice(0, 60)}` : "ok",
   }));
   h += accordion("dev.asksage", "AskSage tool calls", "non-streamed loop · developer diagnostics",
-    table([{ key: "route", label: "route" }, { key: "model", label: "model", mono: true }, { key: "via", label: "parsed via", mono: true }, { key: "text", label: "txt", mono: true }, { key: "calls", label: "tool calls" }, { key: "stop", label: "stop", mono: true }, { key: "flag", label: "flag", pill: true }], askRows as unknown as Record<string, unknown>[]),
+    table([{ key: "when", label: "when", mono: true }, { key: "route", label: "route" }, { key: "model", label: "model", mono: true }, { key: "via", label: "parsed via", mono: true }, { key: "text", label: "txt", mono: true }, { key: "calls", label: "tool calls" }, { key: "stop", label: "stop", mono: true }, { key: "flag", label: "flag", pill: true }], askRows as unknown as Record<string, unknown>[]),
     OPEN.has("dev.asksage") || askAnoms > 0, askAnoms ? `${ask.length} · ${askAnoms}⚠` : String(ask.length));
   h += accordion("dev.telemetry", "Telemetry stream", "recent · metadata only",
     table([{ key: "event", label: "event" }, { key: "run_id", label: "run", mono: true }, { key: "session_id", label: "session", mono: true }, { key: "created_at", label: "at", mono: true }], tel),
     true, String(tel.length));
-  const turnRows = turns.map((t) => ({ seq: t.seq, role: t.role, trust: t.trust, sanitized: t.sanitized, sha: String(t.rawSha256).slice(0, 12) }));
-  h += accordion("dev.turns", "Turn transcripts", "sanitized · raw by sha",
-    table([{ key: "seq", label: "#", mono: true }, { key: "role", label: "role", pill: true }, { key: "trust", label: "trust", mono: true }, { key: "sanitized", label: "text" }, { key: "sha", label: "raw sha", mono: true }], turnRows as unknown as Record<string, unknown>[]),
+  // Newest first (reverse the append-ordered log) so the latest turn is at the top, with an Eastern-time stamp.
+  const turnRows = turns.slice().reverse().map((t) => ({ when: estTime(t.at), seq: t.seq, role: t.role, trust: t.trust, sanitized: t.sanitized, sha: String(t.rawSha256).slice(0, 12) }));
+  h += accordion("dev.turns", "Turn transcripts", "newest first · sanitized · raw by sha",
+    table([{ key: "when", label: "when", mono: true }, { key: "seq", label: "#", mono: true }, { key: "role", label: "role", pill: true }, { key: "trust", label: "trust", mono: true }, { key: "sanitized", label: "text" }, { key: "sha", label: "raw sha", mono: true }], turnRows as unknown as Record<string, unknown>[]),
     OPEN.has("dev.turns"), String(turns.length));
   h += accordion("dev.runs", "Run lineage", "provenance",
     table([{ key: "run_id", label: "run", mono: true }, { key: "kind", label: "kind" }, { key: "mode", label: "mode" }, { key: "sandbox_profile", label: "sandbox" }, { key: "status", label: "status" }], runs),
@@ -1944,6 +1955,9 @@ async function refresh(): Promise<void> {
   try {
     const [sec, mem, led, code] = await Promise.all([bridge.security(), bridge.memory(), bridge.usage(), bridge.codeActivity()]);
     state.security = sec; state.memory = mem; state.ledger = led; state.codeActivity = code;
+    // Keep the developer Logs panel live (AskSage tool calls, transcripts) while it's the open tab —
+    // otherwise its data only refreshed on tab-switch and looked stale mid-turn.
+    if (state.developerMode && state.inspectorTab === "dev") { try { state.dev = await bridge.dev(); } catch { /* keep last */ } }
     checkBudgetWarning(mem?.budgets); // early heads-up before a provider budget runs out
     // the badge reflects the live session CONFIG model (loadConfig), not the
     // historical snapshot - so it shows what the next turn will actually use.

--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -1668,13 +1668,30 @@ function devHtml(d: import("./bridge.ts").DevView | null): string {
     <div class="sec-intro-d">Read-only telemetry, run lineage, transcripts, and audit trails from this machine - sanitized, no raw prompt or file content (the raw is referenced by sha only).</div></div>`;
   if (!d || !d.enabled) { h += `<div class="empty">Developer mode is off. Turn it on in <b>Settings → Developer mode</b> to see the telemetry stream, run lineage, transcripts, and the audit trail.</div>`; return h; }
   const tel = d.snapshot?.telemetry ?? [], runs = d.snapshot?.runs ?? [], exp = d.snapshot?.exports ?? [], blk = d.blocks?.quarantined ?? [], turns = d.turns ?? [];
+  const ask = d.asksage ?? [];
+  const askAnoms = ask.filter((r) => r.anomaly || r.ok === false).length;
   h += chips([
     { cls: "f", n: tel.length, l: "events" },
     { cls: "g", n: runs.length, l: "runs" },
     { cls: "g", n: turns.length, l: "turns" },
     { cls: "q", n: blk.length, l: "live blocks" },
     { cls: "a", n: exp.length, l: "exports" },
+    ...(ask.length ? [{ cls: askAnoms ? "q" : "g", n: ask.length, l: "AskSage calls" } as const] : []),
   ]);
+  // P-ASKSAGE.1 (ADR-0055): AskSage tool-loop diagnostics. One row per non-streamed call. An `anomaly`
+  // (empty-response / truncated) or an error is the smoking gun for the loop "giving up too soon".
+  const askRows = ask.slice().reverse().map((r) => ({
+    route: String(r.route ?? ""),
+    model: String(r.model ?? "").replace(/^.*\//, ""),
+    via: String(r.via ?? (r.ok === false ? "-" : "")),
+    text: r.textLen ?? "",
+    calls: Array.isArray(r.toolCalls) ? (r.toolCalls as string[]).join(", ") : "",
+    stop: String(r.stopReason ?? ""),
+    flag: r.anomaly ? `⚠ ${r.anomaly}` : r.ok === false ? `✕ ${String(r.error ?? "error").slice(0, 60)}` : "ok",
+  }));
+  h += accordion("dev.asksage", "AskSage tool calls", "non-streamed loop · developer diagnostics",
+    table([{ key: "route", label: "route" }, { key: "model", label: "model", mono: true }, { key: "via", label: "parsed via", mono: true }, { key: "text", label: "txt", mono: true }, { key: "calls", label: "tool calls" }, { key: "stop", label: "stop", mono: true }, { key: "flag", label: "flag", pill: true }], askRows as unknown as Record<string, unknown>[]),
+    OPEN.has("dev.asksage") || askAnoms > 0, askAnoms ? `${ask.length} · ${askAnoms}⚠` : String(ask.length));
   h += accordion("dev.telemetry", "Telemetry stream", "recent · metadata only",
     table([{ key: "event", label: "event" }, { key: "run_id", label: "run", mono: true }, { key: "session_id", label: "session", mono: true }, { key: "created_at", label: "at", mono: true }], tel),
     true, String(tel.length));

--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -559,7 +559,7 @@ const isAllowOpt = (kind?: string, optionId?: string) => /allow|approve|grant|ac
 function createPermissionCard(e: Extract<ChatEvent, { type: "permission" }>): { el: HTMLElement; finalize: () => void } {
   let win: HTMLElement;
   if (e.egress) {
-    // P-EGRESS.1 (ADR-0058): the agent wants to reach the internet. Docked above the composer. Subdued
+    // P-EGRESS.1 (ADR-0062): the agent wants to reach the internet. Docked above the composer. Subdued
     // styling that matches the app; the target URL with a copy button + a one-click Cloudflare-Radar check,
     // then the per-website choices (kind: allow → neutral, danger → amber, reject → block).
     const url = e.url ?? e.detail ?? "";
@@ -1177,7 +1177,7 @@ function secCompression(hr: import("./bridge.ts").HeadroomStatus | null): string
     : `<div class="set-note">${icon("info", 12)} Optional: install <b>headroom</b> to compress context on-device (60–95% fewer tokens). Run <code>${esc(hr?.installHint ?? "pip install headroom-ai[proxy]")}</code>, then this toggle appears.</div>`;
   return setCard("compression", "Token compression", "on-device · opt-in", body, true);
 }
-// ADR-0009 Phase D + P-ASKSAGE.1 (ADR-0055): Developer mode toggle. Reveals the read-only Logs rail
+// ADR-0009 Phase D + P-ASKSAGE.1 (ADR-0059): Developer mode toggle. Reveals the read-only Logs rail
 // panel (telemetry, lineage, transcripts, gate-block audit) AND enables AskSage tool-call diagnostics.
 // Uses the existing #devModeToggle handler, which now respawns omp so the diagnostics apply immediately.
 function secDeveloper(): string {
@@ -1256,7 +1256,7 @@ function hydrateSettings(): void {
   void bridge.auth().then((a) => { fillSec("providers", secProviders(a)); fillSec("others", secOthers(a)); });
   fillSec("sovereignty", secSovereignty()); // P-IDE.1c: only renders a card when China-origin models exist
   void bridge.headroom().then((h) => fillSec("compression", secCompression(h)));
-  fillSec("developer", secDeveloper()); // ADR-0055: render from state.developerMode (loaded by loadDev)
+  fillSec("developer", secDeveloper()); // ADR-0059: render from state.developerMode (loaded by loadDev)
   void hydratePersonal();
   hydrateMcp();
   void bridge.asksage().then(async (a) => {
@@ -1743,7 +1743,7 @@ function devHtml(d: import("./bridge.ts").DevView | null): string {
     { cls: "a", n: exp.length, l: "exports" },
     ...(ask.length ? [{ cls: askAnoms ? "q" : "g", n: ask.length, l: "AskSage calls" } as const] : []),
   ]);
-  // P-ASKSAGE.1 (ADR-0055): AskSage tool-loop diagnostics. One row per non-streamed call. An `anomaly`
+  // P-ASKSAGE.1 (ADR-0059): AskSage tool-loop diagnostics. One row per non-streamed call. An `anomaly`
   // (empty-response / truncated) or an error is the smoking gun for the loop "giving up too soon".
   const askRows = ask.slice().reverse().map((r) => ({
     when: estTime(r.at as number),

--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -1130,8 +1130,17 @@ function secCompression(hr: import("./bridge.ts").HeadroomStatus | null): string
         <span><b>Compress context with headroom</b> - fewer tokens before they reach the model. ${hr.running ? `<span class="abadge ok">running · :${hr.port}</span>` : ""}</span></label>
       <div class="set-note">${icon("info", 12)} Runs entirely on your machine (${esc(hr.version ?? "installed")}). Request-routing + a gov-deployment security review are next - see ADR-0008.</div>`
     : `<div class="set-note">${icon("info", 12)} Optional: install <b>headroom</b> to compress context on-device (60–95% fewer tokens). Run <code>${esc(hr?.installHint ?? "pip install headroom-ai[proxy]")}</code>, then this toggle appears.</div>`;
-  // ADR-0009 Phase D: Developer mode toggle (reveals the read-only Logs rail panel).
   return setCard("compression", "Token compression", "on-device · opt-in", body, true);
+}
+// ADR-0009 Phase D + P-ASKSAGE.1 (ADR-0055): Developer mode toggle. Reveals the read-only Logs rail
+// panel (telemetry, lineage, transcripts, gate-block audit) AND enables AskSage tool-call diagnostics.
+// Uses the existing #devModeToggle handler, which now respawns omp so the diagnostics apply immediately.
+function secDeveloper(): string {
+  const on = state.developerMode;
+  const body = `<label class="set-toggle"><input type="checkbox" id="devModeToggle" ${on ? "checked" : ""}/>
+      <span><b>Developer mode</b> - reveal a read-only <b>Logs</b> panel in the rail (telemetry, run lineage, transcripts, gate-block audit) and turn on <b>AskSage tool-call diagnostics</b>. Read-only, on this machine, off by default.</span></label>
+    <div class="set-note">${icon("info", 12)} Turning this on respawns the agent so diagnostics apply right away, then shows a <b>Logs</b> panel in the left rail. Open <b>Logs → AskSage tool calls</b> to watch each non-streamed AskSage call.</div>`;
+  return setCard("developer", "Developer", "logs · diagnostics", body, true);
 }
 function secOthers(auth: import("./bridge.ts").AuthStatus | null): string {
   return setCard("others", "More providers", "", (auth?.others ?? []).map(provCard).join("") || `<div class="empty">none</div>`, true);
@@ -1178,6 +1187,7 @@ function settingsShell(): string {
     setSkel("compression", "Token compression", "headroom · on-device · opt-in", true),
     setSkel("mcp", "MCP connectors", "model context protocol", true),
     setSkel("others", "More providers", "", true),
+    setSkel("developer", "Developer", "logs · diagnostics", true),
     `<div class="set-note">${icon("shield", 12)} Keys are stored on this machine and passed to omp as env vars - never sent anywhere else. OAuth uses omp's own secure credential vault.</div>`,
   ].join("");
 }
@@ -1201,6 +1211,7 @@ function hydrateSettings(): void {
   void bridge.auth().then((a) => { fillSec("providers", secProviders(a)); fillSec("others", secOthers(a)); });
   fillSec("sovereignty", secSovereignty()); // P-IDE.1c: only renders a card when China-origin models exist
   void bridge.headroom().then((h) => fillSec("compression", secCompression(h)));
+  fillSec("developer", secDeveloper()); // ADR-0055: render from state.developerMode (loaded by loadDev)
   void hydratePersonal();
   hydrateMcp();
   void bridge.asksage().then(async (a) => {

--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -747,7 +747,7 @@ async function send(): Promise<void> {
     }
     else if (e.type === "block") onBlock(e);
     else if (e.type === "usage") { tok = e.used; cost = e.cost; state.liveUsage = { used: e.used, size: e.size, cost: e.cost }; paintHud(); renderStatus(); renderMetricsRail(); }
-    else if (e.type === "done") { streamEl.innerHTML = renderMarkdown(buf); enhanceCodeBlocks(streamEl); (node as MsgNode)._md = buf; finishHud(); state.streaming = false; setSendEnabled(); }
+    else if (e.type === "done") { if (e.text && e.text.length > buf.length) buf = e.text; /* reconcile a lossy stream with the server's full reply */ streamEl.innerHTML = renderMarkdown(buf); enhanceCodeBlocks(streamEl); (node as MsgNode)._md = buf; finishHud(); state.streaming = false; setSendEnabled(); }
   };
   try { await bridge.sendPrompt(text, onEvent); }
   finally {

--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -125,7 +125,7 @@ function buildShell(): void {
         <button class="rail-btn" data-rail="security" data-tip="Security|Findings, quarantine & approvals" data-tip-icon="shield">${icon("shield", 20)}<span class="badge" id="railBadge" hidden>0</span></button>
         <button class="rail-btn" data-rail="memory" data-tip="Memory & context|Context window, prompt-cache savings, semantic memory" data-tip-icon="brain">${icon("brain", 20)}</button>
         <button class="rail-btn" data-rail="knowledge" data-tip="Knowledge graph|Your private, encrypted personalization graph - nodes, edges, drill-down" data-tip-icon="graph">${icon("graph", 20)}</button>
-        <button class="rail-btn" id="railLogs" data-rail="dev" hidden data-tip="Logs|Read-only developer logs: telemetry, run lineage, transcripts, gate-block audit, AskSage tool-call diagnostics" data-tip-icon="layout">${icon("layout", 20)}</button>
+        <button class="rail-btn" id="railLogs" data-rail="dev" hidden data-tip="Logs|Read-only developer logs: telemetry, run lineage, transcripts, gate-block audit, AskSage tool-call diagnostics" data-tip-icon="logs">${icon("logs", 20)}</button>
         <div class="spacer"></div>
         <button class="rail-btn" id="railCmd" data-tip="Commands|Ctrl / ⌘ K" data-tip-icon="command">${icon("command", 20)}</button>
         <button class="rail-btn" data-rail="settings" data-tip="Settings" data-tip-icon="sliders">${icon("sliders", 20)}</button>
@@ -1144,7 +1144,7 @@ function secDeveloper(): string {
   const on = state.developerMode;
   const body = `<label class="set-toggle"><input type="checkbox" id="devModeToggle" ${on ? "checked" : ""}/>
       <span><b>Developer mode</b> - reveal a read-only <b>Logs</b> panel in the rail (telemetry, run lineage, transcripts, gate-block audit) and turn on <b>AskSage tool-call diagnostics</b>. Read-only, on this machine, off by default.</span></label>
-    <div class="set-note">${icon("info", 12)} Turning this on respawns the agent so diagnostics apply right away, then shows a <b>Logs</b> panel in the left rail. Open <b>Logs → AskSage tool calls</b> to watch each non-streamed AskSage call.</div>`;
+    <div class="set-note">${icon("info", 12)} <span>Turning this on respawns the agent so the diagnostics take effect immediately, then adds a <b>Logs</b> panel to the left rail. Open it and expand <b>AskSage tool calls</b> to watch each request live.</span></div>`;
   return setCard("developer", "Developer", "logs · diagnostics", body, true);
 }
 function secOthers(auth: import("./bridge.ts").AuthStatus | null): string {
@@ -1680,7 +1680,7 @@ function securityHtml(d: SecuritySnapshot | null): string {
 
 // ── ADR-0009 Phase D: developer Logs view (read-only; metadata only) ──────────────
 function devHtml(d: import("./bridge.ts").DevView | null): string {
-  let h = `<div class="sec-intro"><div class="sec-intro-h"><span class="sec-pulse">${icon("layout", 17)}</span><b>Developer logs</b></div>
+  let h = `<div class="sec-intro"><div class="sec-intro-h"><span class="sec-pulse">${icon("logs", 17)}</span><b>Developer logs</b></div>
     <div class="sec-intro-d">Read-only telemetry, run lineage, transcripts, and audit trails from this machine - sanitized, no raw prompt or file content (the raw is referenced by sha only).</div></div>`;
   if (!d || !d.enabled) { h += `<div class="empty">Developer mode is off. Turn it on in <b>Settings → Developer mode</b> to see the telemetry stream, run lineage, transcripts, and the audit trail.</div>`; return h; }
   const tel = d.snapshot?.telemetry ?? [], runs = d.snapshot?.runs ?? [], exp = d.snapshot?.exports ?? [], blk = d.blocks?.quarantined ?? [], turns = d.turns ?? [];

--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -125,6 +125,7 @@ function buildShell(): void {
         <button class="rail-btn" data-rail="security" data-tip="Security|Findings, quarantine & approvals" data-tip-icon="shield">${icon("shield", 20)}<span class="badge" id="railBadge" hidden>0</span></button>
         <button class="rail-btn" data-rail="memory" data-tip="Memory & context|Context window, prompt-cache savings, semantic memory" data-tip-icon="brain">${icon("brain", 20)}</button>
         <button class="rail-btn" data-rail="knowledge" data-tip="Knowledge graph|Your private, encrypted personalization graph - nodes, edges, drill-down" data-tip-icon="graph">${icon("graph", 20)}</button>
+        <button class="rail-btn" id="railLogs" data-rail="dev" hidden data-tip="Logs|Read-only developer logs: telemetry, run lineage, transcripts, gate-block audit, AskSage tool-call diagnostics" data-tip-icon="layout">${icon("layout", 20)}</button>
         <div class="spacer"></div>
         <button class="rail-btn" id="railCmd" data-tip="Commands|Ctrl / ⌘ K" data-tip-icon="command">${icon("command", 20)}</button>
         <button class="rail-btn" data-rail="settings" data-tip="Settings" data-tip-icon="sliders">${icon("sliders", 20)}</button>
@@ -848,7 +849,11 @@ function hasActiveBlocks(): boolean {
 function focusInspector(tab: Tab): void {
   closeSettings();
   state.inspectorTab = tab;
-  if (state.inspectorRail) setInspectorRail(false);
+  // Expanding from the collapsed metrics rail on an EXPLICIT tab click: clear the rail state directly.
+  // Do NOT route through setInspectorRail() here — its ADR-0021 active-blocks override would hijack the
+  // chosen tab (e.g. clicking Logs/Memory while blocks exist would snap to Security). The passive expand
+  // gesture (#railExpand) still calls setInspectorRail(false), so that override is preserved there.
+  if (state.inspectorRail) { state.inspectorRail = false; $("#inspector")?.classList.remove("rail"); }
   $$(".insp-tab").forEach((t) => t.classList.toggle("active", (t as HTMLElement).dataset.insp === tab));
   $$(".rail-btn").forEach((b) => b.classList.toggle("active", (b as HTMLElement).dataset.rail === tab));
   lastInspHash = ""; renderInspector();

--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -557,20 +557,19 @@ function createReasoning(): ReasoningWin {
 // request. Unanswered at turn's end ⇒ Denied (the backend already fail-closes server-side).
 const isAllowOpt = (kind?: string, optionId?: string) => /allow|approve|grant|accept|yes/i.test(`${kind ?? ""} ${optionId ?? ""}`);
 function createPermissionCard(e: Extract<ChatEvent, { type: "permission" }>): { el: HTMLElement; finalize: () => void } {
-  const btns = e.options.map((o) =>
-    `<button class="perm-btn ${isAllowOpt(o.kind, o.optionId) ? "ok" : "no"}" data-oid="${esc(o.optionId)}">${esc(o.name)}</button>`).join("");
   let win: HTMLElement;
   if (e.egress) {
-    // P-EGRESS.1 (ADR-0058): the agent wants to reach the internet. Show the target prominently with a
-    // copy button + a one-click Cloudflare-Radar safety check, then the per-website approval choices.
+    // P-EGRESS.1 (ADR-0058): the agent wants to reach the internet. Docked above the composer. Subdued
+    // styling that matches the app; the target URL with a copy button + a one-click Cloudflare-Radar check,
+    // then the per-website choices (kind: allow → neutral, danger → amber, reject → block).
     const url = e.url ?? e.detail ?? "";
+    const egCls = (k?: string) => k === "reject" ? "eg-block" : k === "danger" ? "eg-danger" : "eg-allow";
+    const btns = e.options.map((o) => `<button class="perm-btn ${egCls(o.kind)}" data-oid="${esc(o.optionId)}">${esc(o.name)}</button>`).join("");
     win = el(`<div class="perm perm-egress" data-streaming="1">
-      <div class="perm-head perm-head-warn">${icon("shield", 14)}<span>Let the agent reach this website?</span></div>
-      <div class="perm-egress-target"><code class="perm-url">${esc(url)}</code><button class="perm-copy" data-tip="Copy the URL">${icon("copy", 12)}</button></div>
-      <div class="perm-egress-note">${icon("info", 12)}<span>This sends a request to the internet. Approve only sites you trust.</span></div>
-      <button class="perm-radar" data-radar>${icon("search", 12)} Check this site with Cloudflare Radar</button>
+      <div class="perm-eg-head">${icon("git", 13)}<span>The agent wants to visit a website</span></div>
+      <div class="perm-egress-target"><code class="perm-url">${esc(url)}</code><button class="perm-copy" data-tip="Copy URL">${icon("copy", 12)}</button></div>
+      <button class="perm-radar" data-radar>${icon("search", 12)} Check it on Cloudflare Radar</button>
       <div class="perm-actions perm-actions-col">${btns}</div>
-      <div class="perm-result" hidden></div>
     </div>`);
     const copyBtn = $(".perm-copy", win) as HTMLElement | null;
     copyBtn?.addEventListener("click", async () => {
@@ -579,9 +578,10 @@ function createPermissionCard(e: Extract<ChatEvent, { type: "permission" }>): { 
     ($("[data-radar]", win) as HTMLElement | null)?.addEventListener("click", async () => {
       try { await navigator.clipboard.writeText(url); } catch { /* ignore */ }
       window.open("https://radar.cloudflare.com/scan", "_blank", "noopener");
-      showToast({ title: "URL copied · Radar opened", desc: "Paste the URL into Cloudflare Radar's scan box to vet it before allowing.", actions: [{ label: "OK" }], timeout: 4000 });
+      showToast({ title: "URL copied · Radar opened", desc: "Paste the URL into Cloudflare Radar to vet the site before allowing.", actions: [{ label: "OK" }], timeout: 4000 });
     });
   } else {
+    const btns = e.options.map((o) => `<button class="perm-btn ${isAllowOpt(o.kind, o.optionId) ? "ok" : "no"}" data-oid="${esc(o.optionId)}">${esc(o.name)}</button>`).join("");
     win = el(`<div class="perm" data-streaming="1">
       <div class="perm-head">${icon("shield", 14)}<span>Approve tool call?</span></div>
       <div class="perm-body"><b>${esc(e.tool)}</b>${e.detail ? ` · <span class="perm-d">${esc(e.detail)}</span>` : ""}</div>
@@ -590,26 +590,41 @@ function createPermissionCard(e: Extract<ChatEvent, { type: "permission" }>): { 
     </div>`);
   }
   const actions = $(".perm-actions", win) as HTMLElement;
-  const result = $(".perm-result", win) as HTMLElement;
+  const result = $(".perm-result", win) as HTMLElement | null;
   let answered = false;
   const choose = (oid: string | null, label: string, ok: boolean) => {
     if (answered) return;
     answered = true;
     win.removeAttribute("data-streaming");
     void bridge.respondPermission(e.id, oid);
+    if (e.egress) {
+      // Docked card: confirm with a brief toast, then remove it (and the dock when empty).
+      showToast({ title: ok ? "Allowed" : "Blocked", desc: ok ? "The agent can reach the site." : "The agent won't reach that site.", actions: [{ label: "OK" }], timeout: 2200, ...(ok ? {} : { tone: "warn" as const }) });
+      win.remove();
+      const dock = $("#egressDock"); if (dock && !dock.children.length) dock.remove();
+      return;
+    }
     actions.hidden = true;
-    result.hidden = false;
-    result.className = `perm-result ${ok ? "ok" : "no"}`;
-    result.innerHTML = `${icon(ok ? "check" : "close", 13)}<span>${esc(label)}</span>`;
+    if (result) { result.hidden = false; result.className = `perm-result ${ok ? "ok" : "no"}`; result.innerHTML = `${icon(ok ? "check" : "close", 13)}<span>${esc(label)}</span>`; }
   };
   actions.addEventListener("click", (ev) => {
     const b = (ev.target as HTMLElement).closest("[data-oid]") as HTMLElement | null;
     if (!b) return;
     const opt = e.options.find((o) => o.optionId === b.dataset.oid);
-    const ok = isAllowOpt(opt?.kind, opt?.optionId);
-    choose(b.dataset.oid!, ok ? "Allowed" : "Denied", ok);
+    const isDeny = e.egress ? opt?.kind === "reject" : !isAllowOpt(opt?.kind, opt?.optionId);
+    choose(b.dataset.oid!, isDeny ? "Denied" : "Allowed", !isDeny);
   });
   return { el: win, finalize: () => choose(null, "Denied (turn ended)", false) };
+}
+/** P-EGRESS.1: the dock above the composer where egress approval cards sit (not inline in the chat). */
+function egressDock(): HTMLElement {
+  let dock = $("#egressDock");
+  if (!dock) {
+    dock = el(`<div id="egressDock"></div>`);
+    const wrap = $(".composer-wrap")!;
+    wrap.insertBefore(dock, wrap.firstChild);
+  }
+  return dock;
 }
 
 // ── Subagent delegation card - P-TASK.1 (ADR-0028) ──
@@ -766,8 +781,9 @@ async function send(): Promise<void> {
       setPhase("Needs approval"); paintHud();
       const card = createPermissionCard(e);
       permCards.push(card);
-      hud.before(card.el); // sits just above the activity HUD, within this message
-      scrollChat();
+      // P-EGRESS.1: egress approvals dock directly above the prompt bar; normal tool prompts stay inline.
+      if (e.egress) egressDock().appendChild(card.el);
+      else { hud.before(card.el); scrollChat(); }
     }
     else if (e.type === "block") onBlock(e);
     else if (e.type === "usage") { tok = e.used; cost = e.cost; state.liveUsage = { used: e.used, size: e.size, cost: e.cost }; paintHud(); renderStatus(); renderMetricsRail(); }

--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -559,12 +559,36 @@ const isAllowOpt = (kind?: string, optionId?: string) => /allow|approve|grant|ac
 function createPermissionCard(e: Extract<ChatEvent, { type: "permission" }>): { el: HTMLElement; finalize: () => void } {
   const btns = e.options.map((o) =>
     `<button class="perm-btn ${isAllowOpt(o.kind, o.optionId) ? "ok" : "no"}" data-oid="${esc(o.optionId)}">${esc(o.name)}</button>`).join("");
-  const win = el(`<div class="perm" data-streaming="1">
-    <div class="perm-head">${icon("shield", 14)}<span>Approve tool call?</span></div>
-    <div class="perm-body"><b>${esc(e.tool)}</b>${e.detail ? ` · <span class="perm-d">${esc(e.detail)}</span>` : ""}</div>
-    <div class="perm-actions">${btns}</div>
-    <div class="perm-result" hidden></div>
-  </div>`);
+  let win: HTMLElement;
+  if (e.egress) {
+    // P-EGRESS.1 (ADR-0058): the agent wants to reach the internet. Show the target prominently with a
+    // copy button + a one-click Cloudflare-Radar safety check, then the per-website approval choices.
+    const url = e.url ?? e.detail ?? "";
+    win = el(`<div class="perm perm-egress" data-streaming="1">
+      <div class="perm-head perm-head-warn">${icon("shield", 14)}<span>Let the agent reach this website?</span></div>
+      <div class="perm-egress-target"><code class="perm-url">${esc(url)}</code><button class="perm-copy" data-tip="Copy the URL">${icon("copy", 12)}</button></div>
+      <div class="perm-egress-note">${icon("info", 12)}<span>This sends a request to the internet. Approve only sites you trust.</span></div>
+      <button class="perm-radar" data-radar>${icon("search", 12)} Check this site with Cloudflare Radar</button>
+      <div class="perm-actions perm-actions-col">${btns}</div>
+      <div class="perm-result" hidden></div>
+    </div>`);
+    const copyBtn = $(".perm-copy", win) as HTMLElement | null;
+    copyBtn?.addEventListener("click", async () => {
+      try { await navigator.clipboard.writeText(url); copyBtn.innerHTML = icon("check", 12); setTimeout(() => { copyBtn.innerHTML = icon("copy", 12); }, 1200); } catch { /* clipboard blocked */ }
+    });
+    ($("[data-radar]", win) as HTMLElement | null)?.addEventListener("click", async () => {
+      try { await navigator.clipboard.writeText(url); } catch { /* ignore */ }
+      window.open("https://radar.cloudflare.com/scan", "_blank", "noopener");
+      showToast({ title: "URL copied · Radar opened", desc: "Paste the URL into Cloudflare Radar's scan box to vet it before allowing.", actions: [{ label: "OK" }], timeout: 4000 });
+    });
+  } else {
+    win = el(`<div class="perm" data-streaming="1">
+      <div class="perm-head">${icon("shield", 14)}<span>Approve tool call?</span></div>
+      <div class="perm-body"><b>${esc(e.tool)}</b>${e.detail ? ` · <span class="perm-d">${esc(e.detail)}</span>` : ""}</div>
+      <div class="perm-actions">${btns}</div>
+      <div class="perm-result" hidden></div>
+    </div>`);
+  }
   const actions = $(".perm-actions", win) as HTMLElement;
   const result = $(".perm-result", win) as HTMLElement;
   let answered = false;

--- a/desktop/renderer/bridge.ts
+++ b/desktop/renderer/bridge.ts
@@ -140,7 +140,7 @@ export type ChatEvent =
   | { type: "tool"; name: string; detail: string }
   | { type: "subagent"; id: string; agent: string; title: string; assignments: string[] }
   | { type: "block"; tool: string; reason: string; severity: string; findings: string; id?: string; quarantined?: boolean }
-  | { type: "permission"; id: string; tool: string; detail: string; options: { optionId: string; name: string; kind?: string }[] }
+  | { type: "permission"; id: string; tool: string; detail: string; options: { optionId: string; name: string; kind?: string }[]; url?: string; egress?: boolean }
   | { type: "usage"; used: number; size: number; cost: number }
   // P-GOAL.1/3 (ADR-0046): /goal loop events (kept in parity with desktop/acp_backend.ts).
   | { type: "goal-memory"; path: string }

--- a/desktop/renderer/bridge.ts
+++ b/desktop/renderer/bridge.ts
@@ -56,7 +56,7 @@ export interface DevView {
   blocks: { quarantined: BlockRecord[]; approved: BlockRecord[]; total: number };
   // ADR-0009 Phase B (issue #12): captured prompt/response transcripts (sanitized; raw by sha).
   turns: TurnView[];
-  // P-ASKSAGE.1 (ADR-0055): recent AskSage tool-loop call diagnostics (developer mode only).
+  // P-ASKSAGE.1 (ADR-0059): recent AskSage tool-loop call diagnostics (developer mode only).
   asksage?: Array<Record<string, unknown>>;
 }
 // P10.2 cross-model usage & cost ledger

--- a/desktop/renderer/bridge.ts
+++ b/desktop/renderer/bridge.ts
@@ -56,6 +56,8 @@ export interface DevView {
   blocks: { quarantined: BlockRecord[]; approved: BlockRecord[]; total: number };
   // ADR-0009 Phase B (issue #12): captured prompt/response transcripts (sanitized; raw by sha).
   turns: TurnView[];
+  // P-ASKSAGE.1 (ADR-0055): recent AskSage tool-loop call diagnostics (developer mode only).
+  asksage?: Array<Record<string, unknown>>;
 }
 // P10.2 cross-model usage & cost ledger
 export interface ModelUsage {

--- a/desktop/renderer/bridge.ts
+++ b/desktop/renderer/bridge.ts
@@ -342,12 +342,14 @@ const FALLBACK_CONFIG: ConfigOption[] = [
   ] },
 ];
 
-// Generic NDJSON event stream (used by both /api/chat and the /api/goal loop).
-async function streamNdjson(path: string, body: unknown, onEvent: (e: ChatEvent) => void): Promise<void> {
+// Generic NDJSON event stream (used by both /api/chat and the /api/goal loop). `signal` lets Stop abort
+// the CLIENT read so the turn settles even if the server/omp never closes the stream (a wedged turn).
+async function streamNdjson(path: string, body: unknown, onEvent: (e: ChatEvent) => void, signal?: AbortSignal): Promise<void> {
   let res: Response;
   try {
-    res = await fetch(path, { method: "POST", headers: authHeaders({ "content-type": "application/json" }), body: JSON.stringify(body) });
+    res = await fetch(path, { method: "POST", headers: authHeaders({ "content-type": "application/json" }), body: JSON.stringify(body), signal });
   } catch {
+    if (signal?.aborted) return; // Stop pressed — the caller's finally settles the UI; no error line
     onEvent({ type: "token", text: "[backend unreachable - is the GUI server running?]" });
     onEvent({ type: "done" });
     return;
@@ -358,16 +360,25 @@ async function streamNdjson(path: string, body: unknown, onEvent: (e: ChatEvent)
   const dec = new TextDecoder();
   let buf = "";
   const flush = (line: string) => { const s = line.trim(); if (s) { try { onEvent(JSON.parse(s)); } catch { /* skip */ } } };
-  for (;;) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    buf += dec.decode(value, { stream: true });
-    let nl: number;
-    while ((nl = buf.indexOf("\n")) >= 0) { flush(buf.slice(0, nl)); buf = buf.slice(nl + 1); }
-  }
-  flush(buf);
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += dec.decode(value, { stream: true });
+      let nl: number;
+      while ((nl = buf.indexOf("\n")) >= 0) { flush(buf.slice(0, nl)); buf = buf.slice(nl + 1); }
+    }
+    flush(buf);
+  } catch { /* Stop aborted the read, or the stream errored — return so the caller's finally settles. */ }
 }
-const streamChat = (text: string, onEvent: (e: ChatEvent) => void) => streamNdjson("/api/chat", { text }, onEvent);
+// Stop must always recover the UI: aborting this controller ends the client read immediately, so the
+// turn's finally runs even when omp is wedged. cancelChat() aborts it AND posts the server cancel.
+let chatAbort: AbortController | null = null;
+const streamChat = (text: string, onEvent: (e: ChatEvent) => void) => {
+  chatAbort?.abort();
+  chatAbort = new AbortController();
+  return streamNdjson("/api/chat", { text }, onEvent, chatAbort.signal).finally(() => { chatAbort = null; });
+};
 
 export const bridge: LucidBridge = {
   isElectron: !!shell?.isElectron,
@@ -402,7 +413,7 @@ export const bridge: LucidBridge = {
   setMode: (modeId) => post("/api/modes", { modeId }),
   setUiMode: (uiMode) => post("/api/uimode", { uiMode }),
   respondPermission: (id, optionId) => post("/api/chat/permission", { id, optionId }),
-  cancelChat: () => post("/api/chat/cancel", {}),
+  cancelChat: () => { chatAbort?.abort(); return post("/api/chat/cancel", {}); },
   cancelGoal: () => post("/api/goal/cancel", {}),
   commands: async () => (await getData("/api/commands")) ?? [],
   skills: () => getData("/api/skills"),

--- a/desktop/renderer/bridge.ts
+++ b/desktop/renderer/bridge.ts
@@ -148,7 +148,7 @@ export type ChatEvent =
   | { type: "goal-check"; n: number; done: boolean; reason: string }
   | { type: "goal-done"; iters: number; reason: string }
   | { type: "goal-stop"; reason: string }
-  | { type: "done" };
+  | { type: "done"; text?: string }; // text = the authoritative full assistant reply (reconciles lossy streaming)
 export interface GoalOpts { goal: string; condition: string; command?: string; maxIters: number; resume?: string }
 // P-GOAL.4: a stopped loop that can be resumed from its on-disk memory file.
 export interface ResumableLoop { rel: string; goal: string; condition: string; command?: string; iterations: number; updatedAt: number }

--- a/desktop/renderer/icons.ts
+++ b/desktop/renderer/icons.ts
@@ -64,6 +64,8 @@ const RAW: Record<string, string> = {
   info: P("M12 4.5a7.5 7.5 0 1 0 0 15 7.5 7.5 0 0 0 0-15z") + P("M12 11v5") + P("M12 8h.01"),
   // pin / dock
   layout: P("M4 5.5h16v13H4z") + P("M14 5.5v13"),
+  // logs / developer console — a terminal frame with a ">" prompt + cursor line
+  logs: P("M4 5.5h16v13H4z") + P("M7.5 9.7 10 12l-2.5 2.3") + P("M11.8 14.3h4.7"),
   // refresh
   refresh: P("M5 12a7 7 0 0 1 12-5l2 2") + P("M19 5v4h-4") + P("M19 12a7 7 0 0 1-12 5l-2-2") + P("M5 19v-4h4"),
   // copy (two overlapping cards)

--- a/desktop/renderer/styles.css
+++ b/desktop/renderer/styles.css
@@ -467,6 +467,22 @@ body.resizing .sidebar,body.resizing .inspector{transition:none}
 .perm-result.ok{color:var(--green)}
 .perm-result.no{color:var(--txt-3)}
 .perm-result .ic{flex:none}
+/* P-EGRESS.1 (ADR-0058): per-website egress approval card. Amber accent — this is a network-egress gate. */
+.perm-egress{border-left-color:var(--amber,#e0a64e)}
+.perm-head-warn{color:var(--amber,#e0a64e)}
+.perm-egress-target{display:flex;align-items:center;gap:7px;margin:2px 12px 6px;padding:7px 9px;border-radius:8px;
+  background:var(--bg-2);border:1px solid var(--line-soft)}
+.perm-url{font-family:ui-monospace,Menlo,Consolas,monospace;font-size:12px;color:var(--cyan);word-break:break-all;flex:1 1 auto}
+.perm-copy{flex:none;display:inline-flex;align-items:center;border:1px solid var(--line);background:var(--bg-1);color:var(--txt-2);
+  border-radius:7px;padding:4px 7px;cursor:pointer}
+.perm-copy:hover,.perm-copy.ok{border-color:var(--green);color:var(--green)}
+.perm-egress-note{display:flex;align-items:flex-start;gap:6px;padding:0 12px 7px;color:var(--txt-3);font-size:11.5px;line-height:1.5}
+.perm-egress-note .ic{flex:none;margin-top:1px}
+.perm-radar{margin:0 12px 9px;display:inline-flex;align-items:center;gap:6px;font-family:inherit;font-size:12px;font-weight:600;
+  border:1px solid var(--line);background:var(--bg-1);color:var(--accent-2);border-radius:8px;padding:6px 11px;cursor:pointer}
+.perm-radar:hover{border-color:var(--accent-2);background:var(--accent-dim)}
+.perm-actions-col{flex-direction:column;align-items:stretch}
+.perm-actions-col .perm-btn{text-align:left}
 
 /* subagent delegation card (omp `task` tool) — P-TASK.1 (ADR-0028). Mirrors .thoughts/.reasoning. */
 .subagent{margin:8px 0 2px;border:1px solid var(--line);border-left:2px solid var(--cyan);border-radius:11px;

--- a/desktop/renderer/styles.css
+++ b/desktop/renderer/styles.css
@@ -467,7 +467,7 @@ body.resizing .sidebar,body.resizing .inspector{transition:none}
 .perm-result.ok{color:var(--green)}
 .perm-result.no{color:var(--txt-3)}
 .perm-result .ic{flex:none}
-/* P-EGRESS.1 (ADR-0058): per-website egress approval, DOCKED above the prompt bar. Subdued to match the
+/* P-EGRESS.1 (ADR-0062): per-website egress approval, DOCKED above the prompt bar. Subdued to match the
    app — outline buttons (no bright fills), amber only as a thin accent, color on hover. */
 #egressDock{max-width:min(1080px,94vw);margin:0 auto 10px;display:flex;flex-direction:column;gap:8px}
 .perm-egress{margin:0;border:1px solid var(--line);border-left:2px solid color-mix(in srgb,var(--amber,#e0a64e) 55%,var(--line));

--- a/desktop/renderer/styles.css
+++ b/desktop/renderer/styles.css
@@ -467,22 +467,33 @@ body.resizing .sidebar,body.resizing .inspector{transition:none}
 .perm-result.ok{color:var(--green)}
 .perm-result.no{color:var(--txt-3)}
 .perm-result .ic{flex:none}
-/* P-EGRESS.1 (ADR-0058): per-website egress approval card. Amber accent — this is a network-egress gate. */
-.perm-egress{border-left-color:var(--amber,#e0a64e)}
-.perm-head-warn{color:var(--amber,#e0a64e)}
-.perm-egress-target{display:flex;align-items:center;gap:7px;margin:2px 12px 6px;padding:7px 9px;border-radius:8px;
+/* P-EGRESS.1 (ADR-0058): per-website egress approval, DOCKED above the prompt bar. Subdued to match the
+   app — outline buttons (no bright fills), amber only as a thin accent, color on hover. */
+#egressDock{max-width:min(1080px,94vw);margin:0 auto 10px;display:flex;flex-direction:column;gap:8px}
+.perm-egress{margin:0;border:1px solid var(--line);border-left:2px solid color-mix(in srgb,var(--amber,#e0a64e) 55%,var(--line));
+  border-radius:11px;background:var(--bg-1)}
+.perm-eg-head{display:flex;align-items:center;gap:7px;padding:9px 12px 5px;color:var(--txt-2);font-weight:600;font-size:13px}
+.perm-eg-head .ic{flex:none;color:var(--amber,#e0a64e)}
+.perm-egress-target{display:flex;align-items:center;gap:7px;margin:0 12px 7px;padding:6px 9px;border-radius:8px;
   background:var(--bg-2);border:1px solid var(--line-soft)}
-.perm-url{font-family:ui-monospace,Menlo,Consolas,monospace;font-size:12px;color:var(--cyan);word-break:break-all;flex:1 1 auto}
-.perm-copy{flex:none;display:inline-flex;align-items:center;border:1px solid var(--line);background:var(--bg-1);color:var(--txt-2);
-  border-radius:7px;padding:4px 7px;cursor:pointer}
+.perm-url{font-family:ui-monospace,Menlo,Consolas,monospace;font-size:12px;color:var(--txt-2);word-break:break-all;flex:1 1 auto;line-height:1.45}
+.perm-copy{flex:none;display:inline-flex;align-items:center;border:1px solid var(--line);background:var(--bg-1);color:var(--txt-3);
+  border-radius:7px;padding:4px 6px;cursor:pointer;transition:color var(--t) var(--ease),border-color var(--t) var(--ease)}
 .perm-copy:hover,.perm-copy.ok{border-color:var(--green);color:var(--green)}
-.perm-egress-note{display:flex;align-items:flex-start;gap:6px;padding:0 12px 7px;color:var(--txt-3);font-size:11.5px;line-height:1.5}
-.perm-egress-note .ic{flex:none;margin-top:1px}
-.perm-radar{margin:0 12px 9px;display:inline-flex;align-items:center;gap:6px;font-family:inherit;font-size:12px;font-weight:600;
-  border:1px solid var(--line);background:var(--bg-1);color:var(--accent-2);border-radius:8px;padding:6px 11px;cursor:pointer}
-.perm-radar:hover{border-color:var(--accent-2);background:var(--accent-dim)}
-.perm-actions-col{flex-direction:column;align-items:stretch}
-.perm-actions-col .perm-btn{text-align:left}
+.perm-radar{margin:0 12px 9px;align-self:flex-start;display:inline-flex;align-items:center;gap:6px;font-family:inherit;font-size:12px;font-weight:500;
+  border:1px solid var(--line);background:var(--bg-1);color:var(--txt-3);border-radius:8px;padding:5px 10px;cursor:pointer;
+  transition:color var(--t) var(--ease),border-color var(--t) var(--ease)}
+.perm-radar:hover{border-color:var(--accent-2);color:var(--accent-2)}
+.perm-egress .perm-actions-col{flex-direction:column;align-items:stretch;gap:6px;padding:0 12px 11px}
+.perm-egress .perm-btn{text-align:left;font-weight:500;font-size:12.5px;padding:8px 12px;border-radius:9px;
+  background:var(--bg-2);border:1px solid var(--line);color:var(--txt-2);
+  transition:color var(--t) var(--ease),border-color var(--t) var(--ease),background var(--t) var(--ease)}
+.perm-egress .perm-btn:hover{transform:none}
+.perm-egress .eg-allow:hover{border-color:var(--green);color:var(--txt);background:color-mix(in srgb,var(--green) 9%,transparent)}
+.perm-egress .eg-danger{color:var(--amber,#e0a64e);border-color:color-mix(in srgb,var(--amber,#e0a64e) 26%,var(--line))}
+.perm-egress .eg-danger:hover{border-color:var(--amber,#e0a64e);background:color-mix(in srgb,var(--amber,#e0a64e) 10%,transparent)}
+.perm-egress .eg-block{color:var(--txt-3)}
+.perm-egress .eg-block:hover{border-color:var(--red);color:var(--red);background:var(--red-dim)}
 
 /* subagent delegation card (omp `task` tool) — P-TASK.1 (ADR-0028). Mirrors .thoughts/.reasoning. */
 .subagent{margin:8px 0 2px;border:1px solid var(--line);border-left:2px solid var(--cyan);border-radius:11px;

--- a/harness/knowledge/chunk.test.ts
+++ b/harness/knowledge/chunk.test.ts
@@ -1,0 +1,43 @@
+// harness/knowledge/chunk.test.ts — pure chunking: bounds, overlap, boundary preference, determinism.
+
+import { describe, expect, test } from "bun:test";
+import { chunkText } from "./chunk.ts";
+
+describe("chunkText", () => {
+  test("short text returns a single trimmed chunk", () => {
+    expect(chunkText("  hello world  ")).toEqual(["hello world"]);
+  });
+
+  test("empty / whitespace-only returns no chunks", () => {
+    expect(chunkText("")).toEqual([]);
+    expect(chunkText("   \n\t  ")).toEqual([]);
+  });
+
+  test("long text splits into multiple chunks under the size bound", () => {
+    const text = Array.from({ length: 50 }, (_, i) => `Sentence number ${i} has some words in it.`).join(" ");
+    const chunks = chunkText(text, { maxChars: 200, overlapChars: 40 });
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) expect(c.length).toBeLessThanOrEqual(200);
+  });
+
+  test("consecutive chunks overlap (carry-over context)", () => {
+    const text = Array.from({ length: 40 }, (_, i) => `word${i}`).join(" ");
+    const chunks = chunkText(text, { maxChars: 60, overlapChars: 20 });
+    expect(chunks.length).toBeGreaterThan(1);
+    // the tail of chunk[0] should reappear at the head of chunk[1]
+    const tail = chunks[0]!.slice(-10);
+    expect(chunks[1]!.includes(tail.trim().split(" ")[0]!)).toBe(true);
+  });
+
+  test("deterministic: same input → same chunks", () => {
+    const text = "Alpha beta gamma. ".repeat(80);
+    expect(chunkText(text, { maxChars: 150 })).toEqual(chunkText(text, { maxChars: 150 }));
+  });
+
+  test("prefers a sentence boundary near the window end", () => {
+    // The sentence ends at char ~36 — inside the chunker's last-40% preference band for a 40-char window.
+    const text = "Alpha beta gamma delta epsilon zeta. Then come many more words after the boundary here.";
+    const chunks = chunkText(text, { maxChars: 40, overlapChars: 5 });
+    expect(chunks[0]!.endsWith(".")).toBe(true);
+  });
+});

--- a/harness/knowledge/chunk.ts
+++ b/harness/knowledge/chunk.ts
@@ -1,0 +1,59 @@
+// harness/knowledge/chunk.ts
+//
+// P-RAG.1 (ADR-0054): pure text chunking for the local knowledge store. No I/O — splits a document
+// into overlapping, roughly word-bounded windows so each chunk embeds to a coherent vector and
+// retrieval returns readable spans. Deterministic (same input → same chunks), so the ingest pipeline
+// and its tests are reproducible.
+//
+// Strategy: normalize whitespace, then accumulate words up to ~maxChars, preferring to break at a
+// sentence/paragraph boundary near the end of the window. Consecutive chunks overlap by ~overlapChars
+// so a fact split across a boundary is still retrievable from at least one chunk.
+
+export interface ChunkOptions {
+  /** Soft upper bound on chunk length in characters. Default 800 (~150-200 tokens). */
+  maxChars?: number;
+  /** Characters of trailing context repeated at the start of the next chunk. Default 120. */
+  overlapChars?: number;
+}
+
+const DEFAULTS: Required<ChunkOptions> = { maxChars: 800, overlapChars: 120 };
+
+/** Collapse runs of whitespace but keep paragraph breaks (double newline) as soft boundaries. */
+function normalize(text: string): string {
+  return text
+    .replace(/\r\n?/g, "\n")
+    .replace(/[ \t\f\v]+/g, " ")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+/** Split into chunks of at most ~maxChars, breaking at the latest sentence/whitespace boundary
+ *  within the window, with overlapChars of carry-over between consecutive chunks. */
+export function chunkText(text: string, opts: ChunkOptions = {}): string[] {
+  const maxChars = Math.max(1, opts.maxChars ?? DEFAULTS.maxChars);
+  const overlap = Math.max(0, Math.min(opts.overlapChars ?? DEFAULTS.overlapChars, maxChars - 1));
+  const norm = normalize(text);
+  if (!norm) return [];
+  if (norm.length <= maxChars) return [norm];
+
+  const chunks: string[] = [];
+  let start = 0;
+  while (start < norm.length) {
+    let end = Math.min(start + maxChars, norm.length);
+    if (end < norm.length) {
+      // Prefer a boundary in the last third of the window: paragraph > sentence > whitespace.
+      const window = norm.slice(start, end);
+      const floor = Math.floor(maxChars * 0.6);
+      const para = window.lastIndexOf("\n\n");
+      const sentence = Math.max(window.lastIndexOf(". "), window.lastIndexOf(".\n"), window.lastIndexOf("! "), window.lastIndexOf("? "));
+      const space = window.lastIndexOf(" ");
+      const brk = [para, sentence, space].find((i) => i >= floor);
+      if (brk !== undefined && brk > 0) end = start + brk + 1;
+    }
+    const piece = norm.slice(start, end).trim();
+    if (piece) chunks.push(piece);
+    if (end >= norm.length) break;
+    start = Math.max(end - overlap, start + 1);
+  }
+  return chunks;
+}

--- a/harness/knowledge/chunk.ts
+++ b/harness/knowledge/chunk.ts
@@ -1,6 +1,6 @@
 // harness/knowledge/chunk.ts
 //
-// P-RAG.1 (ADR-0054): pure text chunking for the local knowledge store. No I/O — splits a document
+// P-RAG.1 (ADR-0058): pure text chunking for the local knowledge store. No I/O — splits a document
 // into overlapping, roughly word-bounded windows so each chunk embeds to a coherent vector and
 // retrieval returns readable spans. Deterministic (same input → same chunks), so the ingest pipeline
 // and its tests are reproducible.

--- a/harness/knowledge/embedder.test.ts
+++ b/harness/knowledge/embedder.test.ts
@@ -1,0 +1,47 @@
+// harness/knowledge/embedder.test.ts — the deterministic stub embedder: shape, normalization,
+// determinism, and that shared-vocabulary texts embed closer than unrelated ones (so retrieval ranks).
+
+import { describe, expect, test } from "bun:test";
+import { HashEmbedder } from "./embedder.ts";
+
+function dot(a: number[], b: number[]): number {
+  let s = 0;
+  for (let i = 0; i < a.length; i++) s += a[i]! * b[i]!;
+  return s;
+}
+
+describe("HashEmbedder", () => {
+  const emb = new HashEmbedder(128);
+
+  test("id and dim are exposed and consistent", () => {
+    expect(emb.dim).toBe(128);
+    expect(emb.id).toBe("hash-bow-128");
+  });
+
+  test("produces unit-length vectors of the right dim", async () => {
+    const [v] = await emb.embed(["the quick brown fox"]);
+    expect(v!.length).toBe(128);
+    const norm = Math.sqrt(dot(v!, v!));
+    expect(norm).toBeCloseTo(1, 5);
+  });
+
+  test("deterministic for the same input", async () => {
+    const [a] = await emb.embed(["hello knowledge base"]);
+    const [b] = await emb.embed(["hello knowledge base"]);
+    expect(a).toEqual(b!);
+  });
+
+  test("empty text → all-zeros (no NaN from normalization)", async () => {
+    const [v] = await emb.embed([""]);
+    expect(v!.every((x) => x === 0)).toBe(true);
+  });
+
+  test("shared vocabulary ranks closer than unrelated text", async () => {
+    const [base, near, far] = await emb.embed([
+      "duckdb stores vectors for retrieval",
+      "vectors for retrieval are stored in duckdb",
+      "the weather today is sunny and warm",
+    ]);
+    expect(dot(base!, near!)).toBeGreaterThan(dot(base!, far!));
+  });
+});

--- a/harness/knowledge/embedder.ts
+++ b/harness/knowledge/embedder.ts
@@ -1,6 +1,6 @@
 // harness/knowledge/embedder.ts
 //
-// P-RAG.1 (ADR-0054): the embedding seam. The ingest + retrieval pipeline depends on this interface,
+// P-RAG.1 (ADR-0058): the embedding seam. The ingest + retrieval pipeline depends on this interface,
 // NOT on any concrete model, so the spine is testable and air-gap-clean today and the real model drops
 // in later without touching callers.
 //

--- a/harness/knowledge/embedder.ts
+++ b/harness/knowledge/embedder.ts
@@ -1,0 +1,60 @@
+// harness/knowledge/embedder.ts
+//
+// P-RAG.1 (ADR-0054): the embedding seam. The ingest + retrieval pipeline depends on this interface,
+// NOT on any concrete model, so the spine is testable and air-gap-clean today and the real model drops
+// in later without touching callers.
+//
+// `HashEmbedder` is a deterministic, dependency-free embedder: a hashed bag-of-words projected into
+// `dim` dimensions and L2-normalized, so array_cosine_distance is meaningful and documents that share
+// vocabulary rank closer. It is good enough to PROVE the store/retrieval/scan-gate plumbing end to end
+// without a network download. P-RAG.1b swaps in the real WASM `bge-small-en-v1.5` (384-dim) behind this
+// same interface, with weights bundled as extraResources (ADR-0053).
+
+export interface Embedder {
+  readonly id: string;   // model identifier recorded on the dataset (vector-space tag)
+  readonly dim: number;  // vector dimensionality
+  /** Embed each text into a `dim`-length unit vector. Order-preserving. */
+  embed(texts: string[]): Promise<number[][]>;
+}
+
+/** FNV-1a 32-bit hash of a token → stable bucket + sign, no deps. */
+function hashToken(tok: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < tok.length; i++) {
+    h ^= tok.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+function tokenize(text: string): string[] {
+  return text.toLowerCase().match(/[a-z0-9]+/g) ?? [];
+}
+
+export class HashEmbedder implements Embedder {
+  readonly id: string;
+  constructor(readonly dim: number = 256) {
+    this.id = `hash-bow-${dim}`;
+  }
+
+  async embed(texts: string[]): Promise<number[][]> {
+    return texts.map((t) => this.embedOne(t));
+  }
+
+  private embedOne(text: string): number[] {
+    const v = new Array<number>(this.dim).fill(0);
+    for (const tok of tokenize(text)) {
+      const h = hashToken(tok);
+      const bucket = h % this.dim;
+      const sign = (h & 0x10000) ? 1 : -1; // a stable second bit decorrelates collisions
+      v[bucket]! += sign;
+    }
+    // L2-normalize so cosine distance is purely directional (zero vector → all-zeros, distance 1).
+    let norm = 0;
+    for (const x of v) norm += x * x;
+    norm = Math.sqrt(norm);
+    if (norm === 0) return v;
+    for (let i = 0; i < v.length; i++) v[i]! /= norm;
+    return v;
+  }
+}

--- a/harness/knowledge/ingest.test.ts
+++ b/harness/knowledge/ingest.test.ts
@@ -1,0 +1,84 @@
+// harness/knowledge/ingest.test.ts — the scan-gate is the security keystone here. Asserts: clean text
+// is chunked/embedded/stored with trust labels; a poisoned chunk is NEVER stored and IS audited; a
+// dead scanner fails closed (nothing stored); and retrieval wrapping is delimited (invariant #5).
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ScannerClient } from "../security/scanner_client.ts";
+import { ScanUnavailableError } from "../security/scanner_client.ts";
+import { HashEmbedder } from "./embedder.ts";
+import { KnowledgeStore } from "./store.ts";
+import { ingestText, wrapRetrieved } from "./ingest.ts";
+
+// Reuse the project's fake-scanner shape (see personal/*.test.ts): a structural ScannerClient whose
+// scan() returns findings derived from the text. DEFAULT_POLICY blocks at "high".
+const fakeScanner = (findings: (t: string) => unknown[]): ScannerClient =>
+  ({ scan: async (t: string) => ({ findings: findings(t) }) }) as unknown as ScannerClient;
+const cleanScanner = fakeScanner(() => []);
+const poisonScanner = fakeScanner((t) => (/POISON/.test(t) ? [{ severity: "high", finding_type: "zero-width" }] : []));
+const deadScanner = { scan: async () => { throw new ScanUnavailableError("sidecar dead"); } } as unknown as ScannerClient;
+
+describe("ingestText (scan-gated)", () => {
+  let dir: string;
+  let store: KnowledgeStore;
+  const emb = new HashEmbedder(64);
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "kb-ingest-"));
+    store = await KnowledgeStore.open(join(dir, "knowledge.duckdb"));
+  });
+  afterEach(() => { store.close(); rmSync(dir, { recursive: true, force: true }); });
+
+  async function ds() {
+    return (await store.createDataset({ name: "d", classification: "U", source: "local", embeddingModel: emb.id, dim: emb.dim })).dataset_id;
+  }
+
+  test("clean text is chunked, embedded, and stored as trusted", async () => {
+    const id = await ds();
+    const text = Array.from({ length: 30 }, (_, i) => `Clean fact number ${i} about retrieval.`).join(" ");
+    const r = await ingestText({ store, scanner: cleanScanner, embedder: emb, datasetId: id, sourcePath: "clean.txt", text, chunkOptions: { maxChars: 120, overlapChars: 20 } });
+    expect(r.chunksTotal).toBeGreaterThan(1);
+    expect(r.stored).toBe(r.chunksTotal);
+    expect(r.blocked).toBe(0);
+    expect(await store.chunkCount(id)).toBe(r.stored);
+  });
+
+  test("a poisoned chunk is BLOCKED — never stored — and audited via onBlock", async () => {
+    const id = await ds();
+    const blocks: unknown[] = [];
+    // Two paragraphs: one clean, one containing POISON. With a small window each is its own chunk.
+    const text = "This paragraph is perfectly clean and ordinary.\n\nThis paragraph contains POISON and must be quarantined.";
+    const r = await ingestText({
+      store, scanner: poisonScanner, embedder: emb, datasetId: id, sourcePath: "mixed.txt", text,
+      chunkOptions: { maxChars: 60, overlapChars: 0 }, onBlock: (b) => blocks.push(b),
+    });
+    expect(r.blocked).toBeGreaterThanOrEqual(1);
+    expect(blocks.length).toBe(r.blocked);
+    // nothing stored contains POISON
+    const stored = await store.retrieve(id, (await emb.embed(["poison"]))[0]!, 50);
+    expect(stored.every((c) => !/POISON/.test(c.text))).toBe(true);
+    expect(await store.chunkCount(id)).toBe(r.stored);
+  });
+
+  test("a dead scanner fails closed: every chunk blocked, nothing stored", async () => {
+    const id = await ds();
+    const r = await ingestText({ store, scanner: deadScanner, embedder: emb, datasetId: id, sourcePath: "x.txt", text: "anything at all goes here, more than one chunk maybe" });
+    expect(r.stored).toBe(0);
+    expect(r.blocked).toBe(r.chunksTotal);
+    expect(await store.chunkCount(id)).toBe(0);
+  });
+
+  test("wrapRetrieved delimits injected knowledge as untrusted data", async () => {
+    const id = await ds();
+    const [v] = await emb.embed(["delimited knowledge chunk"]);
+    await store.addChunk({ datasetId: id, sourcePath: "d.txt", ordinal: 2, text: "delimited knowledge chunk", trustLabel: "trusted", embedding: v! });
+    const hits = await store.retrieve(id, v!, 3);
+    const wrapped = wrapRetrieved(hits);
+    expect(wrapped.startsWith("UNTRUSTED_CONTENT_START")).toBe(true);
+    expect(wrapped.endsWith("UNTRUSTED_CONTENT_END")).toBe(true);
+    expect(wrapped).toContain("(d.txt#2)");
+    expect(wrapRetrieved([])).toBe("");
+  });
+});

--- a/harness/knowledge/ingest.ts
+++ b/harness/knowledge/ingest.ts
@@ -1,6 +1,6 @@
 // harness/knowledge/ingest.ts
 //
-// P-RAG.1 (ADR-0054): the scan-gated local ingest pipeline + the delimited retrieval wrapper. This is
+// P-RAG.1 (ADR-0058): the scan-gated local ingest pipeline + the delimited retrieval wrapper. This is
 // the security-load-bearing core of the knowledge store.
 //
 // ingestText: chunk → SCAN each chunk fail-closed (scanAndDecide / DEFAULT_POLICY, the same seam as

--- a/harness/knowledge/ingest.ts
+++ b/harness/knowledge/ingest.ts
@@ -1,0 +1,110 @@
+// harness/knowledge/ingest.ts
+//
+// P-RAG.1 (ADR-0054): the scan-gated local ingest pipeline + the delimited retrieval wrapper. This is
+// the security-load-bearing core of the knowledge store.
+//
+// ingestText: chunk → SCAN each chunk fail-closed (scanAndDecide / DEFAULT_POLICY, the same seam as
+// persona/skill import) → embed only the clean chunks → store with their trust label. A blocked chunk
+// (quarantined, suspicious-over-threshold, OR scanner-unavailable) is NEVER embedded and NEVER stored
+// (invariant #3 fail-closed, #5 untrusted-only-delimited, keystone #2 — RAG context never auto-promotes
+// into semantic memory). The audit hook `onBlock` lets the desktop layer recordBlock() without this
+// harness module importing the desktop security log (clean layering).
+//
+// wrapRetrieved: render top-k chunks inside UNTRUSTED_CONTENT_START/END so injected knowledge enters a
+// prompt ONLY as delimited data, in the user-turn tail — never the frozen prefix (invariant #5/#6).
+
+import type { ScannerClient } from "../security/scanner_client.ts";
+import { DEFAULT_POLICY, scanAndDecide, type GatePolicy } from "../security/gate.ts";
+import { UNTRUSTED_START, UNTRUSTED_END } from "../prompt/assembler.ts";
+import { chunkText, type ChunkOptions } from "./chunk.ts";
+import type { Embedder } from "./embedder.ts";
+import type { KnowledgeStore, RetrievedChunk } from "./store.ts";
+
+export interface BlockedChunk {
+  ordinal: number;
+  reason: string;
+  trustLabel: string;
+  findings: number;
+}
+
+export interface IngestResult {
+  datasetId: string;
+  sourcePath: string;
+  chunksTotal: number;
+  stored: number;
+  blocked: number;
+  storedChunkIds: string[];
+  blockedChunks: BlockedChunk[];
+}
+
+export interface IngestArgs {
+  store: KnowledgeStore;
+  scanner: ScannerClient;
+  embedder: Embedder;
+  datasetId: string;
+  sourcePath: string;
+  text: string;
+  artifactId?: string | null;
+  chunkOptions?: ChunkOptions;
+  policy?: GatePolicy;
+  /** Audit hook for a blocked chunk — desktop wiring passes recordBlock(). Never used to store. */
+  onBlock?: (b: BlockedChunk & { sourcePath: string; datasetId: string }) => void;
+}
+
+/** Ingest one text source into a dataset, scanning every chunk fail-closed before it is embedded or
+ *  stored. Returns a per-source summary; blocked chunks are reported, audited (onBlock), never stored. */
+export async function ingestText(args: IngestArgs): Promise<IngestResult> {
+  const { store, scanner, embedder, datasetId, sourcePath } = args;
+  const policy = args.policy ?? DEFAULT_POLICY;
+  const chunks = chunkText(args.text, args.chunkOptions);
+
+  const result: IngestResult = {
+    datasetId, sourcePath, chunksTotal: chunks.length, stored: 0, blocked: 0, storedChunkIds: [], blockedChunks: [],
+  };
+
+  // First pass: scan every chunk (fail-closed). Collect only the clean/suspicious-allowed ones, keeping
+  // their ORIGINAL ordinal so retrieval citations and overlap order stay faithful to the source.
+  const clean: { ordinal: number; text: string; trustLabel: string }[] = [];
+  for (let i = 0; i < chunks.length; i++) {
+    const text = chunks[i]!;
+    let decision: Awaited<ReturnType<typeof scanAndDecide>>;
+    try {
+      decision = await scanAndDecide(scanner, text, policy);
+    } catch (e) {
+      // scanAndDecide already fails closed internally; this guards a thrown scanner construction too.
+      decision = { block: true, reason: `scan threw: ${String((e as Error)?.message ?? e)}`, trustLabel: "quarantined", findings: [], failClosed: true };
+    }
+    if (decision.block) {
+      const b: BlockedChunk = { ordinal: i, reason: decision.reason, trustLabel: decision.trustLabel, findings: decision.findings.length };
+      result.blocked++;
+      result.blockedChunks.push(b);
+      args.onBlock?.({ ...b, sourcePath, datasetId });
+      continue; // NEVER embed or store a blocked chunk
+    }
+    clean.push({ ordinal: i, text, trustLabel: decision.trustLabel });
+  }
+
+  if (clean.length === 0) return result;
+
+  // Embed the clean chunks in one batch, then store each with its trust label.
+  const vectors = await embedder.embed(clean.map((c) => c.text));
+  for (let j = 0; j < clean.length; j++) {
+    const c = clean[j]!;
+    const id = await store.addChunk({
+      datasetId, artifactId: args.artifactId ?? null, sourcePath, ordinal: c.ordinal, text: c.text, trustLabel: c.trustLabel, embedding: vectors[j]!,
+    });
+    result.stored++;
+    result.storedChunkIds.push(id);
+  }
+  return result;
+}
+
+/** Wrap retrieved chunks for injection: delimited as untrusted data, numbered with provenance, ready to
+ *  drop into the USER-turn tail. Empty string when there is nothing to inject. */
+export function wrapRetrieved(chunks: RetrievedChunk[]): string {
+  if (chunks.length === 0) return "";
+  const body = chunks
+    .map((c, i) => `[${i + 1}] (${c.source_path}#${c.ordinal})\n${c.text}`)
+    .join("\n\n");
+  return `${UNTRUSTED_START}\n${body}\n${UNTRUSTED_END}`;
+}

--- a/harness/knowledge/migrations/0010_knowledge_vectors.sql
+++ b/harness/knowledge/migrations/0010_knowledge_vectors.sql
@@ -1,0 +1,42 @@
+-- migration 0010 — knowledge vector store (ADR-0053 / ADR-0054, P-RAG.1)
+--
+-- FROZEN once applied (invariant #10). Lives in its OWN migration set
+-- (harness/knowledge/migrations) applied to a SEPARATE knowledge.duckdb, so it never
+-- touches agent_obs.duckdb and there is no write-lock contention with omp's writer
+-- (ADR-0053 decision #3). The leading number 0010 keeps the project's migration
+-- numbering globally unique/ADR-aligned even though this is a distinct database.
+--
+-- kb_datasets: one row per named knowledge collection. classification is U | CUI
+-- (compartment model, ADR-0012); source is local | asksage; embedding_model + dim
+-- pin the vector space so retrieval never mixes incompatible embeddings.
+--
+-- kb_chunks: the embedded text units. Every chunk was SCANNED fail-closed before it
+-- was stored (invariant #3/#5) and carries the resulting trust_label; quarantined
+-- content is never written here. embedding is a fixed-width FLOAT[dim] used by
+-- DuckDB's built-in array_cosine_distance for brute-force retrieval (no vss/HNSW
+-- extension — air-gap clean, ADR-0053). artifact_id is a SOFT reference to the
+-- content_artifacts row in the core DB (cross-database, so no FK).
+CREATE TABLE kb_datasets (
+  dataset_id      VARCHAR PRIMARY KEY,
+  name            VARCHAR NOT NULL,
+  classification  VARCHAR NOT NULL,   -- 'U' | 'CUI'
+  source          VARCHAR NOT NULL,   -- 'local' | 'asksage'
+  embedding_model VARCHAR NOT NULL,
+  dim             INTEGER NOT NULL,
+  created_at      TIMESTAMP NOT NULL
+);
+
+CREATE TABLE kb_chunks (
+  chunk_id    VARCHAR PRIMARY KEY,
+  dataset_id  VARCHAR NOT NULL REFERENCES kb_datasets(dataset_id),
+  artifact_id VARCHAR,                -- soft ref to content_artifacts (separate DB)
+  source_path VARCHAR NOT NULL,       -- the file/origin this chunk came from
+  ordinal     INTEGER NOT NULL,       -- chunk order within its source
+  text        VARCHAR NOT NULL,       -- the sanitized chunk text (scanned clean)
+  trust_label VARCHAR NOT NULL,       -- trusted | suspicious (quarantined never stored)
+  embedding   FLOAT[] NOT NULL,       -- length == dataset.dim
+  dim         INTEGER NOT NULL,
+  created_at  TIMESTAMP NOT NULL
+);
+
+CREATE INDEX idx_kb_chunks_dataset ON kb_chunks(dataset_id);

--- a/harness/knowledge/migrations/0010_knowledge_vectors.sql
+++ b/harness/knowledge/migrations/0010_knowledge_vectors.sql
@@ -1,4 +1,4 @@
--- migration 0010 — knowledge vector store (ADR-0053 / ADR-0054, P-RAG.1)
+-- migration 0010 — knowledge vector store (ADR-0053 / ADR-0058, P-RAG.1)
 --
 -- FROZEN once applied (invariant #10). Lives in its OWN migration set
 -- (harness/knowledge/migrations) applied to a SEPARATE knowledge.duckdb, so it never

--- a/harness/knowledge/store.test.ts
+++ b/harness/knowledge/store.test.ts
@@ -1,0 +1,84 @@
+// harness/knowledge/store.test.ts — the vector store against a real (temp) knowledge.duckdb: separate
+// migration set applies, dataset/chunk CRUD, brute-force cosine ranking, dim-mismatch fails loudly.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { HashEmbedder } from "./embedder.ts";
+import { KnowledgeStore } from "./store.ts";
+
+describe("KnowledgeStore", () => {
+  let dir: string;
+  let store: KnowledgeStore;
+  // 384-dim (the real bge dimensionality): enough buckets that the stub embedder's hash collisions
+  // don't flip rankings of close sentences. The dim is also what addChunk validates against.
+  const emb = new HashEmbedder(384);
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "kb-"));
+    store = await KnowledgeStore.open(join(dir, "knowledge.duckdb"));
+  });
+  afterEach(() => {
+    store.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  async function dataset() {
+    return store.createDataset({ name: "docs", classification: "U", source: "local", embeddingModel: emb.id, dim: emb.dim });
+  }
+
+  test("the knowledge migration set creates kb tables (separate DB)", async () => {
+    const ds = await dataset();
+    expect(ds.dataset_id).toBeTruthy();
+    expect(await store.listDatasets()).toHaveLength(1);
+    expect(await store.chunkCount(ds.dataset_id)).toBe(0);
+  });
+
+  test("addChunk + retrieve ranks the nearest chunk first", async () => {
+    const ds = await dataset();
+    const texts = [
+      "duckdb brute force cosine retrieval over float arrays",
+      "the cat sat quietly on the warm windowsill",
+      "vector embeddings power semantic search and retrieval",
+    ];
+    const vecs = await emb.embed(texts);
+    for (let i = 0; i < texts.length; i++) {
+      await store.addChunk({ datasetId: ds.dataset_id, sourcePath: "doc.txt", ordinal: i, text: texts[i]!, trustLabel: "trusted", embedding: vecs[i]! });
+    }
+    expect(await store.chunkCount(ds.dataset_id)).toBe(3);
+
+    const [q] = await emb.embed(["cosine retrieval in duckdb"]);
+    const hits = await store.retrieve(ds.dataset_id, q!, 3);
+    expect(hits).toHaveLength(3);
+    expect(hits[0]!.text).toBe(texts[0]!);                 // nearest first
+    expect(hits[0]!.distance).toBeLessThanOrEqual(hits[1]!.distance);
+    expect(hits[1]!.distance).toBeLessThanOrEqual(hits[2]!.distance);
+    expect(hits[0]!.trust_label).toBe("trusted");
+  });
+
+  test("retrieve honors k and is scoped to the dataset", async () => {
+    const a = await dataset();
+    const b = await dataset();
+    const [va] = await emb.embed(["alpha only content"]);
+    const [vb] = await emb.embed(["beta only content"]);
+    await store.addChunk({ datasetId: a.dataset_id, sourcePath: "a", ordinal: 0, text: "alpha only content", trustLabel: "trusted", embedding: va! });
+    await store.addChunk({ datasetId: b.dataset_id, sourcePath: "b", ordinal: 0, text: "beta only content", trustLabel: "trusted", embedding: vb! });
+    const hits = await store.retrieve(a.dataset_id, va!, 5);
+    expect(hits).toHaveLength(1);          // only dataset a's chunk
+    expect(hits[0]!.text).toBe("alpha only content");
+  });
+
+  test("dim mismatch throws at write (never silently stored)", async () => {
+    const ds = await dataset();
+    await expect(
+      store.addChunk({ datasetId: ds.dataset_id, sourcePath: "x", ordinal: 0, text: "bad", trustLabel: "trusted", embedding: [0.1, 0.2] }),
+    ).rejects.toThrow(/dim/);
+  });
+
+  test("unknown dataset throws", async () => {
+    await expect(
+      store.addChunk({ datasetId: "nope", sourcePath: "x", ordinal: 0, text: "y", trustLabel: "trusted", embedding: new Array(64).fill(0) }),
+    ).rejects.toThrow(/unknown dataset/);
+  });
+});

--- a/harness/knowledge/store.ts
+++ b/harness/knowledge/store.ts
@@ -1,0 +1,136 @@
+// harness/knowledge/store.ts
+//
+// P-RAG.1 (ADR-0054): the local knowledge vector store. Wraps a SEPARATE knowledge.duckdb (its own
+// migration set, ADR-0053 decision #3) and exposes dataset + chunk CRUD and brute-force cosine
+// retrieval over DuckDB's built-in `list_cosine_distance` — no vss/HNSW extension, so it runs
+// air-gapped (invariant: air-gap clean).
+//
+// Vectors are stored/queried as inlined numeric SQL list literals: the @duckdb/node-api binding
+// rejects a JS array bound as a parameter ("Cannot create values of type ANY"), and the components are
+// machine-generated finite floats (never user text), so inlining is safe and keeps retrieval in SQL.
+
+import { join } from "node:path";
+import { Snowflake } from "@oh-my-pi/pi-utils";
+import { Db } from "../memory/db.ts";
+
+export const KNOWLEDGE_MIGRATIONS_DIR = join(import.meta.dir, "migrations");
+
+export type Classification = "U" | "CUI";
+export type KbSource = "local" | "asksage";
+
+export interface KbDataset {
+  dataset_id: string;
+  name: string;
+  classification: Classification;
+  source: KbSource;
+  embedding_model: string;
+  dim: number;
+  created_at: string;
+}
+
+export interface KbChunkInput {
+  datasetId: string;
+  artifactId?: string | null;
+  sourcePath: string;
+  ordinal: number;
+  text: string;
+  trustLabel: string;
+  embedding: number[];
+}
+
+export interface RetrievedChunk {
+  chunk_id: string;
+  dataset_id: string;
+  source_path: string;
+  ordinal: number;
+  text: string;
+  trust_label: string;
+  distance: number;
+}
+
+/** Render a vector as a DuckDB numeric list literal `[a,b,c]`. Throws on a non-finite component so a
+ *  bad embedding can never be silently stored or queried (NaN would poison cosine distance). */
+function floatList(v: number[]): string {
+  return "[" + v.map((x) => {
+    if (!Number.isFinite(x)) throw new Error("non-finite embedding component");
+    return x;
+  }).join(",") + "]";
+}
+
+export class KnowledgeStore {
+  private constructor(private readonly db: Db) {}
+
+  /** Open (or create) knowledge.duckdb at `path` and apply the knowledge migration set. */
+  static async open(path: string): Promise<KnowledgeStore> {
+    return new KnowledgeStore(await Db.open(path, KNOWLEDGE_MIGRATIONS_DIR));
+  }
+
+  close(): void { this.db.close(); }
+
+  async createDataset(opts: {
+    name: string;
+    classification: Classification;
+    source: KbSource;
+    embeddingModel: string;
+    dim: number;
+  }): Promise<KbDataset> {
+    const dataset_id = Snowflake.next();
+    const created_at = new Date().toISOString();
+    await this.db.run(
+      "INSERT INTO kb_datasets VALUES ($1,$2,$3,$4,$5,$6,$7)",
+      [dataset_id, opts.name, opts.classification, opts.source, opts.embeddingModel, opts.dim, created_at],
+    );
+    return { dataset_id, name: opts.name, classification: opts.classification, source: opts.source, embedding_model: opts.embeddingModel, dim: opts.dim, created_at };
+  }
+
+  async getDataset(id: string): Promise<KbDataset | undefined> {
+    return (await this.db.get("SELECT * FROM kb_datasets WHERE dataset_id = $1", [id])) as KbDataset | undefined;
+  }
+
+  async listDatasets(): Promise<KbDataset[]> {
+    return (await this.db.all("SELECT * FROM kb_datasets ORDER BY created_at DESC")) as unknown as KbDataset[];
+  }
+
+  /** Insert one already-scanned, already-embedded chunk. Mints its stable id. The embedding length
+   *  must match the dataset's dim — enforced here so a vector-space mismatch fails loudly at write,
+   *  never silently at retrieval. */
+  async addChunk(c: KbChunkInput): Promise<string> {
+    const ds = await this.getDataset(c.datasetId);
+    if (!ds) throw new Error(`unknown dataset: ${c.datasetId}`);
+    if (c.embedding.length !== ds.dim) {
+      throw new Error(`embedding dim ${c.embedding.length} != dataset dim ${ds.dim}`);
+    }
+    const chunk_id = Snowflake.next();
+    await this.db.run(
+      `INSERT INTO kb_chunks (chunk_id, dataset_id, artifact_id, source_path, ordinal, text, trust_label, embedding, dim, created_at)
+       VALUES ($1,$2,$3,$4,$5,$6,$7, ${floatList(c.embedding)}, $8, $9)`,
+      [chunk_id, c.datasetId, c.artifactId ?? null, c.sourcePath, c.ordinal, c.text, c.trustLabel, c.embedding.length, new Date().toISOString()],
+    );
+    return chunk_id;
+  }
+
+  /** Brute-force top-k within a dataset, nearest first (ascending cosine distance). */
+  async retrieve(datasetId: string, queryEmbedding: number[], k: number = 5): Promise<RetrievedChunk[]> {
+    const rows = await this.db.all(
+      `SELECT chunk_id, dataset_id, source_path, ordinal, text, trust_label,
+              list_cosine_distance(embedding, ${floatList(queryEmbedding)}) AS distance
+       FROM kb_chunks WHERE dataset_id = $1
+       ORDER BY distance ASC LIMIT $2`,
+      [datasetId, Math.max(1, Math.floor(k))],
+    );
+    return rows.map((r) => ({
+      chunk_id: String(r.chunk_id),
+      dataset_id: String(r.dataset_id),
+      source_path: String(r.source_path),
+      ordinal: Number(r.ordinal),
+      text: String(r.text),
+      trust_label: String(r.trust_label),
+      distance: Number(r.distance),
+    }));
+  }
+
+  async chunkCount(datasetId: string): Promise<number> {
+    const r = await this.db.get("SELECT count(*) AS n FROM kb_chunks WHERE dataset_id = $1", [datasetId]);
+    return Number(r?.n ?? 0);
+  }
+}

--- a/harness/knowledge/store.ts
+++ b/harness/knowledge/store.ts
@@ -1,6 +1,6 @@
 // harness/knowledge/store.ts
 //
-// P-RAG.1 (ADR-0054): the local knowledge vector store. Wraps a SEPARATE knowledge.duckdb (its own
+// P-RAG.1 (ADR-0058): the local knowledge vector store. Wraps a SEPARATE knowledge.duckdb (its own
 // migration set, ADR-0053 decision #3) and exposes dataset + chunk CRUD and brute-force cosine
 // retrieval over DuckDB's built-in `list_cosine_distance` — no vss/HNSW extension, so it runs
 // air-gapped (invariant: air-gap clean).

--- a/harness/memory/db.ts
+++ b/harness/memory/db.ts
@@ -10,7 +10,7 @@ import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { DuckDBInstance, type DuckDBConnection } from "@duckdb/node-api";
 
-const MIGRATIONS_DIR = join(import.meta.dir, "migrations");
+export const MIGRATIONS_DIR = join(import.meta.dir, "migrations");
 
 export type Row = Record<string, unknown>;
 export type Params = unknown[] | Record<string, unknown>;
@@ -21,14 +21,14 @@ interface Migration {
   sql: string;
 }
 
-function loadMigrations(): Migration[] {
-  const files = readdirSync(MIGRATIONS_DIR)
+function loadMigrations(dir: string): Migration[] {
+  const files = readdirSync(dir)
     .filter((f) => f.endsWith(".sql"))
     .sort();
   return files.map((f) => {
     const m = /^(\d+)_(.+)\.sql$/.exec(f);
     if (!m) throw new Error(`bad migration filename: ${f} (expected NNNN_name.sql)`);
-    return { version: Number(m[1]), name: m[2]!, sql: readFileSync(join(MIGRATIONS_DIR, f), "utf8") };
+    return { version: Number(m[1]), name: m[2]!, sql: readFileSync(join(dir, f), "utf8") };
   });
 }
 
@@ -47,13 +47,17 @@ export class Db {
   private constructor(
     private readonly instance: DuckDBInstance,
     private readonly conn: DuckDBConnection,
+    private readonly migrationsDir: string,
   ) {}
 
-  /** Open (or create) the database at `path` and apply pending migrations. */
-  static async open(path: string): Promise<Db> {
+  /** Open (or create) the database at `path` and apply pending migrations.
+   *  `migrationsDir` selects the migration set — defaults to the core memory schema;
+   *  a SEPARATE database (e.g. knowledge.duckdb, ADR-0053) passes its own dir so its
+   *  migrations apply only to it and never to agent_obs.duckdb (invariant #10). */
+  static async open(path: string, migrationsDir: string = MIGRATIONS_DIR): Promise<Db> {
     const instance = await DuckDBInstance.create(path);
     const conn = await instance.connect();
-    const db = new Db(instance, conn);
+    const db = new Db(instance, conn, migrationsDir);
     await db.migrate();
     return db;
   }
@@ -65,7 +69,7 @@ export class Db {
   static async openReadOnly(path: string): Promise<Db> {
     const instance = await DuckDBInstance.create(path, { access_mode: "READ_ONLY" });
     const conn = await instance.connect();
-    return new Db(instance, conn);
+    return new Db(instance, conn, MIGRATIONS_DIR);
   }
 
   private async migrate(): Promise<void> {
@@ -79,7 +83,7 @@ export class Db {
     const appliedRows = await this.all("SELECT version FROM schema_migrations");
     const applied = new Set(appliedRows.map((r) => Number(r.version)));
 
-    for (const mig of loadMigrations()) {
+    for (const mig of loadMigrations(this.migrationsDir)) {
       if (applied.has(mig.version)) continue;
       for (const stmt of splitStatements(mig.sql)) {
         await this.conn.run(stmt);

--- a/harness/omp/acp_config.yml
+++ b/harness/omp/acp_config.yml
@@ -21,7 +21,7 @@ task:
   isolation:
     mode: none
 
-# P-EGRESS.1 (ADR-0058): force the network-reaching tools to PROMPT, honored in EVERY approval mode
+# P-EGRESS.1 (ADR-0062): force the network-reaching tools to PROMPT, honored in EVERY approval mode
 # (including omp's default `yolo`, which otherwise auto-runs them). Without this an agent silently browses
 # arbitrary internet sites — a real risk in a security/provenance product. The desktop intercepts these
 # permission requests (acp_backend onRequest) and shows the per-website approval dialog; a standing user

--- a/harness/omp/acp_config.yml
+++ b/harness/omp/acp_config.yml
@@ -20,3 +20,15 @@
 task:
   isolation:
     mode: none
+
+# P-EGRESS.1 (ADR-0058): force the network-reaching tools to PROMPT, honored in EVERY approval mode
+# (including omp's default `yolo`, which otherwise auto-runs them). Without this an agent silently browses
+# arbitrary internet sites — a real risk in a security/provenance product. The desktop intercepts these
+# permission requests (acp_backend onRequest) and shows the per-website approval dialog; a standing user
+# decision (allow-this-site / danger mode) can still auto-allow without prompting.
+tools:
+  approval:
+    browser: prompt
+    web_search: prompt
+    web: prompt
+    fetch: prompt

--- a/harness/omp/asksage_stream.test.ts
+++ b/harness/omp/asksage_stream.test.ts
@@ -136,3 +136,88 @@ describe("AskSage Gemini tool use", () => {
     expect(body.tools).toBeUndefined();
   });
 });
+
+// ── Diagnostics + tolerant extraction (P-ASKSAGE.1, ADR-0055) ────────────────────────────────────────
+// These cover the "gives up too soon" failure mode: a follow-up response whose content we'd otherwise
+// drop (proxy wraps it differently) → empty turn → omp thinks the model finished. Tolerant extraction
+// recovers it; the diagnostics make every call (and the empty-response anomaly) observable.
+function mockResp(opts: { ok?: boolean; status?: number; json: any }, capture?: (url: string, init: any) => void): void {
+  globalThis.fetch = (async (url: any, init: any) => {
+    capture?.(String(url), init);
+    return { ok: opts.ok ?? true, status: opts.status ?? 200, json: async () => opts.json } as any;
+  }) as any;
+}
+/** Run `fn` with LUCID_ASKSAGE_DEBUG on and capture parsed `[ASKSAGE_DIAG]` records from stderr. */
+async function withDiag(fn: () => Promise<void>): Promise<any[]> {
+  const lines: string[] = [];
+  const orig = process.stderr.write.bind(process.stderr);
+  process.env.LUCID_ASKSAGE_DEBUG = "1";
+  (process.stderr as any).write = (s: any) => { lines.push(String(s)); return true; };
+  try { await fn(); } finally { (process.stderr as any).write = orig; delete process.env.LUCID_ASKSAGE_DEBUG; }
+  return lines.filter((l) => l.includes("[ASKSAGE_DIAG]")).map((l) => JSON.parse(l.slice(l.indexOf("{"))));
+}
+
+describe("AskSage diagnostics + tolerant extraction", () => {
+  const google = makeAsksageStream("google", () => cfg);
+  const gemini = { id: "gemini-x", api: "asksage-google", provider: "asksage-google", maxTokens: 1000 };
+
+  test("Anthropic: a `response.content`-wrapped reply is still parsed (not dropped)", async () => {
+    mockResp({ json: { response: { content: [{ type: "text", text: "recovered text" }] }, usage: {} } });
+    const done = (await collect(anthropic(model, { messages: [{ role: "user", content: "x" }] }))).find((e) => e.type === "done");
+    expect(done.message.content).toEqual([{ type: "text", text: "recovered text" }]);
+    expect(done.reason).toBe("stop");
+  });
+
+  test("Anthropic: an OpenAI-chat-shaped reply (choices[].message) recovers text + tool calls", async () => {
+    mockResp({ json: { choices: [{ message: { content: "doing it", tool_calls: [{ id: "c1", function: { name: "write_file", arguments: '{"path":"a.txt"}' } }] } }], usage: {} } });
+    const events = await collect(anthropic(model, { messages: [{ role: "user", content: "x" }], tools: [writeTool] }));
+    const end = events.find((e) => e.type === "toolcall_end");
+    expect(end.toolCall).toEqual({ type: "toolCall", id: "c1", name: "write_file", arguments: { path: "a.txt" } });
+    expect(events.find((e) => e.type === "done").reason).toBe("toolUse");
+  });
+
+  test("Gemini: a `{response: \"...\"}`-wrapped reply is still parsed", async () => {
+    mockResp({ json: { response: "gemini wrapped reply", usageMetadata: {} } });
+    const done = (await collect(google(gemini, { messages: [{ role: "user", content: "x" }] }))).find((e) => e.type === "done");
+    expect(done.message.content).toEqual([{ type: "text", text: "gemini wrapped reply" }]);
+  });
+
+  test("diag is OFF without the env (no [ASKSAGE_DIAG] lines)", async () => {
+    mockResp({ json: { content: [{ type: "text", text: "hi" }], usage: {} } });
+    const lines: string[] = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    (process.stderr as any).write = (s: any) => { lines.push(String(s)); return true; };
+    try { await collect(anthropic(model, { messages: [{ role: "user", content: "x" }] })); } finally { (process.stderr as any).write = orig; }
+    expect(lines.some((l) => l.includes("[ASKSAGE_DIAG]"))).toBe(false);
+  });
+
+  test("diag records the request + parsed response per call (via=content, stopReason)", async () => {
+    const recs = await withDiag(async () => {
+      mockResp({ json: { content: [{ type: "text", text: "ok" }], stop_reason: "end_turn", usage: { input_tokens: 5, output_tokens: 2 } } });
+      await collect(anthropic(model, { messages: [{ role: "user", content: "x" }], tools: [writeTool] }));
+    });
+    expect(recs).toHaveLength(1);
+    expect(recs[0]).toMatchObject({ route: "anthropic", ok: true, via: "content", tools: ["write_file"], textLen: 2 });
+    expect(recs[0].anomaly).toBeUndefined();
+  });
+
+  test("diag flags an empty ok response as the `empty-response` anomaly (the give-up smoking gun)", async () => {
+    const recs = await withDiag(async () => {
+      mockResp({ json: { id: "x", usage: {} } }); // no content, no tool calls → empty turn
+      await collect(anthropic(model, { messages: [{ role: "user", content: "x" }] }));
+    });
+    expect(recs[0].anomaly).toBe("empty-response");
+    expect(recs[0].via).toBe("none");
+    expect(typeof recs[0].raw).toBe("string"); // raw snippet captured for inspection
+  });
+
+  test("diag captures HTTP errors with a raw snippet, and the stream errors", async () => {
+    const recs = await withDiag(async () => {
+      mockResp({ ok: false, status: 502, json: { error: { message: "bad gateway" } } });
+      const events = await collect(google(gemini, { messages: [{ role: "user", content: "x" }] }));
+      expect(events.some((e) => e.type === "error")).toBe(true);
+    });
+    expect(recs[0]).toMatchObject({ route: "google", ok: false, status: 502 });
+    expect(recs[0].error).toContain("bad gateway");
+  });
+});

--- a/harness/omp/asksage_stream.test.ts
+++ b/harness/omp/asksage_stream.test.ts
@@ -237,3 +237,61 @@ describe("AskSage diagnostics + tolerant extraction", () => {
     expect(events.some((e) => e.type === "error")).toBe(false); // a deliberate cancel is not an error
   });
 });
+
+// ── Transient-failure resilience (P-RESIL.1, ADR-0057) ───────────────────────────────────────────────
+// A queued mock: returns the next response per fetch call (last one repeats), and reports the call count.
+function mockSeq(responses: Array<{ ok?: boolean; status?: number; json: any }>): () => number {
+  let i = 0;
+  globalThis.fetch = (async () => {
+    const r = responses[Math.min(i, responses.length - 1)]!;
+    i++;
+    return { ok: r.ok ?? true, status: r.status ?? 200, json: async () => r.json } as any;
+  }) as any;
+  return () => i;
+}
+
+describe("AskSage transient-failure resilience", () => {
+  const google = makeAsksageStream("google", () => cfg);
+  const gemini = { id: "gemini-x", api: "asksage-google", provider: "asksage-google", maxTokens: 1000 };
+
+  test("Gemini: a 504 then success retries and succeeds (no wasted turn)", async () => {
+    const calls = mockSeq([
+      { ok: false, status: 504, json: { error: { message: "gateway timeout" } } },
+      { json: { candidates: [{ content: { parts: [{ text: "recovered after retry" }] }, finishReason: "STOP" }], usageMetadata: {} } },
+    ]);
+    const done = (await collect(google(gemini, { messages: [{ role: "user", content: "x" }] }))).find((e) => e.type === "done");
+    expect(calls()).toBe(2); // retried once
+    expect(done.message.content).toEqual([{ type: "text", text: "recovered after retry" }]);
+  });
+
+  test("Gemini: MALFORMED_FUNCTION_CALL then a valid tool call retries and recovers", async () => {
+    const calls = mockSeq([
+      { json: { candidates: [{ content: {}, finishReason: "MALFORMED_FUNCTION_CALL" }], usageMetadata: {} } },
+      { json: { candidates: [{ content: { parts: [{ functionCall: { name: "write_file", args: { path: "a.txt" } } }] }, finishReason: "STOP" }], usageMetadata: {} } },
+    ]);
+    const events = await collect(google(gemini, { messages: [{ role: "user", content: "x" }], tools: [writeTool] }));
+    expect(calls()).toBe(2);
+    const end = events.find((e) => e.type === "toolcall_end");
+    expect(end.toolCall.name).toBe("write_file");
+  });
+
+  test("Gemini: a persistent 504 gives up after MAX_ATTEMPTS (3) and errors", async () => {
+    const calls = mockSeq([{ ok: false, status: 504, json: { error: { message: "down" } } }]);
+    const events = await collect(google(gemini, { messages: [{ role: "user", content: "x" }] }));
+    expect(calls()).toBe(3); // 1 + 2 retries
+    expect(events.some((e) => e.type === "error")).toBe(true);
+  });
+
+  test("a client error (400) is NOT retried", async () => {
+    const calls = mockSeq([{ ok: false, status: 400, json: { error: { message: "bad request" } } }]);
+    const events = await collect(google(gemini, { messages: [{ role: "user", content: "x" }] }));
+    expect(calls()).toBe(1); // no retry on 4xx
+    expect(events.some((e) => e.type === "error")).toBe(true);
+  });
+
+  test("a first-try success makes exactly one request (no needless retry)", async () => {
+    const calls = mockSeq([{ json: { candidates: [{ content: { parts: [{ text: "ok" }] }, finishReason: "STOP" }], usageMetadata: {} } }]);
+    await collect(google(gemini, { messages: [{ role: "user", content: "x" }] }));
+    expect(calls()).toBe(1);
+  });
+});

--- a/harness/omp/asksage_stream.test.ts
+++ b/harness/omp/asksage_stream.test.ts
@@ -220,4 +220,20 @@ describe("AskSage diagnostics + tolerant extraction", () => {
     expect(recs[0]).toMatchObject({ route: "google", ok: false, status: 502 });
     expect(recs[0].error).toContain("bad gateway");
   });
+
+  test("Stop: an aborted signal cancels the fetch and settles cleanly (done/stop, no error)", async () => {
+    // fetch that rejects with an AbortError when the passed signal aborts (mirrors real fetch on abort).
+    globalThis.fetch = ((_url: any, init: any) => new Promise((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () => { const e: any = new Error("aborted"); e.name = "AbortError"; reject(e); });
+    })) as any;
+    const ctrl = new AbortController();
+    const events: any[] = [];
+    const drain = (async () => { for await (const ev of anthropic(model, { messages: [{ role: "user", content: "x" }] }, { signal: ctrl.signal })) events.push(ev); })();
+    ctrl.abort(); // user presses Stop
+    await drain;
+    const done = events.find((e) => e.type === "done");
+    expect(done).toBeDefined();
+    expect(done.reason).toBe("stop");
+    expect(events.some((e) => e.type === "error")).toBe(false); // a deliberate cancel is not an error
+  });
 });

--- a/harness/omp/asksage_stream.test.ts
+++ b/harness/omp/asksage_stream.test.ts
@@ -137,7 +137,7 @@ describe("AskSage Gemini tool use", () => {
   });
 });
 
-// ── Diagnostics + tolerant extraction (P-ASKSAGE.1, ADR-0055) ────────────────────────────────────────
+// ── Diagnostics + tolerant extraction (P-ASKSAGE.1, ADR-0059) ────────────────────────────────────────
 // These cover the "gives up too soon" failure mode: a follow-up response whose content we'd otherwise
 // drop (proxy wraps it differently) → empty turn → omp thinks the model finished. Tolerant extraction
 // recovers it; the diagnostics make every call (and the empty-response anomaly) observable.
@@ -238,7 +238,7 @@ describe("AskSage diagnostics + tolerant extraction", () => {
   });
 });
 
-// ── Transient-failure resilience (P-RESIL.1, ADR-0057) ───────────────────────────────────────────────
+// ── Transient-failure resilience (P-RESIL.1, ADR-0061) ───────────────────────────────────────────────
 // A queued mock: returns the next response per fetch call (last one repeats), and reports the call count.
 function mockSeq(responses: Array<{ ok?: boolean; status?: number; json: any }>): () => number {
   let i = 0;

--- a/harness/omp/asksage_stream.ts
+++ b/harness/omp/asksage_stream.ts
@@ -20,7 +20,7 @@ export interface AsksageStreamCfg { base: string; key: string }
 
 const isRecord = (v: unknown): v is Record<string, unknown> => !!v && typeof v === "object" && !Array.isArray(v);
 
-// ── Diagnostics (P-ASKSAGE.1, ADR-0055) ─────────────────────────────────────────────────────────────
+// ── Diagnostics (P-ASKSAGE.1, ADR-0059) ─────────────────────────────────────────────────────────────
 // AskSage serves Claude/Gemini NON-streamed, so each streamSimple call is one HTTP round-trip = one
 // assistant turn; omp drives the agentic loop. When that loop "gives up too soon" (tools run, files end
 // up half-written, no retry), the usual cause is invisible: a follow-up response we parse to EMPTY text
@@ -41,7 +41,7 @@ function safeJsonArgs(v: unknown): Record<string, any> {
   return {};
 }
 
-// ── Transient-failure resilience (P-RESIL.1, ADR-0057) ───────────────────────────────────────────────
+// ── Transient-failure resilience (P-RESIL.1, ADR-0061) ───────────────────────────────────────────────
 // The gov gateway intermittently 504s, and Gemini sometimes returns finishReason MALFORMED_FUNCTION_CALL
 // with an EMPTY body — both burned a whole turn (and 100k-200k input tokens) for zero output. We retry
 // these transient outcomes a few times with short backoff before giving up, so the agent loop doesn't
@@ -173,7 +173,7 @@ interface AnthropicResult extends RouteResult { toolCalls: OmpToolCall[]; stopRe
 // Locate the Anthropic content blocks TOLERANTLY. The standard reply is `{ content: [...] }` (verified
 // live for text), but a proxy may wrap it. Fallbacks can only RECOVER content the strict parse would
 // drop (they fire only when `content` is absent), and `via` records which shape actually matched so a
-// live test reveals the real wire format instead of silently emitting an empty turn. ADR-0055.
+// live test reveals the real wire format instead of silently emitting an empty turn. ADR-0059.
 function anthropicBlocks(j: any): { blocks: any[]; via: string } {
   if (Array.isArray(j?.content)) return { blocks: j.content, via: "content" };
   if (Array.isArray(j?.response?.content)) return { blocks: j.response.content, via: "response.content" };
@@ -295,7 +295,7 @@ interface GoogleResult extends RouteResult { toolCalls: OmpToolCall[]; stopReaso
 // Google) for real Gemini models. Gemini gives no call id, so we mint a synthetic one (omp tracks the
 // call→result mapping internally and replays the result back by NAME).
 // Locate the Gemini parts TOLERANTLY (mirrors anthropicBlocks). Standard shape is
-// candidates[0].content.parts; `via` records what matched so a live test reveals the real format. ADR-0055.
+// candidates[0].content.parts; `via` records what matched so a live test reveals the real format. ADR-0059.
 function googleParts(j: any): { parts: any[]; via: string } {
   const std = j?.candidates?.[0]?.content?.parts;
   if (Array.isArray(std)) return { parts: std, via: "candidates" };
@@ -367,7 +367,7 @@ export function makeAsksageStream(route: AsksageRoute, getCfg: () => AsksageStre
       const cfg = getCfg();
       // omp passes an AbortSignal and aborts it on session/cancel (Stop). AskSage is non-streamed — one
       // long fetch per turn — so WITHOUT threading this the request kept running after Stop and the turn
-      // hung. Wire it into every fetch and settle cleanly on abort (ADR-0055).
+      // hung. Wire it into every fetch and settle cleanly on abort (ADR-0059).
       const signal: AbortSignal | undefined = options?.signal;
       const { system, messages } = toTurns(context);
       const usageOf = (u: { input: number; output: number; cacheRead: number; cacheWrite: number }) => ({ ...u, totalTokens: u.input + u.output + u.cacheRead + u.cacheWrite });

--- a/harness/omp/asksage_stream.ts
+++ b/harness/omp/asksage_stream.ts
@@ -175,7 +175,7 @@ function anthropicBlocks(j: any): { blocks: any[]; via: string } {
 // Call AskSage's Anthropic Messages route WITH tool support: pass the tool definitions, and parse both
 // text and `tool_use` content blocks from the reply so omp can execute the calls and loop (previously
 // tools were dropped, so Claude emitted tool-call XML as plain text and nothing ran).
-async function callAnthropic(cfg: AsksageStreamCfg, model: string, system: string, messages: AnthropicMsg[], tools: any[] | undefined, maxTokens: number): Promise<AnthropicResult> {
+async function callAnthropic(cfg: AsksageStreamCfg, model: string, system: string, messages: AnthropicMsg[], tools: any[] | undefined, maxTokens: number, signal?: AbortSignal): Promise<AnthropicResult> {
   const body: any = { model, max_tokens: maxTokens, ...(system ? { system } : {}), messages };
   const toolNames = Array.isArray(tools) ? tools.map((t) => t?.name) : [];
   if (Array.isArray(tools) && tools.length) {
@@ -184,7 +184,7 @@ async function callAnthropic(cfg: AsksageStreamCfg, model: string, system: strin
   const reqDiag = { route: "anthropic", model, maxTokens, tools: toolNames, msgs: messages.length };
   let r: Response;
   try {
-    r = await fetch(`${cfg.base}/anthropic/v1/messages`, { method: "POST", headers: jsonHeaders(cfg.key, { "anthropic-version": "2023-06-01" }), body: JSON.stringify(body) });
+    r = await fetch(`${cfg.base}/anthropic/v1/messages`, { method: "POST", headers: jsonHeaders(cfg.key, { "anthropic-version": "2023-06-01" }), body: JSON.stringify(body), signal });
   } catch (e) {
     diag({ ...reqDiag, ok: false, error: `fetch failed: ${String((e as Error)?.message ?? e)}` });
     throw e;
@@ -230,7 +230,7 @@ function splitReferences(message: string): { body: string; refs: string[] } {
 // AskSage's native /query route: a single `message`, with optional RAG grounding
 // on `dataset` and a native `persona` id. One-shot (non-streamed). Underlying model
 // + datasets + persona come from env (set by the desktop from the user's selection).
-async function callQuery(cfg: AsksageStreamCfg, system: string, msgs: { role: string; text: string }[]): Promise<RouteResult & { references?: string }> {
+async function callQuery(cfg: AsksageStreamCfg, system: string, msgs: { role: string; text: string }[], signal?: AbortSignal): Promise<RouteResult & { references?: string }> {
   const model = process.env.ASKSAGE_QUERY_MODEL || "gpt-5.2";
   const datasets = (process.env.ASKSAGE_DATASETS || "").split(",").map((d) => d.trim()).filter(Boolean);
   const persona = Number(process.env.ASKSAGE_PERSONA || "") || undefined;
@@ -239,7 +239,7 @@ async function callQuery(cfg: AsksageStreamCfg, system: string, msgs: { role: st
   const body: any = { message, model, temperature: 0.0, limit_references: 5 };
   if (datasets.length) body.dataset = datasets;
   if (persona) body.persona = persona;
-  const r = await fetch(`${cfg.base}/query`, { method: "POST", headers: jsonHeaders(cfg.key), body: JSON.stringify(body) });
+  const r = await fetch(`${cfg.base}/query`, { method: "POST", headers: jsonHeaders(cfg.key), body: JSON.stringify(body), signal });
   const j: any = await r.json().catch(() => ({}));
   if (!r.ok) { diag({ route: "query", model, status: r.status, ok: false, error: j?.error ?? j?.message ?? `HTTP ${r.status}`, raw: snippet(j) }); throw new Error(j?.error ?? j?.message ?? `AskSage query HTTP ${r.status}`); }
   const raw = String(j?.message ?? j?.response ?? "").trim();
@@ -278,7 +278,7 @@ function googleParts(j: any): { parts: any[]; via: string } {
   return { parts: [], via: "none" };
 }
 
-async function callGoogle(cfg: AsksageStreamCfg, model: string, system: string, contents: GoogleContent[], tools: any[] | undefined, maxTokens: number): Promise<GoogleResult> {
+async function callGoogle(cfg: AsksageStreamCfg, model: string, system: string, contents: GoogleContent[], tools: any[] | undefined, maxTokens: number, signal?: AbortSignal): Promise<GoogleResult> {
   const body: any = { contents, ...(system ? { systemInstruction: { parts: [{ text: system }] } } : {}), generationConfig: { maxOutputTokens: maxTokens } };
   const toolNames = Array.isArray(tools) ? tools.map((t) => t?.name) : [];
   if (Array.isArray(tools) && tools.length) {
@@ -287,7 +287,7 @@ async function callGoogle(cfg: AsksageStreamCfg, model: string, system: string, 
   const reqDiag = { route: "google", model, maxTokens, tools: toolNames, msgs: contents.length };
   let r: Response;
   try {
-    r = await fetch(`${cfg.base}/google/v1beta/models/${model}:generateContent`, { method: "POST", headers: jsonHeaders(cfg.key), body: JSON.stringify(body) });
+    r = await fetch(`${cfg.base}/google/v1beta/models/${model}:generateContent`, { method: "POST", headers: jsonHeaders(cfg.key), body: JSON.stringify(body), signal });
   } catch (e) {
     diag({ ...reqDiag, ok: false, error: `fetch failed: ${String((e as Error)?.message ?? e)}` });
     throw e;
@@ -314,10 +314,14 @@ async function callGoogle(cfg: AsksageStreamCfg, model: string, system: string, 
 /** Build a streamSimple bound to a route. `getCfg` is read lazily so a key/base
  *  change (without a respawn) is still picked up. */
 export function makeAsksageStream(route: AsksageRoute, getCfg: () => AsksageStreamCfg) {
-  return function streamSimple(model: any, context: any, _options?: any): AssistantMessageEventStream {
+  return function streamSimple(model: any, context: any, options?: any): AssistantMessageEventStream {
     const stream = new AssistantMessageEventStream();
     void (async () => {
       const cfg = getCfg();
+      // omp passes an AbortSignal and aborts it on session/cancel (Stop). AskSage is non-streamed — one
+      // long fetch per turn — so WITHOUT threading this the request kept running after Stop and the turn
+      // hung. Wire it into every fetch and settle cleanly on abort (ADR-0055).
+      const signal: AbortSignal | undefined = options?.signal;
       const { system, messages } = toTurns(context);
       const usageOf = (u: { input: number; output: number; cacheRead: number; cacheWrite: number }) => ({ ...u, totalTokens: u.input + u.output + u.cacheRead + u.cacheWrite });
       const mkMessage = (content: any[], stopReason: string, usage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }): any => ({
@@ -357,20 +361,26 @@ export function makeAsksageStream(route: AsksageRoute, getCfg: () => AsksageStre
         const maxTokens = Number(model?.maxTokens) || 8192;
         if (route === "anthropic") {
           const { system: sys, messages: amsgs } = toAnthropicMessages(context);
-          const res = await callAnthropic(cfg, model.id, sys, amsgs, context?.tools, maxTokens);
+          const res = await callAnthropic(cfg, model.id, sys, amsgs, context?.tools, maxTokens, signal);
           emit(res.text, res.toolCalls, res.stopReason === "length" ? "length" : "stop", res.usage);
           return;
         }
         if (route === "google") {
           const { system: sys, contents } = toGoogleContents(context);
-          const res = await callGoogle(cfg, model.id, sys, contents, context?.tools, maxTokens);
+          const res = await callGoogle(cfg, model.id, sys, contents, context?.tools, maxTokens, signal);
           emit(res.text, res.toolCalls, res.stopReason === "length" ? "length" : "stop", res.usage);
           return;
         }
         // RAG /query: single-message, text-only (no tool use).
-        const { text, usage } = await callQuery(cfg, system, messages);
+        const { text, usage } = await callQuery(cfg, system, messages, signal);
         emit(text, [], "stop", usage);
       } catch (e) {
+        // Stop pressed → omp aborts the signal → fetch throws AbortError. Settle the turn cleanly (a
+        // plain stop), NOT an error, so the UI doesn't flash a failure toast for a deliberate cancel.
+        if (signal?.aborted || (e as any)?.name === "AbortError") {
+          emit("", [], "stop", { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+          return;
+        }
         const errMessage = mkMessage([], "error");
         errMessage.errorMessage = String((e as Error)?.message ?? e);
         stream.push({ type: "error", reason: "error", error: errMessage });

--- a/harness/omp/asksage_stream.ts
+++ b/harness/omp/asksage_stream.ts
@@ -202,7 +202,9 @@ async function callAnthropic(cfg: AsksageStreamCfg, model: string, system: strin
   const stopReason: AnthropicResult["stopReason"] = j?.stop_reason === "tool_use" || toolCalls.length ? "toolUse" : j?.stop_reason === "max_tokens" ? "length" : "stop";
   const u = j?.usage ?? {};
   const anomaly = (!text && !toolCalls.length) ? "empty-response" : stopReason === "length" ? "truncated" : undefined;
-  diag({ ...reqDiag, status: r.status, ok: true, respKeys: Object.keys(j ?? {}), via, textLen: text.length, toolCalls: toolCalls.map((t) => t.name), stopReason: j?.stop_reason ?? stopReason, usage: { in: u.input_tokens ?? 0, out: u.output_tokens ?? 0 }, ...(anomaly ? { anomaly, raw: snippet(j) } : {}) });
+  // Log the MAPPED stopReason (what actually drives omp's loop: toolUse = continue) plus the raw provider
+  // finish, so a tool-calling row reads "toolUse", not the bare provider value.
+  diag({ ...reqDiag, status: r.status, ok: true, respKeys: Object.keys(j ?? {}), via, textLen: text.length, toolCalls: toolCalls.map((t) => t.name), stopReason, finish: j?.stop_reason, usage: { in: u.input_tokens ?? 0, out: u.output_tokens ?? 0 }, ...(anomaly ? { anomaly, raw: snippet(j) } : {}) });
   return { text, toolCalls, stopReason, usage: { input: u.input_tokens ?? 0, output: u.output_tokens ?? 0, cacheRead: u.cache_read_input_tokens ?? 0, cacheWrite: u.cache_creation_input_tokens ?? 0 } };
 }
 
@@ -307,7 +309,9 @@ async function callGoogle(cfg: AsksageStreamCfg, model: string, system: string, 
   const stopReason: GoogleResult["stopReason"] = toolCalls.length ? "toolUse" : finish === "MAX_TOKENS" ? "length" : "stop";
   const um = j?.usageMetadata ?? {};
   const anomaly = (!text && !toolCalls.length) ? "empty-response" : stopReason === "length" ? "truncated" : undefined;
-  diag({ ...reqDiag, status: r.status, ok: true, respKeys: Object.keys(j ?? {}), via, textLen: text.length, toolCalls: toolCalls.map((t) => t.name), stopReason: finish ?? stopReason, usage: { in: um.promptTokenCount ?? 0, out: um.candidatesTokenCount ?? 0 }, ...(anomaly ? { anomaly, raw: snippet(j) } : {}) });
+  // Gemini always reports finishReason "STOP" even when it emits a functionCall; log the MAPPED reason
+  // (toolUse = the loop continues) plus the raw finish, so a tool-calling row reads "toolUse", not "STOP".
+  diag({ ...reqDiag, status: r.status, ok: true, respKeys: Object.keys(j ?? {}), via, textLen: text.length, toolCalls: toolCalls.map((t) => t.name), stopReason, finish, usage: { in: um.promptTokenCount ?? 0, out: um.candidatesTokenCount ?? 0 }, ...(anomaly ? { anomaly, raw: snippet(j) } : {}) });
   return { text, toolCalls, stopReason, usage: { input: um.promptTokenCount ?? 0, output: um.candidatesTokenCount ?? 0, cacheRead: 0, cacheWrite: 0 } };
 }
 

--- a/harness/omp/asksage_stream.ts
+++ b/harness/omp/asksage_stream.ts
@@ -20,6 +20,27 @@ export interface AsksageStreamCfg { base: string; key: string }
 
 const isRecord = (v: unknown): v is Record<string, unknown> => !!v && typeof v === "object" && !Array.isArray(v);
 
+// ── Diagnostics (P-ASKSAGE.1, ADR-0055) ─────────────────────────────────────────────────────────────
+// AskSage serves Claude/Gemini NON-streamed, so each streamSimple call is one HTTP round-trip = one
+// assistant turn; omp drives the agentic loop. When that loop "gives up too soon" (tools run, files end
+// up half-written, no retry), the usual cause is invisible: a follow-up response we parse to EMPTY text
+// + ZERO tool calls makes omp think the model finished. These diagnostics make every call observable.
+// Enabled by env LUCID_ASKSAGE_DEBUG (the desktop sets it in developer mode). One `[ASKSAGE_DIAG] {json}`
+// line per call to stderr; acp_backend's onStderr captures it into the developer Logs panel.
+function diag(rec: Record<string, unknown>): void {
+  if (!process.env.LUCID_ASKSAGE_DEBUG) return;
+  try { process.stderr.write(`[ASKSAGE_DIAG] ${JSON.stringify(rec)}\n`); } catch { /* never let logging break a turn */ }
+}
+/** A short, safe snippet of a raw response for the anomaly/error log (never the whole body). */
+function snippet(j: unknown): string {
+  try { return JSON.stringify(j).slice(0, 600); } catch { return String(j).slice(0, 600); }
+}
+function safeJsonArgs(v: unknown): Record<string, any> {
+  if (isRecord(v)) return v;
+  if (typeof v === "string") { try { const p = JSON.parse(v); return isRecord(p) ? p : {}; } catch { return {}; } }
+  return {};
+}
+
 // omp ToolCall content block (the shape omp's agent loop executes + the gate scans).
 interface OmpToolCall { type: "toolCall"; id: string; name: string; arguments: Record<string, any> }
 
@@ -129,28 +150,59 @@ const jsonHeaders = (key: string, extra: Record<string, string> = {}) => ({
 interface RouteResult { text: string; usage: { input: number; output: number; cacheRead: number; cacheWrite: number } }
 interface AnthropicResult extends RouteResult { toolCalls: OmpToolCall[]; stopReason: "stop" | "length" | "toolUse" }
 
+// Locate the Anthropic content blocks TOLERANTLY. The standard reply is `{ content: [...] }` (verified
+// live for text), but a proxy may wrap it. Fallbacks can only RECOVER content the strict parse would
+// drop (they fire only when `content` is absent), and `via` records which shape actually matched so a
+// live test reveals the real wire format instead of silently emitting an empty turn. ADR-0055.
+function anthropicBlocks(j: any): { blocks: any[]; via: string } {
+  if (Array.isArray(j?.content)) return { blocks: j.content, via: "content" };
+  if (Array.isArray(j?.response?.content)) return { blocks: j.response.content, via: "response.content" };
+  if (Array.isArray(j?.message?.content)) return { blocks: j.message.content, via: "message.content" };
+  // Some gateways normalize everything to the OpenAI chat shape.
+  const choice = j?.choices?.[0]?.message;
+  if (isRecord(choice)) {
+    const b: any[] = [];
+    if (typeof choice.content === "string" && choice.content) b.push({ type: "text", text: choice.content });
+    for (const tc of (Array.isArray(choice.tool_calls) ? choice.tool_calls : [])) b.push({ type: "tool_use", id: (tc as any)?.id, name: (tc as any)?.function?.name, input: safeJsonArgs((tc as any)?.function?.arguments) });
+    if (b.length) return { blocks: b, via: "openai-choices" };
+  }
+  for (const k of ["response", "message", "completion", "text", "answer"]) {
+    if (typeof j?.[k] === "string" && j[k].trim()) return { blocks: [{ type: "text", text: j[k] }], via: `string:${k}` };
+  }
+  return { blocks: [], via: "none" };
+}
+
 // Call AskSage's Anthropic Messages route WITH tool support: pass the tool definitions, and parse both
 // text and `tool_use` content blocks from the reply so omp can execute the calls and loop (previously
 // tools were dropped, so Claude emitted tool-call XML as plain text and nothing ran).
 async function callAnthropic(cfg: AsksageStreamCfg, model: string, system: string, messages: AnthropicMsg[], tools: any[] | undefined, maxTokens: number): Promise<AnthropicResult> {
   const body: any = { model, max_tokens: maxTokens, ...(system ? { system } : {}), messages };
+  const toolNames = Array.isArray(tools) ? tools.map((t) => t?.name) : [];
   if (Array.isArray(tools) && tools.length) {
     body.tools = tools.map((t) => ({ name: t.name, description: t.description ?? "", input_schema: toolInputSchema(t) }));
   }
-  const r = await fetch(`${cfg.base}/anthropic/v1/messages`, {
-    method: "POST",
-    headers: jsonHeaders(cfg.key, { "anthropic-version": "2023-06-01" }),
-    body: JSON.stringify(body),
-  });
+  const reqDiag = { route: "anthropic", model, maxTokens, tools: toolNames, msgs: messages.length };
+  let r: Response;
+  try {
+    r = await fetch(`${cfg.base}/anthropic/v1/messages`, { method: "POST", headers: jsonHeaders(cfg.key, { "anthropic-version": "2023-06-01" }), body: JSON.stringify(body) });
+  } catch (e) {
+    diag({ ...reqDiag, ok: false, error: `fetch failed: ${String((e as Error)?.message ?? e)}` });
+    throw e;
+  }
   const j: any = await r.json().catch(() => ({}));
-  if (!r.ok) throw new Error(j?.error?.message ?? `AskSage anthropic HTTP ${r.status}`);
-  const content: any[] = Array.isArray(j?.content) ? j.content : [];
+  if (!r.ok) {
+    diag({ ...reqDiag, status: r.status, ok: false, error: j?.error?.message ?? `HTTP ${r.status}`, raw: snippet(j) });
+    throw new Error(j?.error?.message ?? `AskSage anthropic HTTP ${r.status}`);
+  }
+  const { blocks: content, via } = anthropicBlocks(j);
   const text = content.filter((c) => c?.type === "text" && typeof c.text === "string").map((c) => c.text).join("");
   const toolCalls: OmpToolCall[] = content
     .filter((c) => c?.type === "tool_use")
     .map((c) => ({ type: "toolCall", id: String(c.id ?? ""), name: String(c.name ?? ""), arguments: isRecord(c.input) ? c.input : {} }));
   const stopReason: AnthropicResult["stopReason"] = j?.stop_reason === "tool_use" || toolCalls.length ? "toolUse" : j?.stop_reason === "max_tokens" ? "length" : "stop";
   const u = j?.usage ?? {};
+  const anomaly = (!text && !toolCalls.length) ? "empty-response" : stopReason === "length" ? "truncated" : undefined;
+  diag({ ...reqDiag, status: r.status, ok: true, respKeys: Object.keys(j ?? {}), via, textLen: text.length, toolCalls: toolCalls.map((t) => t.name), stopReason: j?.stop_reason ?? stopReason, usage: { in: u.input_tokens ?? 0, out: u.output_tokens ?? 0 }, ...(anomaly ? { anomaly, raw: snippet(j) } : {}) });
   return { text, toolCalls, stopReason, usage: { input: u.input_tokens ?? 0, output: u.output_tokens ?? 0, cacheRead: u.cache_read_input_tokens ?? 0, cacheWrite: u.cache_creation_input_tokens ?? 0 } };
 }
 
@@ -189,7 +241,7 @@ async function callQuery(cfg: AsksageStreamCfg, system: string, msgs: { role: st
   if (persona) body.persona = persona;
   const r = await fetch(`${cfg.base}/query`, { method: "POST", headers: jsonHeaders(cfg.key), body: JSON.stringify(body) });
   const j: any = await r.json().catch(() => ({}));
-  if (!r.ok) throw new Error(j?.error ?? j?.message ?? `AskSage query HTTP ${r.status}`);
+  if (!r.ok) { diag({ route: "query", model, status: r.status, ok: false, error: j?.error ?? j?.message ?? `HTTP ${r.status}`, raw: snippet(j) }); throw new Error(j?.error ?? j?.message ?? `AskSage query HTTP ${r.status}`); }
   const raw = String(j?.message ?? j?.response ?? "").trim();
   const { body: answer, refs } = splitReferences(raw);
   // Prefer the datasets AskSage reports it actually grounded on (provenance) over what we asked for.
@@ -213,26 +265,49 @@ interface GoogleResult extends RouteResult { toolCalls: OmpToolCall[]; stopReaso
 // Mirrors omp's native Google provider — `parametersJsonSchema` (full JSON Schema, normalized for
 // Google) for real Gemini models. Gemini gives no call id, so we mint a synthetic one (omp tracks the
 // call→result mapping internally and replays the result back by NAME).
+// Locate the Gemini parts TOLERANTLY (mirrors anthropicBlocks). Standard shape is
+// candidates[0].content.parts; `via` records what matched so a live test reveals the real format. ADR-0055.
+function googleParts(j: any): { parts: any[]; via: string } {
+  const std = j?.candidates?.[0]?.content?.parts;
+  if (Array.isArray(std)) return { parts: std, via: "candidates" };
+  if (Array.isArray(j?.content?.parts)) return { parts: j.content.parts, via: "content.parts" };
+  if (Array.isArray(j?.parts)) return { parts: j.parts, via: "parts" };
+  for (const k of ["response", "message", "text", "answer"]) {
+    if (typeof j?.[k] === "string" && j[k].trim()) return { parts: [{ text: j[k] }], via: `string:${k}` };
+  }
+  return { parts: [], via: "none" };
+}
+
 async function callGoogle(cfg: AsksageStreamCfg, model: string, system: string, contents: GoogleContent[], tools: any[] | undefined, maxTokens: number): Promise<GoogleResult> {
   const body: any = { contents, ...(system ? { systemInstruction: { parts: [{ text: system }] } } : {}), generationConfig: { maxOutputTokens: maxTokens } };
+  const toolNames = Array.isArray(tools) ? tools.map((t) => t?.name) : [];
   if (Array.isArray(tools) && tools.length) {
     body.tools = [{ functionDeclarations: tools.map((t) => ({ name: t.name, description: t.description ?? "", parametersJsonSchema: normalizeSchemaForGoogle(toolWireSchema(t)) })) }];
   }
-  const r = await fetch(`${cfg.base}/google/v1beta/models/${model}:generateContent`, {
-    method: "POST",
-    headers: jsonHeaders(cfg.key),
-    body: JSON.stringify(body),
-  });
+  const reqDiag = { route: "google", model, maxTokens, tools: toolNames, msgs: contents.length };
+  let r: Response;
+  try {
+    r = await fetch(`${cfg.base}/google/v1beta/models/${model}:generateContent`, { method: "POST", headers: jsonHeaders(cfg.key), body: JSON.stringify(body) });
+  } catch (e) {
+    diag({ ...reqDiag, ok: false, error: `fetch failed: ${String((e as Error)?.message ?? e)}` });
+    throw e;
+  }
   const j: any = await r.json().catch(() => ({}));
-  if (!r.ok) throw new Error(j?.error?.message ?? `AskSage google HTTP ${r.status}`);
-  const parts: any[] = j?.candidates?.[0]?.content?.parts ?? [];
+  if (!r.ok) {
+    diag({ ...reqDiag, status: r.status, ok: false, error: j?.error?.message ?? `HTTP ${r.status}`, raw: snippet(j) });
+    throw new Error(j?.error?.message ?? `AskSage google HTTP ${r.status}`);
+  }
+  const { parts, via } = googleParts(j);
   const text = parts.filter((p) => typeof p?.text === "string").map((p) => p.text).join("");
   let n = 0;
   const toolCalls: OmpToolCall[] = parts
     .filter((p) => p?.functionCall)
     .map((p) => ({ type: "toolCall", id: `${p.functionCall.name || "tool"}-${n++}`, name: String(p.functionCall.name ?? ""), arguments: isRecord(p.functionCall.args) ? p.functionCall.args : {} }));
-  const stopReason: GoogleResult["stopReason"] = toolCalls.length ? "toolUse" : j?.candidates?.[0]?.finishReason === "MAX_TOKENS" ? "length" : "stop";
+  const finish = j?.candidates?.[0]?.finishReason;
+  const stopReason: GoogleResult["stopReason"] = toolCalls.length ? "toolUse" : finish === "MAX_TOKENS" ? "length" : "stop";
   const um = j?.usageMetadata ?? {};
+  const anomaly = (!text && !toolCalls.length) ? "empty-response" : stopReason === "length" ? "truncated" : undefined;
+  diag({ ...reqDiag, status: r.status, ok: true, respKeys: Object.keys(j ?? {}), via, textLen: text.length, toolCalls: toolCalls.map((t) => t.name), stopReason: finish ?? stopReason, usage: { in: um.promptTokenCount ?? 0, out: um.candidatesTokenCount ?? 0 }, ...(anomaly ? { anomaly, raw: snippet(j) } : {}) });
   return { text, toolCalls, stopReason, usage: { input: um.promptTokenCount ?? 0, output: um.candidatesTokenCount ?? 0, cacheRead: 0, cacheWrite: 0 } };
 }
 

--- a/harness/omp/asksage_stream.ts
+++ b/harness/omp/asksage_stream.ts
@@ -41,6 +41,26 @@ function safeJsonArgs(v: unknown): Record<string, any> {
   return {};
 }
 
+// ── Transient-failure resilience (P-RESIL.1, ADR-0057) ───────────────────────────────────────────────
+// The gov gateway intermittently 504s, and Gemini sometimes returns finishReason MALFORMED_FUNCTION_CALL
+// with an EMPTY body — both burned a whole turn (and 100k-200k input tokens) for zero output. We retry
+// these transient outcomes a few times with short backoff before giving up, so the agent loop doesn't
+// waste a turn on a glitch. Retries are abort-aware (Stop cancels mid-backoff) and logged.
+const MAX_ATTEMPTS = 3;
+const BACKOFF_MS = [800, 2000]; // between attempt 1→2, 2→3
+/** True for HTTP statuses worth retrying (gateway/overload/rate-limit), not client errors. */
+function retriableStatus(status: number): boolean {
+  return status === 429 || (status >= 500 && status <= 599);
+}
+/** Sleep `ms`, rejecting immediately if `signal` aborts (so Stop doesn't wait out the backoff). */
+function backoff(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) { reject(new DOMException("aborted", "AbortError")); return; }
+    const t = setTimeout(resolve, ms);
+    signal?.addEventListener("abort", () => { clearTimeout(t); reject(new DOMException("aborted", "AbortError")); }, { once: true });
+  });
+}
+
 // omp ToolCall content block (the shape omp's agent loop executes + the gate scans).
 interface OmpToolCall { type: "toolCall"; id: string; name: string; arguments: Record<string, any> }
 
@@ -183,16 +203,23 @@ async function callAnthropic(cfg: AsksageStreamCfg, model: string, system: strin
   }
   const reqDiag = { route: "anthropic", model, maxTokens, tools: toolNames, msgs: messages.length };
   let r: Response;
-  try {
-    r = await fetch(`${cfg.base}/anthropic/v1/messages`, { method: "POST", headers: jsonHeaders(cfg.key, { "anthropic-version": "2023-06-01" }), body: JSON.stringify(body), signal });
-  } catch (e) {
-    diag({ ...reqDiag, ok: false, error: `fetch failed: ${String((e as Error)?.message ?? e)}` });
-    throw e;
-  }
-  const j: any = await r.json().catch(() => ({}));
-  if (!r.ok) {
-    diag({ ...reqDiag, status: r.status, ok: false, error: j?.error?.message ?? `HTTP ${r.status}`, raw: snippet(j) });
-    throw new Error(j?.error?.message ?? `AskSage anthropic HTTP ${r.status}`);
+  let j: any;
+  for (let attempt = 1; ; attempt++) {
+    try {
+      r = await fetch(`${cfg.base}/anthropic/v1/messages`, { method: "POST", headers: jsonHeaders(cfg.key, { "anthropic-version": "2023-06-01" }), body: JSON.stringify(body), signal });
+    } catch (e) {
+      if (signal?.aborted) throw e; // Stop — don't retry
+      if (attempt < MAX_ATTEMPTS) { diag({ ...reqDiag, attempt, ok: false, retry: true, error: `fetch failed: ${String((e as Error)?.message ?? e)}` }); await backoff(BACKOFF_MS[attempt - 1] ?? 2000, signal); continue; }
+      diag({ ...reqDiag, attempt, ok: false, error: `fetch failed: ${String((e as Error)?.message ?? e)}` });
+      throw e;
+    }
+    j = await r.json().catch(() => ({}));
+    if (!r.ok) {
+      if (retriableStatus(r.status) && attempt < MAX_ATTEMPTS) { diag({ ...reqDiag, attempt, status: r.status, ok: false, retry: true, error: j?.error?.message ?? `HTTP ${r.status}` }); await backoff(BACKOFF_MS[attempt - 1] ?? 2000, signal); continue; }
+      diag({ ...reqDiag, attempt, status: r.status, ok: false, error: j?.error?.message ?? `HTTP ${r.status}`, raw: snippet(j) });
+      throw new Error(j?.error?.message ?? `AskSage anthropic HTTP ${r.status}`);
+    }
+    break;
   }
   const { blocks: content, via } = anthropicBlocks(j);
   const text = content.filter((c) => c?.type === "text" && typeof c.text === "string").map((c) => c.text).join("");
@@ -288,27 +315,43 @@ async function callGoogle(cfg: AsksageStreamCfg, model: string, system: string, 
   }
   const reqDiag = { route: "google", model, maxTokens, tools: toolNames, msgs: contents.length };
   let r: Response;
-  try {
-    r = await fetch(`${cfg.base}/google/v1beta/models/${model}:generateContent`, { method: "POST", headers: jsonHeaders(cfg.key), body: JSON.stringify(body), signal });
-  } catch (e) {
-    diag({ ...reqDiag, ok: false, error: `fetch failed: ${String((e as Error)?.message ?? e)}` });
-    throw e;
+  let j: any;
+  let via = "none", text = "", toolCalls: OmpToolCall[] = [], finish: string | undefined;
+  for (let attempt = 1; ; attempt++) {
+    try {
+      r = await fetch(`${cfg.base}/google/v1beta/models/${model}:generateContent`, { method: "POST", headers: jsonHeaders(cfg.key), body: JSON.stringify(body), signal });
+    } catch (e) {
+      if (signal?.aborted) throw e;
+      if (attempt < MAX_ATTEMPTS) { diag({ ...reqDiag, attempt, ok: false, retry: true, error: `fetch failed: ${String((e as Error)?.message ?? e)}` }); await backoff(BACKOFF_MS[attempt - 1] ?? 2000, signal); continue; }
+      diag({ ...reqDiag, attempt, ok: false, error: `fetch failed: ${String((e as Error)?.message ?? e)}` });
+      throw e;
+    }
+    j = await r.json().catch(() => ({}));
+    if (!r.ok) {
+      if (retriableStatus(r.status) && attempt < MAX_ATTEMPTS) { diag({ ...reqDiag, attempt, status: r.status, ok: false, retry: true, error: j?.error?.message ?? `HTTP ${r.status}` }); await backoff(BACKOFF_MS[attempt - 1] ?? 2000, signal); continue; }
+      diag({ ...reqDiag, attempt, status: r.status, ok: false, error: j?.error?.message ?? `HTTP ${r.status}`, raw: snippet(j) });
+      throw new Error(j?.error?.message ?? `AskSage google HTTP ${r.status}`);
+    }
+    const parsed = googleParts(j);
+    via = parsed.via;
+    text = parsed.parts.filter((p) => typeof p?.text === "string").map((p) => p.text).join("");
+    let n = 0;
+    toolCalls = parsed.parts
+      .filter((p) => p?.functionCall)
+      .map((p) => ({ type: "toolCall", id: `${p.functionCall.name || "tool"}-${n++}`, name: String(p.functionCall.name ?? ""), arguments: isRecord(p.functionCall.args) ? p.functionCall.args : {} }));
+    finish = j?.candidates?.[0]?.finishReason;
+    // Gemini sometimes returns MALFORMED_FUNCTION_CALL with an empty body (it failed to form a valid tool
+    // call) — burns the whole turn for nothing. Retry it (often stochastic) before accepting the empty.
+    if (finish === "MALFORMED_FUNCTION_CALL" && !text && !toolCalls.length && attempt < MAX_ATTEMPTS) {
+      diag({ ...reqDiag, attempt, ok: true, finish, retry: true, anomaly: "malformed-function-call" });
+      await backoff(BACKOFF_MS[attempt - 1] ?? 2000, signal);
+      continue;
+    }
+    break;
   }
-  const j: any = await r.json().catch(() => ({}));
-  if (!r.ok) {
-    diag({ ...reqDiag, status: r.status, ok: false, error: j?.error?.message ?? `HTTP ${r.status}`, raw: snippet(j) });
-    throw new Error(j?.error?.message ?? `AskSage google HTTP ${r.status}`);
-  }
-  const { parts, via } = googleParts(j);
-  const text = parts.filter((p) => typeof p?.text === "string").map((p) => p.text).join("");
-  let n = 0;
-  const toolCalls: OmpToolCall[] = parts
-    .filter((p) => p?.functionCall)
-    .map((p) => ({ type: "toolCall", id: `${p.functionCall.name || "tool"}-${n++}`, name: String(p.functionCall.name ?? ""), arguments: isRecord(p.functionCall.args) ? p.functionCall.args : {} }));
-  const finish = j?.candidates?.[0]?.finishReason;
   const stopReason: GoogleResult["stopReason"] = toolCalls.length ? "toolUse" : finish === "MAX_TOKENS" ? "length" : "stop";
   const um = j?.usageMetadata ?? {};
-  const anomaly = (!text && !toolCalls.length) ? "empty-response" : stopReason === "length" ? "truncated" : undefined;
+  const anomaly = (!text && !toolCalls.length) ? (finish === "MALFORMED_FUNCTION_CALL" ? "malformed-function-call" : "empty-response") : stopReason === "length" ? "truncated" : undefined;
   // Gemini always reports finishReason "STOP" even when it emits a functionCall; log the MAPPED reason
   // (toolUse = the loop continues) plus the raw finish, so a tool-calling row reads "toolUse", not "STOP".
   diag({ ...reqDiag, status: r.status, ok: true, respKeys: Object.keys(j ?? {}), via, textLen: text.length, toolCalls: toolCalls.map((t) => t.name), stopReason, finish, usage: { in: um.promptTokenCount ?? 0, out: um.candidatesTokenCount ?? 0 }, ...(anomaly ? { anomaly, raw: snippet(j) } : {}) });

--- a/harness/scripts/demo_paskage1.ts
+++ b/harness/scripts/demo_paskage1.ts
@@ -1,6 +1,6 @@
 // harness/scripts/demo_paskage1.ts
 //
-// P-ASKSAGE.1 (ADR-0055): AskSage tool-loop diagnostics + tolerant response extraction. AskSage serves
+// P-ASKSAGE.1 (ADR-0059): AskSage tool-loop diagnostics + tolerant response extraction. AskSage serves
 // Claude/Gemini NON-streamed through our streamSimple adapter; when the agentic loop "gives up too soon"
 // the usual cause is invisible — a follow-up response whose content we drop (the proxy wrapped it
 // differently) becomes an EMPTY turn, and omp concludes the model finished. This demo proves, with a

--- a/harness/scripts/demo_paskage1.ts
+++ b/harness/scripts/demo_paskage1.ts
@@ -1,0 +1,67 @@
+// harness/scripts/demo_paskage1.ts
+//
+// P-ASKSAGE.1 (ADR-0055): AskSage tool-loop diagnostics + tolerant response extraction. AskSage serves
+// Claude/Gemini NON-streamed through our streamSimple adapter; when the agentic loop "gives up too soon"
+// the usual cause is invisible — a follow-up response whose content we drop (the proxy wrapped it
+// differently) becomes an EMPTY turn, and omp concludes the model finished. This demo proves, with a
+// mocked AskSage endpoint, that: (1) a non-standard (wrapped) response is still parsed instead of
+// dropped; (2) a genuinely empty response is flagged as the `empty-response` anomaly in the diagnostics;
+// (3) diagnostics are silent unless LUCID_ASKSAGE_DEBUG is set.
+//
+// Run with: bun run harness/scripts/demo_paskage1.ts
+
+import { makeAsksageStream } from "../omp/asksage_stream.ts";
+
+const cfg = { base: "https://asksage.demo", key: "k" };
+const anthropic = makeAsksageStream("anthropic", () => cfg);
+const model = { id: "claude-x", api: "asksage-anthropic", provider: "asksage-anthropic", maxTokens: 1000 };
+
+const origFetch = globalThis.fetch;
+const fail = (m: string): never => { globalThis.fetch = origFetch; console.error(`FAIL: ${m}`); process.exit(1); };
+const mockJson = (json: any) => { globalThis.fetch = (async () => ({ ok: true, status: 200, json: async () => json })) as any; };
+
+async function collect(stream: any): Promise<any[]> { const ev: any[] = []; for await (const e of stream) ev.push(e); return ev; }
+function captureStderr(): { lines: string[]; restore: () => void } {
+  const lines: string[] = [];
+  const orig = process.stderr.write.bind(process.stderr);
+  (process.stderr as any).write = (s: any) => { lines.push(String(s)); return true; };
+  return { lines, restore: () => { (process.stderr as any).write = orig; } };
+}
+const diagsFrom = (lines: string[]) => lines.filter((l) => l.includes("[ASKSAGE_DIAG]")).map((l) => JSON.parse(l.slice(l.indexOf("{"))));
+
+try {
+  console.log("== [1/3] a NON-STANDARD (wrapped) response is recovered, not dropped ==");
+  // A proxy that returns the Anthropic body nested under `response` — the strict parser would see no
+  // top-level `content` and emit an empty turn (→ omp gives up). Tolerant extraction recovers it.
+  mockJson({ response: { content: [{ type: "text", text: "Recovered the wrapped answer." }] }, usage: {} });
+  const done = (await collect(anthropic(model, { messages: [{ role: "user", content: "continue the task" }] }))).find((e) => e.type === "done");
+  if (!done || !done.message.content.length) fail("wrapped response should have been recovered into a non-empty turn");
+  if (done.message.content[0].text !== "Recovered the wrapped answer.") fail(`unexpected recovered text: ${JSON.stringify(done.message.content)}`);
+  console.log(`   recovered: "${done.message.content[0].text}"  (would otherwise be an empty 'done' → premature stop)`);
+
+  console.log("\n== [2/3] a genuinely EMPTY response is flagged as the `empty-response` anomaly ==");
+  process.env.LUCID_ASKSAGE_DEBUG = "1";
+  let cap = captureStderr();
+  mockJson({ id: "msg_x", usage: {} }); // no content, no tool calls
+  await collect(anthropic(model, { messages: [{ role: "user", content: "x" }] }));
+  cap.restore();
+  const anomalies = diagsFrom(cap.lines);
+  if (anomalies[0]?.anomaly !== "empty-response") fail(`expected empty-response anomaly; got ${JSON.stringify(anomalies[0])}`);
+  if (typeof anomalies[0].raw !== "string") fail("anomaly diag should capture a raw snippet for inspection");
+  console.log(`   diag flagged: anomaly=${anomalies[0].anomaly} · via=${anomalies[0].via} · raw snippet captured (${String(anomalies[0].raw).length} chars)`);
+
+  console.log("\n== [3/3] diagnostics are SILENT unless LUCID_ASKSAGE_DEBUG is set ==");
+  delete process.env.LUCID_ASKSAGE_DEBUG;
+  cap = captureStderr();
+  mockJson({ content: [{ type: "text", text: "ok" }], usage: {} });
+  await collect(anthropic(model, { messages: [{ role: "user", content: "x" }] }));
+  cap.restore();
+  if (diagsFrom(cap.lines).length !== 0) fail("no diagnostics should be emitted without the env flag");
+  console.log("   no [ASKSAGE_DIAG] lines without the flag — zero overhead in normal use.");
+
+  globalThis.fetch = origFetch;
+  console.log("\nPASS: AskSage tool-loop diagnostics + tolerant extraction — wrapped replies recovered, empty turns flagged, off by default.");
+} catch (e) {
+  fail(String((e as Error)?.stack ?? e));
+}
+process.exit(0);

--- a/harness/scripts/demo_prag1.ts
+++ b/harness/scripts/demo_prag1.ts
@@ -1,6 +1,6 @@
 // harness/scripts/demo_prag1.ts
 //
-// P-RAG.1 (ADR-0054): the local knowledge spine. Proves the end-to-end security + retrieval property
+// P-RAG.1 (ADR-0058): the local knowledge spine. Proves the end-to-end security + retrieval property
 // against the REAL Unicode scanner sidecar and a real (temp) knowledge.duckdb:
 //   1. a CLEAN document is chunked, scanned, embedded, and stored in the vector store;
 //   2. a TAMPERED document (Trojan-Source bidi U+202E + zero-width U+200B) is BLOCKED at the gate —

--- a/harness/scripts/demo_prag1.ts
+++ b/harness/scripts/demo_prag1.ts
@@ -1,0 +1,79 @@
+// harness/scripts/demo_prag1.ts
+//
+// P-RAG.1 (ADR-0054): the local knowledge spine. Proves the end-to-end security + retrieval property
+// against the REAL Unicode scanner sidecar and a real (temp) knowledge.duckdb:
+//   1. a CLEAN document is chunked, scanned, embedded, and stored in the vector store;
+//   2. a TAMPERED document (Trojan-Source bidi U+202E + zero-width U+200B) is BLOCKED at the gate —
+//      its poisoned chunk is never embedded and never stored (fail-closed, invariant #3/#5);
+//   3. brute-force cosine retrieval returns the relevant chunk first (DuckDB list_cosine_distance,
+//      no vss/HNSW extension — air-gap clean);
+//   4. retrieved knowledge is wrapped in UNTRUSTED_CONTENT_START/END for late, delimited injection.
+//
+// Run with: bun run harness/scripts/demo_prag1.ts
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { ScannerClient } from "../security/scanner_client.ts";
+import { HashEmbedder } from "../knowledge/embedder.ts";
+import { KnowledgeStore } from "../knowledge/store.ts";
+import { ingestText, wrapRetrieved } from "../knowledge/ingest.ts";
+
+const dir = mkdtempSync(join(homedir(), ".lucid-demo-prag1-"));
+const scanner = new ScannerClient();
+let store: KnowledgeStore | null = null;
+const cleanup = () => { try { scanner.stop(); } catch { /* ignore */ } try { store?.close(); } catch { /* ignore */ } rmSync(dir, { recursive: true, force: true }); };
+const fail = (m: string): never => { cleanup(); console.error(`FAIL: ${m}`); process.exit(1); };
+
+const HANDBOOK = `Retrieval-augmented generation grounds the model in your own documents.
+The knowledge store keeps text chunks together with their embedding vectors.
+
+DuckDB ranks chunks by cosine distance with a built-in array function, so retrieval
+works fully offline with no vector-database extension to install.
+
+Every chunk is scanned at the security gate before it is stored, and again it is only
+ever injected into a prompt as delimited, untrusted data — never as instructions.`;
+
+// A tampered note: a right-to-left override (U+202E) + a zero-width space (U+200B) hidden in the text —
+// never-legitimate control characters the scanner flags HIGH (DEFAULT_POLICY blocks at high).
+const TAMPERED = `This note looks ordinary but hides a Trojan-Source payload: Miti‮gate​ the rollback.`;
+
+try {
+  scanner.start();
+  store = await KnowledgeStore.open(join(dir, "knowledge.duckdb"));
+  const ds = await store.createDataset({ name: "handbook", classification: "U", source: "local", embeddingModel: "hash-bow-384", dim: 384 });
+  const emb = new HashEmbedder(384);
+
+  console.log("== [1/4] a CLEAN document is chunked, scanned, embedded, and stored ==");
+  const r1 = await ingestText({ store, scanner, embedder: emb, datasetId: ds.dataset_id, sourcePath: "handbook.txt", text: HANDBOOK, chunkOptions: { maxChars: 240, overlapChars: 40 } });
+  if (r1.stored < 2 || r1.blocked !== 0) fail(`clean doc should store multiple chunks, block none; got ${JSON.stringify({ stored: r1.stored, blocked: r1.blocked })}`);
+  console.log(`   stored ${r1.stored}/${r1.chunksTotal} chunks  ·  blocked ${r1.blocked}`);
+
+  console.log("\n== [2/4] a TAMPERED note (bidi/zero-width) is BLOCKED — never embedded, never stored ==");
+  const before = await store.chunkCount(ds.dataset_id);
+  let audited = 0;
+  const r2 = await ingestText({ store, scanner, embedder: emb, datasetId: ds.dataset_id, sourcePath: "tampered.txt", text: TAMPERED, onBlock: () => audited++ });
+  const after = await store.chunkCount(ds.dataset_id);
+  if (r2.stored !== 0 || r2.blocked < 1) fail(`tampered note must be blocked, nothing stored; got ${JSON.stringify({ stored: r2.stored, blocked: r2.blocked })}`);
+  if (after !== before) fail(`store count changed on a blocked ingest (${before} → ${after})`);
+  if (audited !== r2.blocked) fail("every blocked chunk must be audited via onBlock");
+  console.log(`   blocked ${r2.blocked} chunk(s)  ·  audited ${audited}  ·  store count unchanged at ${after}`);
+
+  console.log("\n== [3/4] brute-force cosine retrieval returns the relevant chunk first ==");
+  const [q] = await emb.embed(["how does cosine ranking work without a vector database extension"]);
+  const hits = await store.retrieve(ds.dataset_id, q!, 3);
+  if (hits.length === 0) fail("retrieval returned nothing");
+  if (!/cosine distance/.test(hits[0]!.text)) fail(`expected the cosine-distance chunk first; got: ${hits[0]!.text.slice(0, 60)}`);
+  console.log(`   top hit (d=${hits[0]!.distance.toFixed(4)}): ${hits[0]!.text.replace(/\n/g, " ").slice(0, 80)}...`);
+
+  console.log("\n== [4/4] retrieved knowledge is wrapped as delimited, untrusted data ==");
+  const wrapped = wrapRetrieved(hits);
+  if (!wrapped.startsWith("UNTRUSTED_CONTENT_START") || !wrapped.endsWith("UNTRUSTED_CONTENT_END")) fail("injection must be delimited");
+  console.log("   " + wrapped.split("\n")[0] + "  ...  " + wrapped.split("\n").slice(-1)[0]);
+
+  cleanup();
+  console.log("\nPASS: local knowledge spine — scan-gated ingest, fail-closed block, offline cosine retrieval, delimited injection.");
+} catch (e) {
+  fail(String((e as Error)?.stack ?? e));
+}
+process.exit(0);

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "demo-P-CODE.1": "bun run harness/scripts/demo_pcode1.ts",
     "demo-P-TPS.1": "bun run harness/scripts/demo_ptps1.ts",
     "demo-P-SKILL.1": "bun run harness/scripts/demo_pskill1.ts",
+    "demo-P-RAG.1": "bun run harness/scripts/demo_prag1.ts",
     "dashboards": "bun run harness/scripts/materialize_dashboards.ts",
     "omp:secure": "omp -e harness/omp/security_extension.ts -e harness/omp/token_speed_extension.ts",
     "dashboard:tui": "bun run tools/dashboard_tui.ts",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "demo-P-TPS.1": "bun run harness/scripts/demo_ptps1.ts",
     "demo-P-SKILL.1": "bun run harness/scripts/demo_pskill1.ts",
     "demo-P-RAG.1": "bun run harness/scripts/demo_prag1.ts",
+    "demo-P-ASKSAGE.1": "bun run harness/scripts/demo_paskage1.ts",
     "dashboards": "bun run harness/scripts/materialize_dashboards.ts",
     "omp:secure": "omp -e harness/omp/security_extension.ts -e harness/omp/token_speed_extension.ts",
     "dashboard:tui": "bun run tools/dashboard_tui.ts",


### PR DESCRIPTION
## Summary

Three increments built on this branch, now rebased on top of master (PR #79's `/goal` loop-engineering is fully merged in — `0 17`, clean). ADRs were renumbered **0058-0062** to de-collide with master's P-GOAL.9-12 (ADR-0054-0057).

### P-RAG.1 — local knowledge spine (ADR-0058)
Air-gap-clean RAG core: scan-gated ingest (every chunk through `scanAndDecide`, fail-closed — blocked chunks never stored), offline cosine retrieval via DuckDB `list_cosine_distance` (no vss extension), UNTRUSTED-delimited injection. Separate `knowledge.duckdb` with its own migration (`0010_knowledge_vectors.sql`); `Db.open(path, migrationsDir?)` parameterized additively. Keystone #2 preserved — RAG chunks are retrieval context, never semantic memory.

### P-ASKSAGE.1 + P-RESIL.1 — AskSage tool-loop reliability (ADR-0059/0061)
- **Diagnostics:** per-call `[ASKSAGE_DIAG]` ring (dev-mode), tolerant response extraction (recovers wrapped shapes, flags `empty-response`/`truncated`), surfaced in **Logs → AskSage tool calls** (live, newest-first, EST-stamped).
- **Resilience:** retry transient **504/5xx/429** + Gemini **MALFORMED_FUNCTION_CALL** (abort-aware backoff).
- **Hang fixes:** Stop reliably aborts a wedged turn (threads omp's `options.signal` into every fetch + client-stream abort); idle cap 2min→5min for the non-streamed gov gateway; `done` reconciles the full reply (lossy-stream safety net); listener-clobber guard.
- Adds the missing **Developer-mode toggle** + **Logs rail button** (with a dedicated icon).
- ADR-0060 (auto-continue wellness-check) scoped, not yet built.

### P-EGRESS.1 — per-website approval for network tools (ADR-0062)
`tools.approval: {browser: prompt}` forces omp to request permission in every mode; a docked, subdued approval dialog above the prompt bar (URL + copy + Cloudflare Radar check + 4 choices: allow-once / allow-site / allow-all / block). Fail-closed: no live UI ⇒ deny. Pure verdict logic in `desktop/egress_policy.ts` (13 tests) + `~/.omp/lucid-egress.json` store.

## Verification
- Typecheck clean (root + desktop + server).
- **bun test harness 506/0 · desktop 404/0** (master's +65 loop tests and this branch's egress/knowledge tests all green together).
- Demos: `make demo-P-RAG.1`, `demo-P-ASKSAGE.1` self-contained green.
- Prompt prefix untouched (frozen layers 1-4); all untrusted content scanned + delimited + late.

## Notes
- ADRs renumbered 0058-0062; DECISIONS.md log kept ascending (0053 → 0062).
- Conflict resolutions on merge: ChatEvent `done.text` unioned with master's `goal-report` event; demo/ADR/progress blocks kept from both sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)