### PR TITLE
feat(desktop): managed-config update channel (github | feed | managed) — ADR-A009 (#74)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2326,3 +2326,9 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
 - **shipped:** `harness/knowledge/pdf.ts` - `extractPdfText` (unpdf/pdf.js, pure JS, air-gap clean; fail-closed `%PDF-` sniff + non-destructive copy) and `ingestPdf` that delegates to the UNCHANGED scan-gated `ingestText`, so PDF pages are gated/embedded exactly like .txt; `demo-P-RAG.1c` proves semantic retrieval FROM a 3-page PDF (zero-shared-word query ranks the pets page first, d=0.45 vs 0.58/0.70) + a corrupt PDF fails closed; `pdf.test.ts` covers a POISON page blocked + a dead scanner; `pdf_fixture.ts` (test-only PDF writer, no binary in git). harness 518 pass / 1 skip / 0 fail; typecheck clean; new DIRECT dep `unpdf`.
 - **stubbed:** image/scanned-PDF OCR (a text-less PDF yields zero chunks, not an error); PDF code is not yet imported by the dev server / chat path (only pdf.ts + its test + demo).
 - **next:** remaining P-RAG.1c slices - WASM packaging (web build + bundled weights as extraResources), per-turn retrieval injection into chat, Knowledge ingest UI + image caption-at-ingest.
+
+---
+**ADR-A009 / #74 - managed-config update channel (OSS-core)**
+- **shipped:** `managed_config.ts` gains `updateChannel: "github"|"feed"|"managed"` + `updateFeedUrl` and a PURE `resolveUpdatePolicy` (fail-safe: unmanaged/unknown→github, feed-without-url→managed, managed→disabled); `updater.ts` honors it - `managed` skips the in-app check entirely (no offline nag/hang), `feed` points electron-updater's generic provider at the customer mirror, `github` unchanged. 8 new tests; full typecheck clean.
+- **stubbed:** the internal-feed mirror layout + native enterprise packages (MSI/MSIX/rpm/deb/pkg) are the rest of ADR-A009 (private follow-on issues #75-79); macOS feed-update still needs signing.
+- **next:** wire the channel into the managed-config TEMPLATE + ADMX (private ADR-A010), and the Channel-B/C packaging.

--- a/desktop/managed_config.test.ts
+++ b/desktop/managed_config.test.ts
@@ -1,0 +1,44 @@
+// desktop/managed_config.test.ts — the pure update-channel policy resolver (ADR-A009, #74). Fail-safe by
+// design: unmanaged/unknown ⇒ github (never silently disable), feed-without-url ⇒ managed (never hit a
+// wrong/empty feed), managed ⇒ disabled.
+
+import { describe, expect, test } from "bun:test";
+import { resolveUpdatePolicy, type ManagedConfig } from "./managed_config.ts";
+
+describe("resolveUpdatePolicy (ADR-A009 #74)", () => {
+  test("unmanaged (null) defaults to the github channel", () => {
+    expect(resolveUpdatePolicy(null)).toEqual({ channel: "github" });
+  });
+
+  test("a managed config with no updateChannel defaults to github", () => {
+    expect(resolveUpdatePolicy({ orgName: "Acme" })).toEqual({ channel: "github" });
+  });
+
+  test("an unknown channel value fails safe to github (never silently disables updates)", () => {
+    expect(resolveUpdatePolicy({ updateChannel: "nonsense" as never })).toEqual({ channel: "github" });
+  });
+
+  test("github channel is explicit github", () => {
+    expect(resolveUpdatePolicy({ updateChannel: "github" })).toEqual({ channel: "github" });
+  });
+
+  test("feed channel with a URL uses that internal mirror", () => {
+    const mc: ManagedConfig = { updateChannel: "feed", updateFeedUrl: "https://feed.acme.com/lucid/" };
+    expect(resolveUpdatePolicy(mc)).toEqual({ channel: "feed", feedUrl: "https://feed.acme.com/lucid/" });
+  });
+
+  test("feed URL is trimmed", () => {
+    const mc: ManagedConfig = { updateChannel: "feed", updateFeedUrl: "  https://feed.acme.com/  " };
+    expect(resolveUpdatePolicy(mc)).toEqual({ channel: "feed", feedUrl: "https://feed.acme.com/" });
+  });
+
+  test("feed channel with NO usable URL fails safe to managed (no wrong/empty feed)", () => {
+    expect(resolveUpdatePolicy({ updateChannel: "feed" })).toEqual({ channel: "managed" });
+    expect(resolveUpdatePolicy({ updateChannel: "feed", updateFeedUrl: "   " })).toEqual({ channel: "managed" });
+  });
+
+  test("managed channel disables the in-app check (no feedUrl)", () => {
+    expect(resolveUpdatePolicy({ updateChannel: "managed" })).toEqual({ channel: "managed" });
+    expect(resolveUpdatePolicy({ updateChannel: "managed", updateFeedUrl: "https://ignored/" })).toEqual({ channel: "managed" });
+  });
+});

--- a/desktop/managed_config.ts
+++ b/desktop/managed_config.ts
@@ -25,14 +25,28 @@ export interface ManagedAttribution {
   /** If set, the email must end in one of these domains (e.g. ["company.com","contractor.company.com"]). */
   allowedEmailDomains?: string[];
 }
+export type UpdateChannel = "github" | "feed" | "managed";
+
 export interface ManagedConfig {
   /** Shown as "Managed by <orgName>" in the UI. */
   orgName?: string;
   attribution?: ManagedAttribution;
   /** Force AskSage-only (gov gateway) routing. */
   asksageOnly?: boolean;
+  /** ADR-A009: which in-app update channel this fleet uses. Default "github" (today's public feed).
+   *  "feed" = electron-updater generic provider against a customer-hosted mirror (needs updateFeedUrl);
+   *  "managed" = IT owns the version (MSI/MSIX/rpm/deb/pkg), so the in-app update check is DISABLED. */
+  updateChannel?: UpdateChannel;
+  /** The customer-hosted feed URL for updateChannel:"feed" (mirrors latest*.yml + installers). */
+  updateFeedUrl?: string;
   /** Reserved/extensible: pinned mcpServers, BI endpoint, locked workspace roots, etc. */
   [k: string]: unknown;
+}
+
+export interface UpdatePolicy {
+  channel: UpdateChannel;
+  /** Present only when channel === "feed". */
+  feedUrl?: string;
 }
 
 function candidatePaths(): string[] {
@@ -87,3 +101,22 @@ export function skipAllowed(): boolean {
   if (a.requireEmail) return false;
   return a.allowSkip !== false;
 }
+
+/** ADR-A009 (#74): resolve the effective update policy from a (possibly null) managed config. PURE so it
+ *  is unit-testable without files. Fail-safe defaults:
+ *   - unmanaged / unset / unknown value ⇒ "github" (today's behavior — never silently disable updates),
+ *   - "feed" with a non-blank URL ⇒ feed against that URL,
+ *   - "feed" with NO usable URL ⇒ "managed" (disable the check rather than hit a wrong/empty feed),
+ *   - "managed" ⇒ disable the in-app check (IT owns the version). */
+export function resolveUpdatePolicy(mc: ManagedConfig | null): UpdatePolicy {
+  const channel = mc?.updateChannel;
+  if (channel === "managed") return { channel: "managed" };
+  if (channel === "feed") {
+    const feedUrl = typeof mc?.updateFeedUrl === "string" ? mc.updateFeedUrl.trim() : "";
+    return feedUrl ? { channel: "feed", feedUrl } : { channel: "managed" };
+  }
+  return { channel: "github" }; // default + unknown value
+}
+
+/** Read-side: the effective update policy from the live managed config. */
+export function updatePolicy(): UpdatePolicy { return resolveUpdatePolicy(managedConfig().config); }

--- a/desktop/updater.ts
+++ b/desktop/updater.ts
@@ -1,18 +1,34 @@
 // desktop/updater.ts - in-app auto-update via electron-updater.
 //
-// Packaged builds check the GitHub Releases feed (publish provider in
-// package.json) on launch. A new version downloads in the background; when it's
-// ready we ask the user to restart. No-op in dev (no update feed) and safe when
-// offline or when no newer release exists.
+// Packaged builds check an update feed on launch, selected by managed-config
+// (ADR-A009, #74) so ONE binary behaves correctly in any environment:
+//   - "github"  (default): the public GitHub Releases feed (publish provider in
+//                package.json) - today's behavior.
+//   - "feed":   electron-updater's GENERIC provider against a customer-hosted
+//                mirror (updateFeedUrl) - intranet / no-internet, in-app update
+//                still works.
+//   - "managed": IT owns the version (MSI/MSIX/rpm/deb/pkg via SCCM/Intune/YUM/
+//                Jamf), so the in-app check is DISABLED - never nag or hang offline.
+// A new version downloads in the background; when it's ready we ask the user to
+// restart. No-op in dev and safe when offline or when no newer release exists.
 //
 // macOS auto-update requires a SIGNED build (Squirrel.Mac refuses unsigned);
 // Windows (NSIS) updates unsigned but SmartScreen may warn. See desktop/README.
 
 import { app, BrowserWindow, dialog } from "electron";
 import { autoUpdater } from "electron-updater";
+import { updatePolicy } from "./managed_config.ts";
 
 export function initAutoUpdate(getWindow: () => BrowserWindow | null): void {
   if (!app.isPackaged) return; // dev: no feed, would throw on missing config
+
+  // ADR-A009 (#74): the managed-config update channel. "managed" disables the in-app check entirely so
+  // a policy-managed / air-gapped fleet never makes an outbound update call or hangs waiting on one.
+  const policy = updatePolicy();
+  if (policy.channel === "managed") {
+    console.log("[updater] channel=managed — in-app update check disabled (IT owns the version)");
+    return;
+  }
 
   autoUpdater.autoDownload = true;
   autoUpdater.autoInstallOnAppQuit = true;
@@ -35,6 +51,17 @@ export function initAutoUpdate(getWindow: () => BrowserWindow | null): void {
       setImmediate(() => autoUpdater.quitAndInstall());
     }
   });
+
+  // ADR-A009 (#74): "feed" points electron-updater's GENERIC provider at the customer-hosted mirror;
+  // "github" leaves the package.json publish provider untouched (today's behavior).
+  if (policy.channel === "feed" && policy.feedUrl) {
+    try {
+      autoUpdater.setFeedURL({ provider: "generic", url: policy.feedUrl });
+      console.log(`[updater] channel=feed — internal mirror ${policy.feedUrl}`);
+    } catch (e) {
+      console.warn("[updater] feed URL rejected, falling back to default provider:", (e as Error)?.message ?? e);
+    }
+  }
 
   // Best-effort: a failed check (offline, no release yet) must never block launch.
   autoUpdater.checkForUpdates().catch((e) => console.warn("[updater] check failed:", e?.message ?? e));


### PR DESCRIPTION
Implements **TechLead187/lucidagentIDEaddon#74** (PI-4 / ADR-A009) — the OSS-core piece so **one binary behaves correctly in any environment**.

## Change
- `desktop/managed_config.ts` — `ManagedConfig` gains `updateChannel: "github" | "feed" | "managed"` + `updateFeedUrl`, and a **pure, fail-safe `resolveUpdatePolicy`**:
  - unmanaged / unset / unknown → **github** (updates never silently disabled)
  - **feed** with a URL → that internal mirror; feed **without** a usable URL → **managed** (never hit a wrong/empty feed)
  - **managed** → disabled
- `desktop/updater.ts` — honors the policy:
  - **github** (default): the public GitHub Releases feed, unchanged.
  - **feed**: `electron-updater` generic provider → `updateFeedUrl` (intranet mirror; in-app update still works offline-from-internet).
  - **managed**: in-app check **disabled** — no outbound call, no offline nag/hang (IT owns the version via SCCM/Intune/YUM/Jamf packages).

IT selects the channel through the **existing trustworthy managed-config paths** (admin-only file / `LUCID_MANAGED_CONFIG`).

## Verification
- `desktop/managed_config.test.ts` — **8** new tests over the pure resolver (defaults, unknown-value fail-safe, feed trim, feed-without-url → managed, managed disables). Full `bun run typecheck` clean (harness + desktop + server). Sibling policy/config suites green (30/30).
- The `updater.ts` wiring is thin and matches the existing best-effort pattern (no Electron unit harness exists; the runtime branch is reviewed).

## Done when (from #74)
✅ the three channels are selectable by policy: github default, feed → generic provider against a mirror, managed → no outbound update traffic.

Closes TechLead187/lucidagentIDEaddon#74

🤖 Generated with [Claude Code](https://claude.com/claude-code)