### PR TITLE
fix(ci): stamp a monotonic build version so in-app auto-update actually fires

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -67,6 +67,18 @@ jobs:
       # fetched + SHA-256-verified by desktop/build/fetch-runtimes.ts, which each `dist:<os>` script
       # runs first (pinned versions, vendor-cross-checked hashes — fail-closed). The old inline
       # `latest`-curl steps were unpinned/unverified AND shadowed that path, so they were removed.
+      # electron-updater compares VERSION numbers. A rolling "latest" release that always ships 0.1.0
+      # never looks newer than an installed 0.1.0, so the in-app updater is a permanent no-op (the new
+      # code is in the installer, but auto-update refuses to fetch it). Stamp a MONOTONIC version per
+      # build: the git tag for tagged releases, else 0.1.<run number>. Build-time only (not committed).
+      - name: Set build version (so auto-update sees a newer release)
+        shell: bash
+        working-directory: desktop
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then V="${GITHUB_REF#refs/tags/v}"; else V="0.1.${GITHUB_RUN_NUMBER}"; fi
+          node -e "const fs=require('fs'),p=require('./package.json');p.version=process.argv[1];fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')" "$V"
+          echo "build version = $V"
+
       - name: Build installer (${{ matrix.script }})
         run: bun run ${{ matrix.script }}
         working-directory: desktop


### PR DESCRIPTION
## The bug (reported live)

A merged feature (the security-block **Dismiss** button) never appeared in an installed app, even after a fresh build was published. Cause: **every build ships version `0.1.0`**, and the rolling "latest" release advertises `version: 0.1.0` in `latest.yml`. `electron-updater` only updates to a **higher** version, so an installed `0.1.0` app checks the feed, sees `0.1.0 == 0.1.0`, and concludes it's current — **forever**. The new code is in the published `Setup.exe`; auto-update just refuses to fetch it.

## The fix

Stamp a **monotonic version** per build, right before `electron-builder` packages:
- tagged release (`refs/tags/v*`) → the tag version
- otherwise → `0.1.${{ github.run_number }}`

Build-time only (the committed dev version stays `0.1.0`). After this lands and one rolling build publishes `0.1.<N>` (> `0.1.0`), existing `0.1.0` installs will finally see a newer release and auto-update.

## Notes
- Fixes **Windows + Linux** auto-update. **macOS** auto-update additionally needs a *signed* build (Squirrel.Mac refuses unsigned) — unchanged, separate concern.
- This is the connected-channel (Channel A) counterpart to the offline update design in the private repo's ADR-A009.
- Verified: workflow YAML parses; `shell: bash` + `node` are available on all three runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)