### PR TITLE
feat(security): Dismiss a reviewed gate block (acknowledge without releasing)

### DIFF
--- a/desktop/dev.ts
+++ b/desktop/dev.ts
@@ -10,7 +10,7 @@
 
 import { join } from "node:path";
 import { devSnapshot, securitySnapshot } from "../tools/web/data.ts";
-import { approveBlock, liveBlocks } from "./security_log.ts";
+import { approveBlock, dismissBlock, liveBlocks } from "./security_log.ts";
 import { probeRateLimits } from "./ratelimit_probe.ts";
 import { OBS_DB_PATH, codeActivity, memorySnapshot, rateLimits, sessionPathById, usageLedger } from "../tools/memory_data.ts";
 import { backend } from "./acp_backend.ts";
@@ -234,6 +234,7 @@ const server = Bun.serve({
       }
       // Audited fail-closed override: release one quarantined call (ADR-0019 C).
       if (p === "/api/security/approve" && req.method === "POST") { const b = await readBody<{ id?: unknown }>(req); return json({ ok: true, data: approveBlock(String(b.id ?? "")) }); }
+      if (p === "/api/security/dismiss" && req.method === "POST") { const b = await readBody<{ id?: unknown }>(req); return json({ ok: true, data: dismissBlock(String(b.id ?? "")) }); }
       // Anchor the snapshot to the ACTIVE chat session (its on-disk transcript) so the Context window
       // + Prompt-cache gauges reflect the live conversation; fall back to findSession's cwd match only
       // when there's no active session yet (fresh launch).

--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -1667,7 +1667,7 @@ function securityHtml(d: SecuritySnapshot | null): string {
   // arrays may be absent on a fresh machine - guard every one.
   const quarantine = d?.quarantine ?? [], approvals = d?.approvals ?? [], findings = d?.findings ?? [];
   const promotion = d?.promotion ?? [], exports = d?.exports ?? [], runs = d?.runs ?? [];
-  const live = d?.live ?? { quarantined: [], approved: [], total: 0 };
+  const live = d?.live ?? { quarantined: [], approved: [], dismissed: [], total: 0 };
   const totFind = findings.reduce((a, r) => a + Number(r.n || 0), 0);
   const promoted = Number((promotion.find((r) => r.outcome === "promoted") || {}).n || 0);
   const blocked = Number((promotion.find((r) => r.outcome === "blocked") || {}).n || 0);
@@ -1684,16 +1684,27 @@ function securityHtml(d: SecuritySnapshot | null): string {
   ]);
   // Live blocks (this session) - what the gate actually stopped in THIS GUI, with the audited
   // "Approve & retry" override. Sits up top so the toast "Review" lands on something actionable.
-  if (live.quarantined.length || live.approved.length) {
+  if (live.quarantined.length || live.approved.length || live.dismissed.length) {
     const rows = live.quarantined.length
       ? live.quarantined.map((b) => `<div class="liveblk">
           <div class="lb-head"><span class="pill quarantined">${esc(b.severity)}</span><b>${esc(b.tool)}</b><span class="lb-reason">${esc(b.reason)}</span></div>
           <div class="lb-foot"><span class="lb-meta">${esc(b.findings || "no detail")} · ${esc(relTime(Date.parse(b.at)))}</span>
-            <button class="btn-mini ok" data-approve="${esc(b.id)}" data-tip="Approve &amp; retry|Release this one blocked call (audited) and re-send your last message so the agent can try again. Use only if you're sure it was a false positive.">${icon("check", 13)} Approve &amp; retry</button></div>
+            <button class="btn-mini ok" data-approve="${esc(b.id)}" data-tip="Approve &amp; retry|Release this one blocked call (audited) and re-send your last message so the agent can try again. Use only if you're sure it was a false positive.">${icon("check", 13)} Approve &amp; retry</button>
+            <button class="btn-mini dismiss" data-dismiss="${esc(b.id)}" data-tip="Dismiss|Acknowledge this block and move it to the Dismissed section. The call STAYS blocked - this only clears it from the active queue. The audit record is kept.">${icon("close", 13)} Dismiss</button></div>
         </div>`).join("")
-      : `<div class="empty">No active blocks - everything released or clean.</div>`;
+      : `<div class="empty">No active blocks - everything released, dismissed, or clean.</div>`;
     const approvedNote = live.approved.length ? `<div class="lb-approved">${icon("check", 12)} ${live.approved.length} released this session · audited</div>` : "";
-    h += accordion("sec.live", "Live blocks", "this session · gate-enforced", rows + approvedNote, true, String(live.quarantined.length));
+    // Dismissed: reviewed + acknowledged, STILL blocked. Muted + collapsed, out of the active count.
+    const dismissedNote = live.dismissed.length
+      ? `<details class="lb-dismissed"><summary>${live.dismissed.length} dismissed · still blocked · audited</summary>`
+        + live.dismissed.map((b) => `<div class="liveblk muted">
+            <div class="lb-head"><span class="pill dismissed">${esc(b.severity)}</span><b>${esc(b.tool)}</b><span class="lb-reason">${esc(b.reason)}</span></div>
+            <div class="lb-foot"><span class="lb-meta">${esc(b.findings || "no detail")} · ${esc(relTime(Date.parse(b.at)))}</span>
+              <button class="btn-mini ok" data-approve="${esc(b.id)}" data-tip="Approve &amp; retry|Release this blocked call (audited) and re-send your last message. Use only if you now trust the source.">${icon("check", 13)} Approve &amp; retry</button></div>
+          </div>`).join("")
+        + `</details>`
+      : "";
+    h += accordion("sec.live", "Live blocks", "this session · gate-enforced", rows + approvedNote + dismissedNote, true, String(live.quarantined.length));
   }
   if (!d && !live.total) { h += `<div class="empty">Nothing has tripped the scanner yet. The moment a tool call carries hidden-Unicode or another injection, the finding, the quarantine queue, and the audit trail appear right here.</div>`; return h; }
   h += accordion("sec.quarantine", "Quarantine review", "isolated · fail-closed",
@@ -3435,6 +3446,25 @@ function wire(): void {
           actions: [{ label: "OK" }], timeout: 4500,
         });
         if (retry && !state.streaming) { const ta = $("#input") as HTMLTextAreaElement; ta.value = retry; void send(); }
+      })();
+      return;
+    }
+    // Dismiss: acknowledge a reviewed block — moves it to the Dismissed section WITHOUT releasing it
+    // (the call stays blocked, the audit record is kept). Clears it from the active "quarantined" count.
+    const dismiss = (e.target as HTMLElement).closest("[data-dismiss]") as HTMLElement | null;
+    if (dismiss) {
+      const id = dismiss.dataset.dismiss!;
+      (dismiss as HTMLButtonElement).disabled = true;
+      void (async () => {
+        const r = await bridge.securityDismiss(id);
+        if (!r) { showToast({ title: "Already handled", desc: "That block was already released or dismissed.", actions: [{ label: "OK" }], timeout: 3000 }); return; }
+        await refresh(); // drop it from the active list + counts, into the Dismissed section
+        showToast({
+          title: "Dismissed · still blocked",
+          desc: "Moved to the Dismissed section. The call stays blocked; the audit record is kept.",
+          meta: `tool=${r.tool} · dismissed`,
+          actions: [{ label: "OK" }], timeout: 4000,
+        });
       })();
       return;
     }

