### PR TITLE
fix(desktop): bundle bun+uv runtimes (win/linux) + Linux AppImage CI build + startup-failure dialog

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -60,46 +60,10 @@ jobs:
         run: bun install
         working-directory: desktop
 
-      # Embed the static bun + uv binaries so the installed app needs no
-      # prerequisites. Named <tool>-<platform>-<arch> to match desktop/runtime.ts;
-      # extraResources bundles them into Resources/runtimes. The first launch uses
-      # them to install omp + provision the scanner interpreter.
-      - name: Bundle runtimes (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        working-directory: desktop/runtimes
-        run: |
-          New-Item -ItemType Directory -Force tmp | Out-Null
-          curl -L -o tmp/bun.zip https://github.com/oven-sh/bun/releases/latest/download/bun-windows-x64.zip
-          curl -L -o tmp/uv.zip  https://github.com/astral-sh/uv/releases/latest/download/uv-x86_64-pc-windows-msvc.zip
-          Expand-Archive tmp/bun.zip -DestinationPath tmp/bun -Force
-          Expand-Archive tmp/uv.zip  -DestinationPath tmp/uv  -Force
-          Copy-Item (Get-ChildItem tmp/bun -Recurse -Filter bun.exe)[0].FullName bun-win32-x64.exe
-          Copy-Item (Get-ChildItem tmp/uv  -Recurse -Filter uv.exe)[0].FullName  uv-win32-x64.exe
-          Remove-Item tmp -Recurse -Force
-          Get-ChildItem
-
-      - name: Bundle runtimes (macOS)
-        if: runner.os == 'macOS'
-        shell: bash
-        working-directory: desktop/runtimes
-        run: |
-          set -euo pipefail
-          mkdir -p tmp
-          # bun (both arches; runtime.ts picks by process.arch)
-          curl -L -o tmp/bun-arm.zip https://github.com/oven-sh/bun/releases/latest/download/bun-darwin-aarch64.zip
-          curl -L -o tmp/bun-x64.zip https://github.com/oven-sh/bun/releases/latest/download/bun-darwin-x64.zip
-          unzip -o tmp/bun-arm.zip -d tmp && mv tmp/bun-darwin-aarch64/bun bun-darwin-arm64
-          unzip -o tmp/bun-x64.zip -d tmp && mv tmp/bun-darwin-x64/bun bun-darwin-x64
-          # uv (both arches; tar.gz)
-          curl -L -o tmp/uv-arm.tgz https://github.com/astral-sh/uv/releases/latest/download/uv-aarch64-apple-darwin.tar.gz
-          curl -L -o tmp/uv-x64.tgz https://github.com/astral-sh/uv/releases/latest/download/uv-x86_64-apple-darwin.tar.gz
-          tar xzf tmp/uv-arm.tgz -C tmp && mv tmp/uv-aarch64-apple-darwin/uv uv-darwin-arm64
-          tar xzf tmp/uv-x64.tgz -C tmp && mv tmp/uv-x86_64-apple-darwin/uv uv-darwin-x64
-          chmod +x bun-darwin-* uv-darwin-*
-          rm -rf tmp
-          ls -la
-
+      # The static bun + uv binaries the installed app needs (so it has no prerequisites) are now
+      # fetched + SHA-256-verified by desktop/build/fetch-runtimes.ts, which each `dist:<os>` script
+      # runs first (pinned versions, vendor-cross-checked hashes — fail-closed). The old inline
+      # `latest`-curl steps were unpinned/unverified AND shadowed that path, so they were removed.
       - name: Build installer (${{ matrix.script }})
         run: bun run ${{ matrix.script }}
         working-directory: desktop

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -1,9 +1,9 @@
-# Build the LucidAgentIDE desktop installers (macOS .zip app bundle + Windows .exe).
+# Build the LucidAgentIDE desktop installers (macOS .zip app bundle + Windows .exe + Linux AppImage).
 #
 # electron-builder can't cross-build/sign a mac app from Windows, so this runs
 # the real packaging on native runners: macOS for the .zip bundle, Windows for the
-# NSIS installer + portable .exe. Both bundle the repo into the app
-# (extraResources) per desktop/package.json.
+# NSIS installer + portable .exe, and Ubuntu for the AppImage. All bundle the repo
+# into the app (extraResources) per desktop/package.json.
 #
 # (macOS ships .zip, not .dmg: the default DMG layout drives a Finder/AppleScript
 #  background pass that is fragile on headless Apple-Silicon runners. The .zip is a
@@ -41,6 +41,9 @@ jobs:
           - os: windows-latest
             label: Windows (NSIS + portable, x64)
             script: dist:win
+          - os: ubuntu-latest
+            label: Linux (AppImage, x64)
+            script: dist:linux
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
@@ -69,9 +72,10 @@ jobs:
         working-directory: desktop
         env:
           # --- Code signing (all optional; absent secrets ⇒ unsigned build) ---
-          # Per-OS Authenticode / Apple Developer cert as base64-encoded PKCS#12.
-          CSC_LINK: ${{ runner.os == 'macOS' && secrets.MAC_CSC_LINK || secrets.WIN_CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ runner.os == 'macOS' && secrets.MAC_CSC_KEY_PASSWORD || secrets.WIN_CSC_KEY_PASSWORD }}
+          # Per-OS Authenticode / Apple Developer cert as base64-encoded PKCS#12. Linux (AppImage) is
+          # unsigned, so it must resolve to empty — don't let it inherit the Windows cert.
+          CSC_LINK: ${{ runner.os == 'macOS' && secrets.MAC_CSC_LINK || runner.os == 'Windows' && secrets.WIN_CSC_LINK || '' }}
+          CSC_KEY_PASSWORD: ${{ runner.os == 'macOS' && secrets.MAC_CSC_KEY_PASSWORD || runner.os == 'Windows' && secrets.WIN_CSC_KEY_PASSWORD || '' }}
           # Only hunt the keychain for a mac identity when a mac cert is provided.
           CSC_IDENTITY_AUTO_DISCOVERY: ${{ runner.os == 'macOS' && secrets.MAC_CSC_LINK != '' }}
           # macOS notarization (electron-builder runs notarytool when these are set).
@@ -91,6 +95,7 @@ jobs:
             desktop/release/*.zip
             desktop/release/*Setup*.exe
             desktop/release/*portable*.exe
+            desktop/release/*.AppImage
             desktop/release/*.blockmap
             desktop/release/latest*.yml
 
@@ -105,6 +110,7 @@ jobs:
             desktop/release/*.zip
             desktop/release/*Setup*.exe
             desktop/release/*portable*.exe
+            desktop/release/*.AppImage
             desktop/release/*.blockmap
             desktop/release/latest*.yml
 
@@ -153,11 +159,12 @@ jobs:
           make_latest: "true"
           body: |
             Rolling build — auto-updated on every successful CI build (commit ${{ github.sha }}).
-            Always the newest Windows + macOS installers. For a pinned version, see the tagged releases.
+            Always the newest Windows, macOS, and Linux installers. For a pinned version, see the tagged releases.
           files: |
             dist/*.dmg
             dist/*Setup*.exe
             dist/*portable*.exe
+            dist/*.AppImage
             dist/*.zip
             dist/*.blockmap
             dist/latest*.yml

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 <a href="https://github.com/mlcyclops/lucidagentide/actions/workflows/codeql.yml"><img src="https://img.shields.io/github/actions/workflow/status/mlcyclops/lucidagentide/codeql.yml?branch=master&label=CodeQL&logo=github&logoColor=white&style=flat-square" alt="CodeQL SAST" /></a>
 <a href="https://github.com/mlcyclops/lucidagentide/actions/workflows/build-desktop.yml"><img src="https://img.shields.io/github/actions/workflow/status/mlcyclops/lucidagentide/build-desktop.yml?label=Windows%20Build&logo=windows&logoColor=white&style=flat-square" alt="Windows Build" /></a>
 <a href="https://github.com/mlcyclops/lucidagentide/actions/workflows/build-desktop.yml"><img src="https://img.shields.io/github/actions/workflow/status/mlcyclops/lucidagentide/build-desktop.yml?label=macOS%20Build&logo=apple&logoColor=white&style=flat-square" alt="macOS Build" /></a>
+<a href="https://github.com/mlcyclops/lucidagentide/actions/workflows/build-desktop.yml"><img src="https://img.shields.io/github/actions/workflow/status/mlcyclops/lucidagentide/build-desktop.yml?label=Linux%20Build&logo=linux&logoColor=white&style=flat-square" alt="Linux Build" /></a>
 <img src="https://img.shields.io/badge/tests-473%20harness%20%2B%20326%20desktop%20%2B%2055%20sidecar-46d27e?style=flat-square" alt="tests" />
 <img src="https://img.shields.io/badge/gate-fail--closed-e07bf0?style=flat-square" alt="fail-closed gate" />
 
@@ -37,6 +38,7 @@
 <a href="https://github.com/mlcyclops/lucidagentide/releases/latest/download/LucidAgentIDE-Setup.exe"><img src="https://img.shields.io/badge/Download-Windows%20Installer-2ea44f?style=for-the-badge&logo=windows&logoColor=white" alt="Download Windows installer (latest release)" /></a>
 <a href="https://github.com/mlcyclops/lucidagentide/releases/latest/download/LucidAgentIDE-mac-arm64.zip"><img src="https://img.shields.io/badge/Download-macOS%20Apple%20Silicon-000000?style=for-the-badge&logo=apple&logoColor=white" alt="Download macOS Apple Silicon (latest release)" /></a>
 <a href="https://github.com/mlcyclops/lucidagentide/releases/latest/download/LucidAgentIDE-mac-x64.zip"><img src="https://img.shields.io/badge/macOS-Intel-555555?style=for-the-badge&logo=apple&logoColor=white" alt="Download macOS Intel (latest release)" /></a>
+<a href="https://github.com/mlcyclops/lucidagentide/releases/latest/download/LucidAgentIDE-x86_64.AppImage"><img src="https://img.shields.io/badge/Download-Linux%20AppImage-f0a500?style=for-the-badge&logo=linux&logoColor=white" alt="Download Linux AppImage (latest release)" /></a>
 <a href="https://github.com/mlcyclops/lucidagentide/releases/latest"><img src="https://img.shields.io/github/v/release/mlcyclops/lucidagentide?label=latest&style=for-the-badge&color=c64bd6&sort=semver" alt="Latest release version" /></a>
 
 <sub>⬆ Always the most recent successful release - links auto-update each version (no release yet? they appear after the first tagged build).</sub>
@@ -403,18 +405,22 @@ path** and you get genuine model replies in a plain browser - no Electron needed
 
 ### Platform Builds
 
-CI builds desktop installers for **both platforms** on every tag push:
+CI builds desktop installers for **all three platforms** on every tag push:
 
 | Platform | Artifact | Status | Download (latest release) |
 |:--|:--|:--|:--|
 | **Windows** | NSIS installer + portable `.exe` (x64) | [![Windows Build](https://img.shields.io/github/actions/workflow/status/mlcyclops/lucidagentide/build-desktop.yml?label=passing&logo=windows&logoColor=white&style=flat-square)](https://github.com/mlcyclops/lucidagentide/actions/workflows/build-desktop.yml) | [**Installer**](https://github.com/mlcyclops/lucidagentide/releases/latest/download/LucidAgentIDE-Setup.exe) · [Portable](https://github.com/mlcyclops/lucidagentide/releases/latest/download/LucidAgentIDE-portable.exe) |
 | **macOS** | `.zip` app bundle (arm64 + x64) | [![macOS Build](https://img.shields.io/github/actions/workflow/status/mlcyclops/lucidagentide/build-desktop.yml?label=passing&logo=apple&logoColor=white&style=flat-square)](https://github.com/mlcyclops/lucidagentide/actions/workflows/build-desktop.yml) | [**Apple Silicon**](https://github.com/mlcyclops/lucidagentide/releases/latest/download/LucidAgentIDE-mac-arm64.zip) · [Intel](https://github.com/mlcyclops/lucidagentide/releases/latest/download/LucidAgentIDE-mac-x64.zip) |
+| **Linux** | portable `AppImage` (x64) | [![Linux Build](https://img.shields.io/github/actions/workflow/status/mlcyclops/lucidagentide/build-desktop.yml?label=passing&logo=linux&logoColor=white&style=flat-square)](https://github.com/mlcyclops/lucidagentide/actions/workflows/build-desktop.yml) | [**AppImage**](https://github.com/mlcyclops/lucidagentide/releases/latest/download/LucidAgentIDE-x86_64.AppImage) |
 
-Both builds bundle [Bun](https://bun.sh) and [uv](https://docs.astral.sh/uv/) runtimes so the installed app
+All builds bundle [Bun](https://bun.sh) and [uv](https://docs.astral.sh/uv/) runtimes so the installed app
 needs **zero prerequisites**. Code-signing and notarization are supported when certs are configured.
 
 > **macOS:** the download is a zipped `LucidAgentIDE.app` - unzip it and drag the app into **Applications**.
 > (Builds ship as `.zip` rather than `.dmg`; in-app auto-update uses the same zip feed.)
+>
+> **Linux:** the download is a portable `AppImage` - `chmod +x LucidAgentIDE-x86_64.AppImage` and run it,
+> no install needed.
 
 ## <img src=".github/assets/icons/roadmap.svg" width="28" align="top" alt=""> Roadmap
 

--- a/desktop/build/fetch-runtimes.ts
+++ b/desktop/build/fetch-runtimes.ts
@@ -27,34 +27,39 @@ const BUN_VERSION = "1.3.14"; // github.com/oven-sh/bun -> release tag bun-v<ver
 const UV_VERSION = "0.11.23"; // github.com/astral-sh/uv -> release tag <ver>
 
 interface RuntimeSpec {
-	readonly name: string; // output name under runtimes/ — must match bundled()
+	readonly platform: "darwin" | "win32" | "linux"; // the process.platform this runtime targets
+	readonly name: string; // output name under runtimes/ — must match runtime.ts bundled()
 	readonly url: string; // exact, versioned release archive URL (never `latest`)
 	readonly kind: "zip" | "tgz";
 	readonly member: string; // executable basename inside the archive
 	readonly sha256: string; // expected SHA-256 of the archive (committed + vendor-cross-checked)
 }
 
-const bunUrl = (arch: string): string =>
-	`https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-darwin-${arch}.zip`;
-const uvUrl = (triple: string): string =>
-	`https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-${triple}.tar.gz`;
+const bunUrl = (slug: string): string =>
+	`https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-${slug}.zip`;
+const uvUrl = (triple: string, ext: "tar.gz" | "zip" = "tar.gz"): string =>
+	`https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-${triple}.${ext}`;
 
 const SPECS: readonly RuntimeSpec[] = [
+	// macOS (both arches; runtime.ts picks by process.arch)
 	{
+		platform: "darwin",
 		name: "bun-darwin-arm64",
 		kind: "zip",
 		member: "bun",
-		url: bunUrl("aarch64"),
+		url: bunUrl("darwin-aarch64"),
 		sha256: "d8b96221828ad6f97ac7ac0ab7e95872341af763001e8803e8267652c2652620",
 	},
 	{
+		platform: "darwin",
 		name: "bun-darwin-x64",
 		kind: "zip",
 		member: "bun",
-		url: bunUrl("x64"),
+		url: bunUrl("darwin-x64"),
 		sha256: "4183df3374623e5bab315c547cfa0974533cd457d86b73b639f7a87974cd6633",
 	},
 	{
+		platform: "darwin",
 		name: "uv-darwin-arm64",
 		kind: "tgz",
 		member: "uv",
@@ -62,11 +67,46 @@ const SPECS: readonly RuntimeSpec[] = [
 		sha256: "71ef9de85db820749b3b12b7585624ee279e9c5afcbc6f8236bc3d628c4305b0",
 	},
 	{
+		platform: "darwin",
 		name: "uv-darwin-x64",
 		kind: "tgz",
 		member: "uv",
 		url: uvUrl("x86_64-apple-darwin"),
 		sha256: "7a88155033cc469bba5bd5a24212e355eb92e3e2a276320b669ec576296c1e25",
+	},
+	// Windows x64 — output names carry the `.exe` so they match runtime.ts bundled() (EXE = ".exe").
+	{
+		platform: "win32",
+		name: "bun-win32-x64.exe",
+		kind: "zip",
+		member: "bun.exe",
+		url: bunUrl("windows-x64"),
+		sha256: "0a0620930b6675d7ba440e81f4e0e00d3cfbe096c4b140d3fff02205e9e18922",
+	},
+	{
+		platform: "win32",
+		name: "uv-win32-x64.exe",
+		kind: "zip",
+		member: "uv.exe",
+		url: uvUrl("x86_64-pc-windows-msvc", "zip"),
+		sha256: "02ad29f07e674d68726ba3bb1ff25b335d83515756e2b1a194bb56c3cc30e07c",
+	},
+	// Linux x64
+	{
+		platform: "linux",
+		name: "bun-linux-x64",
+		kind: "zip",
+		member: "bun",
+		url: bunUrl("linux-x64"),
+		sha256: "951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f",
+	},
+	{
+		platform: "linux",
+		name: "uv-linux-x64",
+		kind: "tgz",
+		member: "uv",
+		url: uvUrl("x86_64-unknown-linux-gnu"),
+		sha256: "e12c4cda2fe8c305510a78380a88f2c32a27e90cdcd123cefd2873388f0ebb5f",
 	},
 ];
 
@@ -77,7 +117,16 @@ const hashOf = (file: string): string => createHash("sha256").update(readFileSyn
 
 mkdirSync(OUT, { recursive: true });
 
-for (const spec of SPECS) {
+// electron-builder packages on the matching OS, so by default we fetch only the current platform's
+// runtimes (RUNTIME_OS overrides — e.g. to pre-stage another OS's binaries). Filtering keeps a Windows
+// build from downloading the mac/linux binaries it would never bundle.
+const TARGET = (process.env.RUNTIME_OS ?? process.platform) as RuntimeSpec["platform"];
+const specs = SPECS.filter((s) => s.platform === TARGET);
+if (specs.length === 0) {
+	console.warn(`fetch-runtimes: no runtime specs for platform "${TARGET}" — nothing to bundle.`);
+}
+
+for (const spec of specs) {
 	const dest = join(OUT, spec.name);
 	if (!REFRESH && existsSync(dest)) {
 		console.log(`runtimes: ${spec.name} (cached)`);

--- a/desktop/main.ts
+++ b/desktop/main.ts
@@ -40,12 +40,16 @@ function startDevServer(): void {
   dev.stdout?.on("data", (d) => process.stdout.write(d));
   dev.stderr?.on("data", (d) => process.stderr.write(d));
 }
-async function waitForServer(timeoutMs = 12000): Promise<void> {
+// Returns true once the dev server answers /api/health, false if it never does within the window.
+// 30s headroom: the server's own init (DuckDB open + omp acp spawn) can outlast a slow first launch;
+// the splash already covered the longer omp/scanner provisioning before we got here.
+async function waitForServer(timeoutMs = 30000): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    try { if ((await fetch(`http://localhost:${PORT}/api/health`)).ok) return; } catch { /* retry */ }
+    try { if ((await fetch(`http://localhost:${PORT}/api/health`)).ok) return true; } catch { /* retry */ }
     await sleep(180);
   }
