### PR TITLE
fix(build): fetch-runtimes — drop Unix `find` so Windows CI build passes

### DIFF
--- a/desktop/build/fetch-runtimes.ts
+++ b/desktop/build/fetch-runtimes.ts
@@ -18,9 +18,19 @@
 
 import { $ } from "bun";
 import { createHash } from "node:crypto";
-import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { chmodSync, cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+
+// Locate the extracted member by basename, recursively. Cross-platform ON PURPOSE: it replaces a
+// `find … -name` shell call that on the Windows CI runner resolves to System32\find.exe (a text-search
+// tool with incompatible syntax → "FIND: Parameter format not correct"), not the Unix find.
+function findMember(root: string, member: string): string | null {
+	for (const rel of readdirSync(root, { recursive: true }) as string[]) {
+		if (rel.split(/[\\/]/).pop() === member) return join(root, rel);
+	}
+	return null;
+}
 
 // Pinned upstream versions — bump deliberately, then REFRESH the hashes below.
 const BUN_VERSION = "1.3.14"; // github.com/oven-sh/bun -> release tag bun-v<ver>
@@ -168,12 +178,12 @@ for (const spec of specs) {
 	} else {
 		await $`tar xzf ${archive} -C ${tmp}`;
 	}
-	const found = (await $`find ${tmp} -type f -name ${spec.member}`.text()).trim().split("\n")[0];
+	const found = findMember(tmp, spec.member);
 	if (!found) {
 		rmSync(tmp, { recursive: true, force: true });
 		throw new Error(`fetch-runtimes: "${spec.member}" not found in ${spec.url}`);
 	}
-	await $`cp ${found} ${dest}`;
+	cpSync(found, dest);
 	chmodSync(dest, 0o755);
 	rmSync(tmp, { recursive: true, force: true });
 	console.log(`runtimes: ${spec.name} ok (sha256 verified)`);


### PR DESCRIPTION
## The break

PR #82 wired `dist:win` / `dist:linux` to run `fetch-runtimes.ts`, which made the script run on the **Windows CI runner for the first time**. There, bun's shell resolved `find` to **`System32\find.exe`** (a text-search tool, not Unix find):

```
const found = (await $`find ${tmp} -type f -name ${spec.member}`...
stderr: "FIND: Parameter format not correct"
error: script "dist:win" exited with code 1
```

Local runs passed only because Git Bash puts Unix `find` first on PATH — the bug was invisible until CI.

## The fix

- Replace the `find … -name` shell call with a **portable recursive `readdir`** (`findMember`) that matches by basename across `\`/`/` separators.
- Replace the `cp` shell builtin with `fs.cpSync`.
- No external `find`/`cp` on any OS now; the remaining shell calls (`curl`, `unzip`) already succeeded on the Windows runner.

## Verified

Deleted the cached win binaries and re-ran `runtimes:win` — both **re-extracted, located, copied, and SHA-256-verified**; desktop typecheck clean. The same portable path now serves macOS, Windows, and Linux.

After merge, re-run **Build desktop installers** from `master` to get green Windows + Linux (AppImage) + macOS artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)