### PR TITLE
feat(rag): P-RAG.1b — real bge-small embedder (semantic retrieval) behind the seam

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -5295,3 +5295,63 @@ deciding is not a stalled turn.
 
 ADR-0027/P-ACP.3 (the tool-permission forwarding this extends), ADR-0019 (the content gate this complements
 with an egress gate), ADR-0059 (the diagnostics that surfaced the browser flailing). CLAUDE.md #3/#4.
+
+-----
+
+## ADR-0063 - P-RAG.1b: the real WASM embedder (bge-small-en-v1.5) behind the P-RAG.1 seam
+
+**Date:** 2026-06-25
+**Status:** Accepted - BUILT.
+**Increment:** P-RAG.1b.
+
+### Context
+
+P-RAG.1 (ADR-0058) shipped the knowledge spine against a deterministic `HashEmbedder` stub: enough to
+prove the scan-gate + store + cosine-retrieval plumbing, but a bag-of-words hash only matches SHARED
+vocabulary - it has no notion of meaning, so "a small furry pet that meows" and "kittens are
+housecats" look unrelated. The whole point of RAG is semantic recall. P-RAG.1b drops in a real model.
+
+### Decision - one concrete embedder behind the existing seam
+
+`TransformersEmbedder` (`harness/knowledge/transformers_embedder.ts`) implements the unchanged
+`Embedder` interface (`id`, `dim`, `embed`) with **`bge-small-en-v1.5` (384-dim)** via
+[transformers.js](https://github.com/huggingface/transformers.js) (`@huggingface/transformers`),
+mean-pooled + L2-normalized so DuckDB `list_cosine_distance` stays meaningful. The model is loaded
+LAZILY once and reused. Because it is just another `Embedder`, ingest.ts, store.ts, and every existing
+test are untouched - **tests keep `HashEmbedder` (fast, no download); production passes this one**.
+
+**Air-gap (ADR-0053).** `TransformersEmbedder({ modelPath })` sets `env.localModelPath` +
+`env.allowRemoteModels = false`, so a bundled-weights deployment loads ONLY from disk and never reaches
+the HuggingFace Hub. Without `modelPath` the model is fetched once and cached (dev / connected).
+
+**Backend - WASM is the shipped path, deferred to P-RAG.1c.** transformers.js's Node build runs
+`onnxruntime-node` (native CPU), which is present in the harness + dev server where ingest/retrieval run
+today, so 1b works there now. The packaged desktop build excludes native binaries in favor of a WASM
+backend (ADR-0053); transformers.js only exposes WASM through its separate **web build**
+(`onnxruntime-web`), and `device: "wasm"` is NOT accepted by the node build. Wiring the WASM web build +
+bundling the model weights as `extraResources` into the SHIPPED app is **P-RAG.1c** (the Knowledge UI
+increment). This module is backend-agnostic - callers only ever see `Embedder` - so that switch never
+touches ingest or retrieval.
+
+**Scope - PDF deferred.** ADR-0053 paired the embedder with `unpdf` PDF->text. To keep one clean
+increment, PDF (and image) ingest moves to **P-RAG.1c** alongside the ingest UI; 1b is the embedder.
+
+### Consequences
+
+- Retrieval is genuinely SEMANTIC. `make demo-P-RAG.1b` proves it: a query sharing **zero** content
+  words with the target chunk still ranks it first (kittens d=0.47, vs unrelated 0.58 / 0.72), while the
+  tampered note is still blocked fail-closed and the hit is still wrapped UNTRUSTED + delimited.
+- New dep `@huggingface/transformers` (+ onnxruntime). It is NOT yet imported by the dev server / chat
+  path (only the demo + test), so the packaged app loads no model until 1c wires it deliberately.
+- The real-model test is opt-in (`LUCID_TEST_EMBED=1`); the normal suite stays fast and network-free.
+
+### Invariants preserved
+
+Same `Embedder` seam (#frozen-contract spirit - callers/tests unchanged); the fail-closed gate runs
+UPSTREAM of the embedder, so poisoned text is never embedded (#3/#5); keystone #2 holds - RAG chunks are
+retrieval context, never semantic-memory promotion.
+
+### Relates to
+
+ADR-0058 (the seam this fills), ADR-0053 (RAG scope: WASM / bundled weights / air-gap / the deferred PDF
++ UI), CLAUDE.md invariants #2 (transformers.js is JS/WASM, not a second Python) / #3 / #5 + keystone #2.

--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,10 @@ demo-P-GOAL.12: ## P-GOAL.12 (ADR-0057): Pre-Flight Audit — readiness L0→L3,
 demo-P-RAG.1: ## P-RAG.1 (ADR-0058): local knowledge spine — scan-gated ingest, fail-closed block, offline cosine retrieval, delimited injection
 	$(BUN) run harness/scripts/demo_prag1.ts
 
+.PHONY: demo-P-RAG.1b
+demo-P-RAG.1b: ## P-RAG.1b (ADR-0063): real bge-small embedder — SEMANTIC retrieval (zero shared words), still scan-gated + delimited
+	$(BUN) run harness/scripts/demo_prag1b.ts
+
 .PHONY: demo-P-ASKSAGE.1
 demo-P-ASKSAGE.1: ## P-ASKSAGE.1 (ADR-0059): AskSage tool-loop diagnostics + tolerant extraction — wrapped replies recovered, empty turns flagged
 	$(BUN) run harness/scripts/demo_paskage1.ts

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2314,3 +2314,9 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
   criteria to the immediate next run only; automations still don't take a budget/criteria.
 - **next:** escalation ping on unattended stop; a budget + criteria field for scheduled automations; an
   optional multi-turn interview.
+
+---
+**P-RAG.1b - the real bge-small embedder (ADR-0063)**
+- **shipped:** `TransformersEmbedder` (bge-small-en-v1.5, 384d, transformers.js) behind the unchanged P-RAG.1 `Embedder` seam - semantic retrieval proven by `demo-P-RAG.1b` (a query sharing ZERO content words ranks the right chunk first: kittens d=0.47 vs 0.58/0.72); air-gap `modelPath` option (local weights + remote disabled); opt-in real-model test (`LUCID_TEST_EMBED=1`). harness 513 pass / 1 skip / 0 fail; typecheck clean.
+- **stubbed:** the WASM web-build backend + bundled model WEIGHTS for the PACKAGED app are deferred to P-RAG.1c (node/native backend works in the harness + dev server today); the embedder is not yet imported by the chat path.
+- **next:** P-RAG.1c - Knowledge ingest UI + PDF (`unpdf`) + image caption-at-ingest + per-turn retrieval injection + the WASM packaging (bundle weights as extraResources).

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "lucid-agent-ide-harness",
       "dependencies": {
         "@duckdb/node-api": "1.5.4-r.1",
+        "@huggingface/transformers": "^4.2.0",
         "@oh-my-pi/pi-agent-core": "16.0.6",
         "@oh-my-pi/pi-ai": "16.0.6",
         "@oh-my-pi/pi-coding-agent": "16.0.6",
@@ -558,7 +559,7 @@
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
-    "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
+    "sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
 
     "stack-trace": ["stack-trace@0.0.10", "", {}, "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg=="],
 
@@ -656,6 +657,8 @@
 
     "ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
+    "argparse/sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
+
     "chromium-bidi/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
@@ -665,8 +668,6 @@
     "markit-ai/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "onnxruntime-web/onnxruntime-common": ["onnxruntime-common@1.24.0-dev.20251116-b39e144322", "", {}, "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw=="],
-
-    "roarr/sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
 
     "rss-parser/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
 

--- a/harness/knowledge/transformers_embedder.test.ts
+++ b/harness/knowledge/transformers_embedder.test.ts
@@ -1,0 +1,32 @@
+// P-RAG.1b (ADR-0063): TransformersEmbedder contract. The CHEAP checks (id/dim/empty-batch) run in the
+// normal suite without loading the model. The real-model proof (slow: downloads/loads bge-small) is
+// OPT-IN via LUCID_TEST_EMBED=1 and otherwise lives in `make demo-P-RAG.1b`, so `bun test harness`
+// stays fast and never needs network/weights.
+
+import { test, expect } from "bun:test";
+import { TransformersEmbedder } from "./transformers_embedder.ts";
+
+test("advertises bge-small-en-v1.5 @ 384 dim (the dataset vector-space tag)", () => {
+  const e = new TransformersEmbedder();
+  expect(e.id).toBe("bge-small-en-v1.5");
+  expect(e.dim).toBe(384);
+});
+
+test("embed([]) is a no-op and never loads the model", async () => {
+  const e = new TransformersEmbedder();
+  expect(await e.embed([])).toEqual([]);
+});
+
+const realTest = process.env.LUCID_TEST_EMBED === "1" ? test : test.skip;
+realTest("real embeddings are 384-dim, unit-norm, and SEMANTIC (cat~feline > cat~revenue)", async () => {
+  const e = new TransformersEmbedder();
+  const [cat, feline, revenue] = await e.embed([
+    "the cat sat on the mat",
+    "a feline rested on a rug",
+    "quarterly revenue grew twelve percent",
+  ]);
+  const dot = (a: number[], b: number[]) => a.reduce((s, x, i) => s + x * b[i]!, 0);
+  expect(cat!.length).toBe(384);
+  expect(Math.sqrt(dot(cat!, cat!))).toBeCloseTo(1, 3); // L2-normalized
+  expect(dot(cat!, feline!)).toBeGreaterThan(dot(cat!, revenue!)); // meaning, not shared words
+});

--- a/harness/knowledge/transformers_embedder.ts
+++ b/harness/knowledge/transformers_embedder.ts
@@ -1,0 +1,62 @@
+// harness/knowledge/transformers_embedder.ts
+//
+// P-RAG.1b (ADR-0063): the REAL embedder behind the P-RAG.1 `Embedder` seam (ADR-0058). Drops in
+// `bge-small-en-v1.5` (384-dim) via transformers.js, replacing the HashEmbedder stub with genuine
+// SEMANTIC vectors — documents that MEAN the same thing now rank close even with no shared words
+// (the hash bag-of-words stub can only match shared vocabulary). Same `Embedder` interface, so
+// ingest.ts / store.ts and every test are untouched: tests keep HashEmbedder, production swaps this in.
+//
+// Air-gap (ADR-0053): pass `modelPath` to load BUNDLED weights with the network disabled, so an
+// offline / air-gapped deployment never reaches the HuggingFace Hub. Without it, the model is fetched
+// once and cached (dev / connected).
+//
+// Backend note: transformers.js's Node build runs onnxruntime-node (native CPU) — fine for the harness
+// + dev server (where ingest/retrieval run today). The packaged desktop app excludes that native binary
+// in favor of a WASM backend (ADR-0053); wiring the WASM web build into the SHIPPED app is the
+// P-RAG.1c packaging step. This module is backend-agnostic — callers only see `Embedder` — so that
+// switch never touches ingest or retrieval.
+
+import { pipeline, env, type FeatureExtractionPipeline } from "@huggingface/transformers";
+import type { Embedder } from "./embedder.ts";
+
+const MODEL_ID = "Xenova/bge-small-en-v1.5"; // the ONNX build on the Hub
+const DIM = 384;
+
+export interface TransformersEmbedderOptions {
+  /** A local directory of bundled model weights. When set, remote model fetches are DISABLED
+   *  (air-gap): transformers.js loads ONLY from this path, never the network. */
+  modelPath?: string;
+}
+
+export class TransformersEmbedder implements Embedder {
+  readonly id = "bge-small-en-v1.5"; // recorded on the dataset as its vector-space tag
+  readonly dim = DIM;
+  private pipe: Promise<FeatureExtractionPipeline> | null = null;
+
+  constructor(private readonly opts: TransformersEmbedderOptions = {}) {}
+
+  /** Lazily load the model ONCE and reuse it across calls. */
+  private load(): Promise<FeatureExtractionPipeline> {
+    if (!this.pipe) {
+      if (this.opts.modelPath) {
+        env.localModelPath = this.opts.modelPath;
+        env.allowRemoteModels = false; // air-gap: never touch the network
+      }
+      this.pipe = pipeline("feature-extraction", MODEL_ID) as Promise<FeatureExtractionPipeline>;
+    }
+    return this.pipe;
+  }
+
+  async embed(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) return []; // no-op, and no model load for an empty batch
+    const pipe = await this.load();
+    // bge wants mean-pooled + L2-normalized sentence embeddings → unit vectors for cosine.
+    const out = await pipe(texts, { pooling: "mean", normalize: true });
+    const rows = out.tolist() as number[][];
+    // Fail LOUD on a dim mismatch — a wrong-width vector would silently poison cosine retrieval.
+    if (rows[0] && rows[0].length !== DIM) {
+      throw new Error(`TransformersEmbedder: expected ${DIM}-dim vectors, got ${rows[0].length}`);
+    }
+    return rows;
+  }
+}

--- a/harness/scripts/demo_prag1b.ts
+++ b/harness/scripts/demo_prag1b.ts
@@ -1,0 +1,80 @@
+// harness/scripts/demo_prag1b.ts
+//
+// P-RAG.1b (ADR-0063): the REAL embedder. Same spine as P-RAG.1, but `bge-small-en-v1.5` (384-dim)
+// replaces the hash stub — so retrieval is SEMANTIC. The headline proof (step 3): a query that shares
+// ZERO content words with the target chunk still retrieves it first. The hash bag-of-words stub
+// CANNOT do this (no shared tokens ⇒ no signal); a real embedding can, because it matches meaning.
+// The fail-closed gate (step 2) is unchanged — poisoned text never reaches the embedder.
+//
+// Run with: bun run harness/scripts/demo_prag1b.ts   (first run downloads the model; then cached)
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { ScannerClient } from "../security/scanner_client.ts";
+import { TransformersEmbedder } from "../knowledge/transformers_embedder.ts";
+import { KnowledgeStore } from "../knowledge/store.ts";
+import { ingestText, wrapRetrieved } from "../knowledge/ingest.ts";
+
+const dir = mkdtempSync(join(homedir(), ".lucid-demo-prag1b-"));
+const scanner = new ScannerClient();
+let store: KnowledgeStore | null = null;
+const cleanup = () => { try { scanner.stop(); } catch { /* ignore */ } try { store?.close(); } catch { /* ignore */ } rmSync(dir, { recursive: true, force: true }); };
+const fail = (m: string): never => { cleanup(); console.error(`FAIL: ${m}`); process.exit(1); };
+
+// Three documents on three unrelated topics, each its own chunk.
+const DOCS: Record<string, string> = {
+  "pets.txt": "Kittens are playful young housecats. They purr softly when content and chase a ball of yarn for hours.",
+  "finance.txt": "The firm reported strong quarterly earnings, with revenue climbing sharply compared with the previous year.",
+  "coast.txt": "At dusk the tide slips back and gentle swells fold quietly onto the deserted shoreline.",
+};
+// A query that describes the pets doc using NONE of its words — pure meaning.
+const QUERY = "a small furry pet that meows and likes to nap in the sun";
+
+const TAMPERED = `This note looks ordinary but hides a Trojan-Source payload: Miti‮gate​ the rollback.`;
+
+const words = (s: string) => new Set((s.toLowerCase().match(/[a-z]+/g) ?? []).filter((w) => w.length > 3));
+
+try {
+  scanner.start();
+  store = await KnowledgeStore.open(join(dir, "knowledge.duckdb"));
+  const emb = new TransformersEmbedder();
+  const ds = await store.createDataset({ name: "topics", classification: "U", source: "local", embeddingModel: emb.id, dim: emb.dim });
+
+  console.log(`== [1/4] three CLEAN topic docs are scan-gated, embedded (${emb.id}, ${emb.dim}d), and stored ==`);
+  for (const [path, text] of Object.entries(DOCS)) {
+    const r = await ingestText({ store, scanner, embedder: emb, datasetId: ds.dataset_id, sourcePath: path, text, chunkOptions: { maxChars: 400, overlapChars: 0 } });
+    if (r.stored !== 1 || r.blocked !== 0) fail(`${path}: expected 1 stored, 0 blocked; got ${JSON.stringify({ stored: r.stored, blocked: r.blocked })}`);
+  }
+  console.log(`   stored ${await store.chunkCount(ds.dataset_id)} chunks across 3 topics`);
+
+  console.log("\n== [2/4] a TAMPERED note (bidi/zero-width) is BLOCKED — never embedded, never stored ==");
+  const before = await store.chunkCount(ds.dataset_id);
+  const r2 = await ingestText({ store, scanner, embedder: emb, datasetId: ds.dataset_id, sourcePath: "tampered.txt", text: TAMPERED });
+  if (r2.stored !== 0 || r2.blocked < 1) fail(`tampered note must be blocked; got ${JSON.stringify({ stored: r2.stored, blocked: r2.blocked })}`);
+  if (await store.chunkCount(ds.dataset_id) !== before) fail("store count changed on a blocked ingest");
+  console.log(`   blocked ${r2.blocked} chunk(s)  ·  store count unchanged at ${before}`);
+
+  console.log("\n== [3/4] SEMANTIC retrieval: a query with ZERO shared words still finds the right chunk ==");
+  const [q] = await emb.embed([QUERY]);
+  const hits = await store.retrieve(ds.dataset_id, q!, 3);
+  if (hits.length < 3) fail("retrieval should return all three chunks ranked");
+  const top = hits[0]!;
+  if (!/Kittens/.test(top.text)) fail(`expected the pets chunk first; got: ${top.text.slice(0, 50)}`);
+  const overlap = [...words(QUERY)].filter((w) => words(top.text).has(w));
+  if (overlap.length !== 0) fail(`the query shares words with the hit (${overlap.join(",")}) — not a clean semantic-only proof`);
+  console.log(`   query: "${QUERY}"`);
+  console.log(`   shared content words with the winning chunk: ${overlap.length}  (purely semantic match)`);
+  for (const h of hits) console.log(`     d=${h.distance.toFixed(4)}  ${h.text.slice(0, 52)}...`);
+
+  console.log("\n== [4/4] the retrieved chunk is wrapped as delimited, untrusted data ==");
+  const wrapped = wrapRetrieved(hits.slice(0, 1));
+  if (!wrapped.startsWith("UNTRUSTED_CONTENT_START") || !wrapped.endsWith("UNTRUSTED_CONTENT_END")) fail("injection must be delimited");
+  console.log("   " + wrapped.split("\n")[0] + "  ...  " + wrapped.split("\n").slice(-1)[0]);
+
+  cleanup();
+  console.log("\nPASS: real bge-small embedder — semantic retrieval (no shared vocabulary), still scan-gated + fail-closed + delimited.");
+} catch (e) {
+  fail(String((e as Error)?.stack ?? e));
+}
+process.exit(0);

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "demo-P-TPS.1": "bun run harness/scripts/demo_ptps1.ts",
     "demo-P-SKILL.1": "bun run harness/scripts/demo_pskill1.ts",
     "demo-P-RAG.1": "bun run harness/scripts/demo_prag1.ts",
+    "demo-P-RAG.1b": "bun run harness/scripts/demo_prag1b.ts",
     "demo-P-ASKSAGE.1": "bun run harness/scripts/demo_paskage1.ts",
     "dashboards": "bun run harness/scripts/materialize_dashboards.ts",
     "omp:secure": "omp -e harness/omp/security_extension.ts -e harness/omp/token_speed_extension.ts",
@@ -54,6 +55,7 @@
   },
   "dependencies": {
     "@duckdb/node-api": "1.5.4-r.1",
+    "@huggingface/transformers": "^4.2.0",
     "@oh-my-pi/pi-agent-core": "16.0.6",
     "@oh-my-pi/pi-ai": "16.0.6",
     "@oh-my-pi/pi-coding-agent": "16.0.6",


### PR DESCRIPTION
## What

P-RAG.1 shipped the knowledge spine against a deterministic **HashEmbedder stub** — enough to prove the scan-gate + store + cosine plumbing, but a bag-of-words hash only matches *shared vocabulary*. P-RAG.1b drops in a real model so retrieval is **semantic**.

`TransformersEmbedder` (`bge-small-en-v1.5`, 384-dim, transformers.js, mean-pooled + L2-normalized) implements the **unchanged `Embedder` interface** — so `ingest.ts`, `store.ts`, and every existing test are untouched. **Tests keep `HashEmbedder` (fast, no download); production passes the real one.**

## The proof (`make demo-P-RAG.1b`)

A query sharing **zero content words** with the target still retrieves it first — impossible for the hash stub:

```
query: "a small furry pet that meows and likes to nap in the sun"
shared content words with the winning chunk: 0  (purely semantic match)
  d=0.4681  Kittens are playful young housecats...   ← top hit
  d=0.5757  At dusk the tide slips back...
  d=0.7229  The firm reported strong quarterly earnings...
```

Fail-closed gate (tampered note blocked, never embedded) and UNTRUSTED-delimited injection both preserved.

## Scope + deferrals (ADR-0063)

- **Air-gap:** `TransformersEmbedder({ modelPath })` loads bundled weights with the network disabled (ADR-0053). Otherwise fetched once + cached.
- **Backend:** the node build uses `onnxruntime-node` (works in the harness + dev server today). The packaged app's **WASM web-build + bundled weights** are **deferred to P-RAG.1c** — the embedder is backend-agnostic via the seam, and isn't imported by the chat path yet.
- **PDF/image ingest deferred to P-RAG.1c** (with the Knowledge UI), to keep this a clean single increment.
- Real-model test is opt-in (`LUCID_TEST_EMBED=1`); the suite stays fast + network-free.

## Verified
Typecheck clean · `bun test harness` **513 pass / 1 skip / 0 fail** · `make demo-P-RAG.1b` green · prior `demo-P-RAG.1` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)