+  return false;
 }
 
 function createWindow(): void {
@@ -61,6 +65,12 @@ function createWindow(): void {
   win.once("ready-to-show", () => win!.show());
   // external links (e.g. duckdb.org) open in the OS browser, not a new Electron window
   win.webContents.setWindowOpenHandler(({ url }) => { if (/^https?:/.test(url)) shell.openExternal(url); return { action: "deny" }; });
+  // If the dev server isn't answering yet (slow first launch), the load fails — retry a bounded number
+  // of times so a late-ready server self-heals into a rendered window instead of a permanent black one.
+  let reloadTries = 0;
+  win.webContents.on("did-fail-load", () => {
+    if (reloadTries++ < 30) setTimeout(() => win?.loadURL(`http://localhost:${PORT}`), 1000);
+  });
   win.loadURL(`http://localhost:${PORT}`);
   win.on("closed", () => (win = null));
 }
@@ -95,9 +105,21 @@ app.whenReady().then(async () => {
   }
 
   startDevServer();
-  await waitForServer();
+  const serverUp = await waitForServer();
   createWindow();
   splash?.close();
+  // Don't leave the user staring at a black window with no explanation: if the local engine never
+  // came up (e.g. no usable bun runtime), say so. The window keeps retrying via did-fail-load, so a
+  // late start still recovers; this only fires when it genuinely failed to answer in time.
+  if (!serverUp) {
+    dialog.showErrorBox(
+      "LucidAgentIDE could not start its local engine",
+      `The bundled background service did not respond on port ${PORT} within 30 seconds, so the window ` +
+        `may stay blank.\n\nThis usually means the bundled runtime is missing or was blocked. The app ` +
+        `will keep retrying — if it stays blank, reinstall the latest release, or relaunch from a ` +
+        `terminal to see the startup log.`,
+    );
+  }
   initAutoUpdate(() => win); // packaged-only; checks GitHub Releases, prompts on download
   app.on("activate", () => { if (BrowserWindow.getAllWindows().length === 0) createWindow(); });
 });

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -116,7 +116,8 @@
     "linux": {
       "icon": "build/icon.png",
       "category": "Development",
-      "target": ["AppImage"]
+      "target": ["AppImage"],
+      "artifactName": "${productName}-x86_64.${ext}"
     },
     "publish": [
       {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -7,15 +7,18 @@
   "scripts": {
     "build": "bun build main.ts --target=node --format=cjs --external electron --outfile dist/main.js && bun build preload.ts --target=node --format=cjs --external electron --outfile dist/preload.js",
     "icons": "bun run build/make-icons.ts",
+    "runtimes": "bun run build/fetch-runtimes.ts",
     "runtimes:mac": "bun run build/fetch-runtimes.ts",
+    "runtimes:win": "bun run build/fetch-runtimes.ts",
+    "runtimes:linux": "bun run build/fetch-runtimes.ts",
     "compile-lucid": "bun build --compile ../harness/launcher/lucid_acp.ts --outfile ../bin/lucid",
     "start": "bun run build && electron .",
     "web": "bun run dev.ts",
     "typecheck": "tsc --noEmit",
     "dist:mac": "bun run runtimes:mac && bun run icons && bun run build && bun run compile-lucid && electron-builder --mac --publish never",
-    "dist:win": "bun run icons && bun run build && bun run compile-lucid && electron-builder --win --publish never",
-    "dist:linux": "bun run icons && bun run build && bun run compile-lucid && electron-builder --linux --publish never",
-    "dist": "bun run icons && bun run build && bun run compile-lucid && electron-builder --publish never"
+    "dist:win": "bun run runtimes:win && bun run icons && bun run build && bun run compile-lucid && electron-builder --win --publish never",
+    "dist:linux": "bun run runtimes:linux && bun run icons && bun run build && bun run compile-lucid && electron-builder --linux --publish never",
+    "dist": "bun run runtimes && bun run icons && bun run build && bun run compile-lucid && electron-builder --publish never"
   },
   "build": {
     "appId": "com.lucidagentide.desktop",


### PR DESCRIPTION
## The bug

A packaged Windows app showed a **black screen**. Root cause: the Electron shell spawns the bun dev server and loads `http://localhost:PORT` — but a **local `dist:win` shipped an empty `resources/runtimes`** (no bundled `bun`). With no bun and no `~/.bun` fallback, the server never starts, the window loads a dead URL, and stays black (the server's stderr has nowhere to go in a packaged GUI, so there's no visible error).

Why local builds were broken while CI releases weren't: Windows/Linux runtimes were only ever embedded by an **inline `latest`-curl step in CI**; `fetch-runtimes.ts` (the pinned + verified path) covered **macOS only**, and `dist:win`/`dist:linux` never fetched runtimes at all.

## The fix

- **`fetch-runtimes.ts`** — add win32 + linux x64 specs for bun + uv, pinned to the same versions as macOS, with **SHA-256 hashes cross-checked against the vendors' published checksums** (bun `SHASUMS256.txt`, uv `.sha256`). Added a `platform` field + filter so each build fetches only its own OS's runtimes.
- **`package.json`** — `dist:win` / `dist:linux` / `dist` now fetch runtimes first, exactly like `dist:mac` already did. **Fail-closed**: a hash mismatch or missing hash aborts the build.
- **`build-desktop.yml`** — removed the inline unpinned `latest`-curl runtimes steps. They were unverified *and* shadowed the pinned path (fetch-runtimes skips already-present files). CI now uses the same verified `dist:<os>` path on every OS, restoring the repo's pinned + verified supply-chain posture.
- **`main.ts`** — `waitForServer()` returns a bool (30s window); on failure it shows an **error dialog** instead of a silent black window, and retries `loadURL` on `did-fail-load` so a slow-starting server **self-heals** into a rendered window.

## Verification

- `bun run runtimes:win` fetched + **SHA-256-verified** `bun-win32-x64.exe` (98,480,216 B — byte-size-identical to CI) and `uv-win32-x64.exe`. Platform filter correctly skipped mac/linux.
- Desktop typecheck clean; `bun test desktop` **407 / 0**.
- Binaries stay gitignored (`desktop/runtimes/*`); only the 4 source files change.

> Note: the hashes are committed; a clean local `bun run desktop dist:win` will now fetch-verify-bundle a working runtime. (Full `dist:win` packaging not run here — heavy — but the runtimes step, the actual bug, is verified.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)