### PR TITLE
fix(security): live-block time shows "unknown" not "NaNd ago" for a bad timestamp

### DIFF
--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -213,6 +213,7 @@ function buildShell(): void {
 
 // ───────────────────────── sidebar (real omp sessions) ─────────────────────────
 function relTime(ms: number): string {
+  if (!Number.isFinite(ms)) return "unknown"; // a missing/unparseable timestamp must not render "NaNd ago"
   const s = Math.round((Date.now() - ms) / 1000);
   if (s < 60) return "just now";
   const m = Math.floor(s / 60); if (m < 60) return `${m}m ago`;


### PR DESCRIPTION
## Bug (reported)

A live gate block with a missing/unparseable `at` rendered **"NaNd ago"** in the Security panel (`relTime(NaN)` falls through to `${Math.floor(NaN/24)}d ago`).

## Fix

One-line guard: non-finite input → **"unknown"**. Valid timestamps unchanged. The malformed block can now also just be cleared with **Dismiss**.

Typecheck clean. (Not browser-verified — reproducing needs a malformed-block fixture — but the guard is trivially correct.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)