--- a/desktop/renderer/bridge.ts
+++ b/desktop/renderer/bridge.ts
@@ -7,12 +7,12 @@
 // native-only is window controls + crisp text zoom, exposed by the Electron
 // preload as `window.lucid`; in a plain browser those fall back to CSS zoom.
 
-export interface BlockRecord { id: string; tool: string; severity: string; findings: string; reason: string; at: string; status: "quarantined" | "approved"; reviewer?: string }
+export interface BlockRecord { id: string; tool: string; severity: string; findings: string; reason: string; at: string; status: "quarantined" | "approved" | "dismissed"; reviewer?: string }
 export interface SecuritySnapshot {
   findings: any[]; unicode: any[]; approvals: any[]; quarantine: any[];
   promotion: any[]; exports: any[]; runs: any[];
   // GUI-owned LIVE gate blocks (ADR-0019 C) - present even when the DuckDB views are empty.
-  live?: { quarantined: BlockRecord[]; approved: BlockRecord[]; total: number };
+  live?: { quarantined: BlockRecord[]; approved: BlockRecord[]; dismissed: BlockRecord[]; total: number };
 }
 export interface MemorySnapshot {
   session: null | {
@@ -208,6 +208,7 @@ export interface LucidBridge {
   security(): Promise<SecuritySnapshot | null>;
   /** Release one quarantined call - the audited fail-closed override (ADR-0019 C). */
   securityApprove(id: string): Promise<BlockRecord | null>;
+  securityDismiss(id: string): Promise<BlockRecord | null>;
   memory(): Promise<MemorySnapshot | null>;
   budget(): Promise<{ label: string; used: number; status: string; resetsAt: number | null }[] | null>;
   // P10.3: live API-key rate-limit probe (opt-in). `rateLimits()` returns probed limits ([] when off);
@@ -412,6 +413,7 @@ export const bridge: LucidBridge = {
   isElectron: !!shell?.isElectron,
   security: () => getData("/api/security"),
   securityApprove: (id) => post("/api/security/approve", { id }),
+  securityDismiss: (id) => post("/api/security/dismiss", { id }),
   memory: () => getData("/api/memory"),
   budget: () => getData("/api/budget"),
   rateLimits: (force) => getData(`/api/ratelimits${force ? "?force=1" : ""}`),

--- a/desktop/renderer/styles.css
+++ b/desktop/renderer/styles.css
@@ -897,6 +897,16 @@ body.resizing .sidebar,body.resizing .inspector{transition:none}
 .btn-mini:hover{background:var(--bg-3);color:var(--txt)}
 .btn-mini.ok:hover{border-color:var(--green);color:#84e3a6}
 .btn-mini.danger:hover{border-color:var(--red);color:#ff9b9b}
+/* Dismissed live blocks (acknowledged, STILL blocked) - muted + collapsed, out of the active count. */
+.pill.dismissed{background:var(--bg-3);color:var(--txt-2);border-color:var(--line)}
+.liveblk.muted{border-color:var(--line);background:color-mix(in srgb,var(--bg-2) 70%,transparent);opacity:.78}
+.lb-dismissed{margin-top:8px}
+.lb-dismissed>summary{cursor:pointer;list-style:none;font-size:11px;color:var(--txt-2);padding:4px 2px;user-select:none}
+.lb-dismissed>summary::-webkit-details-marker{display:none}
+.lb-dismissed>summary:hover{color:var(--txt)}
+.lb-dismissed>summary::before{content:"\25B8";display:inline-block;margin-right:6px;transition:transform var(--t-fast)}
+.lb-dismissed[open]>summary::before{transform:rotate(90deg)}
+.lb-dismissed .liveblk{margin-top:6px}
 
 /* provider budget */
 .bgt-head{display:flex;align-items:center;gap:10px;margin:0 0 8px}

--- a/desktop/security_log.ts
+++ b/desktop/security_log.ts
@@ -21,9 +21,10 @@ export interface BlockRecord {
   reason: string;
   sessionId?: string;
   at: string; // ISO timestamp
-  status: "quarantined" | "approved";
+  status: "quarantined" | "approved" | "dismissed";
   reviewer?: string;
   approvedAt?: string;
+  dismissedAt?: string;
 }
 
 const LOG_PATH = join(homedir(), ".omp", "lucid-blocks.jsonl");
@@ -37,8 +38,9 @@ function load(): BlockRecord[] {
     if (existsSync(LOG_PATH)) {
       for (const line of readFileSync(LOG_PATH, "utf8").split("\n")) {
         if (!line.trim()) continue;
-        const o = JSON.parse(line) as BlockRecord & { _approval?: boolean };
+        const o = JSON.parse(line) as BlockRecord & { _approval?: boolean; _dismiss?: boolean };
         if (o._approval) { const r = byId.get(o.id); if (r) { r.status = "approved"; r.reviewer = o.reviewer; r.approvedAt = o.approvedAt; } }
+        else if (o._dismiss) { const r = byId.get(o.id); if (r) { r.status = "dismissed"; r.reviewer = o.reviewer; r.dismissedAt = o.dismissedAt; } }
         else byId.set(o.id, { ...o, status: o.status ?? "quarantined" });
       }
     }
@@ -73,11 +75,23 @@ export function approveBlock(id: string, reviewer = "user"): BlockRecord | null 
   return r;
 }
 
-export interface LiveBlocks { quarantined: BlockRecord[]; approved: BlockRecord[]; total: number }
+/** Acknowledge a block WITHOUT releasing it: the call stays blocked (never imported/run) — this only
+ *  moves it out of the active queue into the Dismissed section so a reviewed, correctly-blocked event
+ *  stops lighting the "quarantined" count. The audit record is RETAINED (never deleted). Returns null
+ *  if unknown or not currently quarantined (approved blocks aren't dismissable). */
+export function dismissBlock(id: string, reviewer = "user"): BlockRecord | null {
+  const r = load().find((x) => x.id === id);
+  if (!r || r.status !== "quarantined") return null;
+  r.status = "dismissed"; r.reviewer = reviewer; r.dismissedAt = new Date().toISOString();
+  append({ _dismiss: true, id, reviewer, dismissedAt: r.dismissedAt });
+  return r;
+}
+
+export interface LiveBlocks { quarantined: BlockRecord[]; approved: BlockRecord[]; dismissed: BlockRecord[]; total: number }
 
 /** The live-block view for the Security panel (most-recent first, capped). */
 export function liveBlocks(): LiveBlocks {
   const all = load();
   const recent = (s: BlockRecord["status"]) => all.filter((b) => b.status === s).slice(-100).reverse();
-  return { quarantined: recent("quarantined"), approved: recent("approved"), total: all.length };
+  return { quarantined: recent("quarantined"), approved: recent("approved"), dismissed: recent("dismissed"), total: all.length };
 }


### PR DESCRIPTION
## The problem (reported)

> "What am I supposed to do with these? I can't delete them — it only gives me Approve & retry or stay in the live blocks."

Quarantined live blocks (e.g. blocked skill imports caught by the gate) had **only "Approve & retry"**. There was no way to clear a block you *correctly don't want to release* — so poison/test blocks kept the red **"quarantined"** count lit forever.

## The fix

A **Dismiss** action that **acknowledges without releasing**:
- The block moves to a muted, collapsed **"Dismissed"** section and out of the active count.
- The call **stays blocked** — never imported/run. Dismiss is *acknowledge*, **not delete**.
- The **audit record is retained**: the JSONL keeps the original block + a `_dismiss` marker (security records must persist — ADR-0019).
- "Approve & retry" is still available from the Dismissed section in case you change your mind.

### Changes
- `security_log.ts` — `dismissBlock(id)` (quarantined → dismissed via a `_dismiss` marker; `load()` applies it); `liveBlocks()` returns a `dismissed` list; status union gains `"dismissed"`.
- `dev.ts` — `POST /api/security/dismiss`.
- `bridge.ts` — `BlockRecord` status + `live.dismissed` + `securityDismiss()`.
- `app.ts` — Dismiss button per quarantined block + collapsed "Dismissed" subsection + handler.
- `styles.css` — muted styles for the dismissed rows/section.

## Verified live

Against the real `~/.omp/lucid-blocks.jsonl`: dismissing a block dropped **quarantined 3 → 2**, created the **"1 dismissed · still blocked · audited"** section, and appended a `_dismiss` marker **while keeping the original record** (confirmed nothing deleted). Tooltip copy confirmed. Typecheck clean; `bun test desktop` **407 / 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)