### PR TITLE
feat(brief): P-BRIEF.1 — Executive Engineering Update generator behind a vendor-agnostic audio seam (ADR-0070)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -5801,3 +5801,82 @@ block records into the export schema without adding enum values. Frozen prefix u
 `security_log.ts` (the audit extended), ADR-0068 (carries the sink config), ADR-0066/0067/0062 (the
 decisions exported), `contracts.ts` `EventName` (#8), and the private ADR-A011 (the per-SIEM connector
 shapes - the "how").
+
+## ADR-0070 - P-BRIEF.1: Executive Engineering Update — repo logs → brief + podcast behind a vendor-agnostic audio seam
+
+**Date:** 2026-06-26
+**Status:** Accepted - BUILT (slice 1: the generator + the audio seam). Audio backends, the Goal Loop
+accordion, and Slack/Drive delivery are follow-on slices (P-BRIEF.2/.3).
+**Increment:** P-BRIEF.1. Informed by a deep-research pass (NotebookLM Enterprise API, ElevenLabs,
+Podcastfy/Kokoro, Workspace OAuth, Slack) — findings folded in below.
+
+### Context
+
+Goal: an automated "Executive Engineering Update" - a curated written brief AND a podcast - generated
+from a repo's own change history (PROGRESS.md, DECISIONS.md/ADRs, HANDOFF.md, and the goal-loop
+After-Action Report), focused on LOAD-BEARING DEPENDENCIES, TECH DEBT, and UPCOMING DECISIONS, and
+configurable from the Goal Loop UI. The open question was the audio-generation backend; a deep-research
+pass resolved it (verified, 22/25 claims confirmed).
+
+### Research findings (verified)
+
+- **NotebookLM has an official ENTERPRISE API.** `notebooks.audioOverviews.create` (Discovery Engine
+  `google.cloud.notebooklm.v1alpha`, HTTP POST, GCP bearer token) creates notebooks + Audio Overviews
+  programmatically. It is `v1alpha`/Preview (pre-GA, one-audio-overview-per-notebook). The separate
+  standalone Podcast API is DEPRECATED (no new-customer allowlisting) - do NOT build on it.
+- **No headless browser.** omp DOES ship `puppeteer-core`, but driving the CONSUMER NotebookLM is
+  unnecessary given the API and carries real Workspace-AUP suspension risk (24h cure §4.1; immediate
+  §4.2). Rejected.
+- **Multi-vendor alternatives.** ElevenLabs `POST /v1/studio/podcasts` (two-speaker "conversation" /
+  "bulletin"; allowlist-gated). Air-gap: **Podcastfy** (Apache-2.0, vendor-agnostic `tts_model`) or Open
+  Notebook for transcript/orchestration + a **self-hosted Kokoro TTS** server (OpenAI-compatible
+  `/v1/audio/speech`, true offline `KOKORO_LOCAL_ONLY`). (Open Notebook's full-offline claim was REFUTED;
+  rely on Podcastfy+Kokoro for the verified offline audio path.)
+- **Auth.** GCP bearer via OAuth consent or a plain service account; AVOID domain-wide delegation (Google
+  IAM best-practice - DWD can impersonate any user). Workspace/Drive delivery via the `google_workspace_mcp`
+  server (3-legged OAuth 2.1+PKCE, auto refresh) - it does NOT cover NotebookLM. Slack delivery is a
+  dedicated Slack bot (`files.upload` + `chat.postMessage`), not a provider connector.
+
+### Decision
+
+**1. A pure generator (BUILT this slice).** `harness/brief/engineering_update.ts` - no I/O, no Date.now,
+no network: parse PROGRESS.md (shipped/stubbed/next) + DECISIONS.md (ADR status + `DEPENDS ON`/`Blocked
+by`) + an optional AAR (`AarLike`, declared locally so harness never imports desktop) into a typed
+`EngineeringUpdate` (recentlyShipped · loadBearingDependencies · techDebt · upcomingDecisions · risks).
+Mapping: PROGRESS `stubbed` + `DEFERRED`/`FINDING` ADRs → tech debt; `Proposed`/`SCOPE/PLAN`/`DEFERRED`
+ADRs + PROGRESS `next` → upcoming decisions; ADR `DEPENDS ON` edges → load-bearing; AAR
+errors/blocks/non-met outcome → risks. Renders a written brief AND a TTS-ready two-host podcast SCRIPT.
+
+**2. A vendor-agnostic `PodcastBackend` seam (BUILT).** `synthesize(script) → PodcastResult`. The default
+`ScriptOnlyBackend` returns the script with NO audio, so the pipeline never hard-fails on a missing cloud
+key and the AIR-GAP default ships today. The cloud/offline adapters (NotebookLM Enterprise, ElevenLabs,
+Podcastfy+Kokoro) implement this same interface in P-BRIEF.2 - the generator never changes.
+
+**3. Follow-on slices (deferred).** P-BRIEF.2: the audio adapters (behind the seam) + delivery (Slack bot,
+Workspace MCP). P-BRIEF.3: the Goal Loop accordion - provider picker (script-only | NotebookLM-Enterprise
+| ElevenLabs | Podcastfy+Kokoro), cadence, and destinations - wired as advanced config; the cloud paths
+gate through egress (ADR-0062) + managed-config (ADR-0068) and keys live like other provider keys.
+
+### Generation-option comparison
+
+| Option | API today | Auth | Air-gap | ToS/risk | Role |
+|---|---|---|---|---|---|
+| NotebookLM Enterprise audioOverviews | yes (v1alpha/Preview) | GCP bearer (OAuth/SA) | no (cloud) | low (official API) | primary cloud |
+| ElevenLabs studio/podcasts | yes (allowlist-gated) | xi-api-key | no | low | hosted multi-vendor |
+| Podcastfy + self-hosted Kokoro | yes (OSS) | none (local) | YES (Kokoro `LOCAL_ONLY`) | none | air-gap |
+| Headless consumer NotebookLM | n/a | Workspace OAuth | no | HIGH (suspension) | REJECTED |
+| Script-only (default) | built | none | YES | none | fallback / no-vendor |
+
+### Consequences / invariants
+
+- Air-gap by default (script-only, pure, no network); the cloud backends are opt-in and egress-gated.
+- The brief is a SUMMARY of already-local logs - no raw source/CUI leaves the host until a vendor backend
+  is deliberately configured. The frozen prefix is untouched; no `contracts.ts` change.
+- `make demo-P-BRIEF.1` generates a real update from THIS repo's logs (shipped/deps/debt/decisions + a
+  two-host script) with no vendor. 10 unit tests; typecheck clean.
+
+### Relates to
+
+`desktop/loop_report.ts` (the AAR input), DECISIONS.md/PROGRESS.md (the inputs), ADR-0067 (the loop AAR
+blocks feed Risks), ADR-0020 (MCP servers - the Workspace/Slack delivery surface), ADR-0062/0068
+(egress + managed-config govern the cloud backends), and the deep-research pass that chose the backend.

--- a/Makefile
+++ b/Makefile
@@ -186,6 +186,10 @@ demo-P-RAG.1b: ## P-RAG.1b (ADR-0063): real bge-small embedder — SEMANTIC retr
 demo-P-RAG.1c: ## P-RAG.1c (ADR-0064): PDF -> text through the SAME scan gate — semantic retrieval from a PDF, corrupt PDF fails closed
 	$(BUN) run harness/scripts/demo_prag1c.ts
 
+.PHONY: demo-P-BRIEF.1
+demo-P-BRIEF.1: ## P-BRIEF.1 (ADR-0070): Executive Engineering Update from the repo's DECISIONS/PROGRESS — written brief + two-host podcast script, air-gap clean
+	$(BUN) run harness/scripts/demo_pbrief1.ts
+
 .PHONY: demo-P-ASKSAGE.1
 demo-P-ASKSAGE.1: ## P-ASKSAGE.1 (ADR-0059): AskSage tool-loop diagnostics + tolerant extraction — wrapped replies recovered, empty turns flagged
 	$(BUN) run harness/scripts/demo_paskage1.ts

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2332,3 +2332,9 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
 - **shipped:** `managed_config.ts` gains `updateChannel: "github"|"feed"|"managed"` + `updateFeedUrl` and a PURE `resolveUpdatePolicy` (fail-safe: unmanaged/unknown→github, feed-without-url→managed, managed→disabled); `updater.ts` honors it - `managed` skips the in-app check entirely (no offline nag/hang), `feed` points electron-updater's generic provider at the customer mirror, `github` unchanged. 8 new tests; full typecheck clean.
 - **stubbed:** the internal-feed mirror layout + native enterprise packages (MSI/MSIX/rpm/deb/pkg) are the rest of ADR-A009 (private follow-on issues #75-79); macOS feed-update still needs signing.
 - **next:** wire the channel into the managed-config TEMPLATE + ADMX (private ADR-A010), and the Channel-B/C packaging.
+
+---
+**P-BRIEF.1 - Executive Engineering Update generator (ADR-0070)**
+- **shipped:** `harness/brief/engineering_update.ts` (PURE, air-gap) - parses PROGRESS.md + DECISIONS.md (+ optional AAR) into a typed `EngineeringUpdate` (load-bearing deps / tech debt / upcoming decisions / shipped / risks) and renders a written brief AND a TTS-ready two-host podcast script; a vendor-agnostic `PodcastBackend` seam with a `ScriptOnlyBackend` default (no cloud key needed). `demo-P-BRIEF.1` runs against THIS repo's logs (6 shipped, the ADR-0067→0066 edge, 7 debt, 12 decisions). Deep-research chose the backend: NotebookLM Enterprise audioOverviews API (primary), ElevenLabs (multi-vendor), Podcastfy+Kokoro (air-gap), NO headless browser. 10 tests; typecheck clean.
+- **stubbed:** the audio adapters (NotebookLM Enterprise / ElevenLabs / Podcastfy+Kokoro) behind the seam, Slack/Workspace delivery, and the Goal Loop accordion config are P-BRIEF.2/.3.
+- **next:** P-BRIEF.2 - implement one audio backend (likely ElevenLabs or Podcastfy+Kokoro first) + delivery, egress/managed-config gated.

--- a/harness/brief/engineering_update.test.ts
+++ b/harness/brief/engineering_update.test.ts
@@ -1,0 +1,114 @@
+// harness/brief/engineering_update.test.ts — the Executive Engineering Update generator (P-BRIEF.1,
+// ADR-0070). Pure parse → structured update → written brief + podcast script + the backend seam.
+
+import { test, expect, describe } from "bun:test";
+import {
+  parseProgress, parseAdrs, buildEngineeringUpdate, renderEngineeringBrief,
+  buildPodcastScript, renderScript, ScriptOnlyBackend, type EngineeringUpdate,
+} from "./engineering_update.ts";
+
+const PROGRESS = `
+# Progress
+
+---
+**P-EXEC.1 - exec approval**
+- **shipped:** the per-action gate for bash/eval, classifier + catastrophic set.
+- **stubbed:** ssh + task coverage deferred to P-EXEC.2.
+- **next:** wire the loop dial.
+
+---
+**P-RAG.1c - PDF ingest**
+- **shipped:** unpdf parser behind the scan gate.
+- **stubbed:** image OCR not wired.
+- **next:** WASM packaging decision.
+`;
+
+const DECISIONS = `
+## ADR-0066 - P-EXEC.1: exec approval (bash + eval)
+**Status:** Accepted - BUILT.
+DEPENDS ON nothing.
+
+## ADR-0067 - P-GOAL.13: loop risk dial
+**Status:** Proposed - SCOPE/PLAN.
+**Increment:** P-GOAL.13. DEPENDS ON ADR-0066's classifier.
+
+## ADR-0065 - WASM finding
+**Status:** Proposed - FINDING, decision DEFERRED.
+`;
+
+describe("parseProgress", () => {
+  test("pulls shipped/stubbed/next per entry", () => {
+    const p = parseProgress(PROGRESS);
+    expect(p.length).toBe(2);
+    expect(p[0]!.title).toContain("P-EXEC.1");
+    expect(p[0]!.shipped).toContain("per-action gate");
+    expect(p[0]!.stubbed).toContain("ssh + task");
+    expect(p[1]!.next).toContain("WASM packaging");
+  });
+});
+
+describe("parseAdrs", () => {
+  test("captures id/title/status and DEPENDS ON", () => {
+    const a = parseAdrs(DECISIONS);
+    expect(a.map((x) => x.id)).toEqual(["ADR-0066", "ADR-0067", "ADR-0065"]);
+    expect(a[1]!.status).toMatch(/SCOPE\/PLAN/);
+    expect(a[1]!.dependsOn).toContain("ADR-0066");
+  });
+});
+
+describe("buildEngineeringUpdate", () => {
+  const u: EngineeringUpdate = buildEngineeringUpdate({ label: "test@abc123", progressMd: PROGRESS, decisionsMd: DECISIONS });
+
+  test("recently shipped comes from PROGRESS shipped lines", () => {
+    expect(u.recentlyShipped.some((i) => /exec approval|per-action gate/i.test(i.title + (i.detail ?? "")))).toBe(true);
+  });
+  test("tech debt collects stubbed + deferred/finding ADRs", () => {
+    expect(u.techDebt.some((i) => /ssh \+ task|image OCR/i.test(i.detail ?? ""))).toBe(true);
+    expect(u.techDebt.some((i) => /ADR-0065/.test(i.title))).toBe(true); // FINDING/deferred
+  });
+  test("upcoming decisions include open (Proposed/SCOPE/DEFERRED) ADRs and PROGRESS next", () => {
+    expect(u.upcomingDecisions.some((i) => /ADR-0067/.test(i.title))).toBe(true);
+    expect(u.upcomingDecisions.some((i) => /ADR-0065/.test(i.title))).toBe(true);
+    expect(u.upcomingDecisions.some((i) => /^Next:/.test(i.title))).toBe(true);
+    // a BUILT/Accepted ADR is NOT an open decision
+    expect(u.upcomingDecisions.some((i) => /ADR-0066/.test(i.title))).toBe(false);
+  });
+  test("load-bearing dependencies surface the DEPENDS ON edges", () => {
+    expect(u.loadBearingDependencies.some((i) => /ADR-0067 depends on ADR-0066/.test(i.title))).toBe(true);
+  });
+  test("folds an AAR into risks", () => {
+    const withAar = buildEngineeringUpdate({
+      label: "x", progressMd: PROGRESS, decisionsMd: DECISIONS,
+      aar: { outcome: "stopped", outcomeReason: "stalled", iterations: 3, toolCalls: { shell: 4 }, loc: null, errors: [{ iter: 2, detail: "boom" }] },
+    });
+    expect(withAar.risks.some((r) => /error/i.test(r.title))).toBe(true);
+    expect(withAar.risks.some((r) => /stopped/i.test(r.title))).toBe(true);
+  });
+});
+
+describe("render + podcast seam", () => {
+  const u = buildEngineeringUpdate({ label: "demo", progressMd: PROGRESS, decisionsMd: DECISIONS });
+
+  test("the written brief has the three exec sections", () => {
+    const md = renderEngineeringBrief(u);
+    expect(md).toContain("# Executive Engineering Update — demo");
+    expect(md).toContain("## Load-bearing dependencies");
+    expect(md).toContain("## Tech debt");
+    expect(md).toContain("## Upcoming decisions");
+  });
+
+  test("the podcast script is a two-host dialogue", () => {
+    const s = buildPodcastScript(u);
+    const speakers = new Set(s.turns.map((t) => t.speaker));
+    expect(speakers.size).toBe(2);
+    expect(s.turns.length).toBeGreaterThan(3);
+    expect(renderScript(s)).toContain("**Host:**");
+  });
+
+  test("ScriptOnlyBackend returns the script with no audio (never hard-fails)", async () => {
+    const r = await new ScriptOnlyBackend().synthesize(buildPodcastScript(u));
+    expect(r.backendId).toBe("script-only");
+    expect(r.audioPath).toBeUndefined();
+    expect(r.script.turns.length).toBeGreaterThan(0);
+  });
+});

--- a/harness/brief/engineering_update.ts
+++ b/harness/brief/engineering_update.ts
@@ -1,0 +1,241 @@
+// harness/brief/engineering_update.ts
+//
+// P-BRIEF.1 (ADR-0070): the "Executive Engineering Update" generator. Turns a repo's own structured
+// change logs - PROGRESS.md (shipped/stubbed/next), DECISIONS.md (ADR status + DEPENDS ON / Relates to),
+// and the goal-loop After-Action Report (loop_report.ts `LoopMetrics`) - into a typed `EngineeringUpdate`
+// with the three sections an exec audience cares about: LOAD-BEARING DEPENDENCIES, TECH DEBT, and UPCOMING
+// DECISIONS (plus recently-shipped + risks). It then renders a written brief AND a TTS-ready two-host
+// podcast SCRIPT.
+//
+// PURE + air-gap by construction: no I/O, no Date.now(), no network. The caller passes the file contents
+// and an optional AAR; audio is produced by a separate `PodcastBackend` (the seam below) so the default
+// path emits a script and NO cloud vendor is required. The NotebookLM-Enterprise / ElevenLabs / Podcastfy
+// adapters are follow-on slices that implement this same interface (ADR-0070).
+
+// Minimal structural view of the goal-loop After-Action Report (desktop/loop_report.ts `LoopMetrics`),
+// declared locally so this harness module never imports the desktop layer (clean layering). The desktop
+// caller passes its real LoopMetrics, which structurally satisfies this.
+export interface AarLike {
+  outcome?: string;
+  outcomeReason?: string;
+  iterations?: number;
+  toolCalls?: Record<string, number>;
+  loc?: { added: number; removed: number } | null;
+  errors?: { iter: number; detail: string }[];
+  blocks?: { reason?: string }[];
+}
+
+export interface UpdateItem {
+  title: string;
+  detail?: string;
+  /** Where the signal came from (e.g. "PROGRESS.md", "ADR-0066"). */
+  source: string;
+}
+
+export interface EngineeringUpdate {
+  /** A caller-supplied label (repo/branch/date) - never minted here, to keep this module pure. */
+  label: string;
+  recentlyShipped: UpdateItem[];
+  loadBearingDependencies: UpdateItem[];
+  techDebt: UpdateItem[];
+  upcomingDecisions: UpdateItem[];
+  risks: UpdateItem[];
+}
+
+// ── parsing inputs ────────────────────────────────────────────────────────────
+
+interface ProgressEntry { title: string; shipped?: string; stubbed?: string; next?: string }
+
+/** Parse PROGRESS.md: blocks separated by a `---` rule, each a bold title + shipped/stubbed/next bullets.
+ *  Tolerant - a block missing any field still parses. Returns entries in file order. */
+export function parseProgress(md: string): ProgressEntry[] {
+  const out: ProgressEntry[] = [];
+  for (const block of (md || "").split(/^\s*---\s*$/m)) {
+    const titleM = block.match(/\*\*(.+?)\*\*/);
+    if (!titleM) continue;
+    const field = (name: string) => {
+      const m = block.match(new RegExp(`\\*\\*${name}:\\*\\*\\s*([\\s\\S]*?)(?:\\n\\s*-\\s*\\*\\*|\\n\\s*$|$)`, "i"));
+      return m ? m[1]!.replace(/\s+/g, " ").trim() : undefined;
+    };
+    const title = titleM[1]!.replace(/\s+/g, " ").trim();
+    const e: ProgressEntry = { title, shipped: field("shipped"), stubbed: field("stubbed"), next: field("next") };
+    if (e.shipped || e.stubbed || e.next) out.push(e);
+  }
+  return out;
+}
+
+interface AdrEntry { id: string; title: string; status: string; dependsOn: string[]; body: string }
+
+/** Parse DECISIONS.md ADR headers + their Status line and any DEPENDS ON / Blocked by signal. */
+export function parseAdrs(md: string): AdrEntry[] {
+  const out: AdrEntry[] = [];
+  const re = /^##\s+(ADR-\d+)\s*[-–]\s*(.+)$/gm;
+  const heads: { id: string; title: string; idx: number }[] = [];
+  for (const m of (md || "").matchAll(re)) heads.push({ id: m[1]!, title: m[2]!.trim(), idx: m.index! });
+  for (let i = 0; i < heads.length; i++) {
+    const h = heads[i]!;
+    const body = (md || "").slice(h.idx, i + 1 < heads.length ? heads[i + 1]!.idx : undefined);
+    const statusM = body.match(/\*\*Status:\*\*\s*(.+)/i);
+    const status = statusM ? statusM[1]!.trim() : "";
+    const dependsOn: string[] = [];
+    for (const dm of body.matchAll(/(?:DEPENDS ON|Blocked by|depends on)\b[^.\n]*?(ADR-\d+|#\d+)/gi)) dependsOn.push(dm[1]!);
+    out.push({ id: h.id, title: h.title, status, dependsOn, body });
+  }
+  return out;
+}
+
+const isOpenDecision = (status: string) => /proposed|scope\/plan|deferred|finding|\(design\)/i.test(status);
+const isShipped = (status: string) => /built|accepted/i.test(status) && !/deferred|finding|proposed/i.test(status);
+const clip = (s: string, n = 240) => (s.length > n ? s.slice(0, n - 1).trimEnd() + "…" : s);
+
+/** Build the structured update from the repo's logs. `aar` (optional) folds the latest loop run's
+ *  blocks/errors into the Risks section. `label` is caller-supplied (purity). */
+export function buildEngineeringUpdate(args: {
+  label: string;
+  progressMd?: string;
+  decisionsMd?: string;
+  aar?: AarLike | null;
+  /** How many recent PROGRESS entries to consider (most recent last in the file). Default 6. */
+  recentWindow?: number;
+}): EngineeringUpdate {
+  const recentWindow = args.recentWindow ?? 6;
+  const progress = parseProgress(args.progressMd ?? "");
+  const adrs = parseAdrs(args.decisionsMd ?? "");
+  const recent = progress.slice(-recentWindow);
+
+  const recentlyShipped: UpdateItem[] = [];
+  const techDebt: UpdateItem[] = [];
+  const upcomingDecisions: UpdateItem[] = [];
+  const loadBearingDependencies: UpdateItem[] = [];
+  const risks: UpdateItem[] = [];
+
+  for (const e of recent) {
+    if (e.shipped) recentlyShipped.push({ title: e.title, detail: clip(e.shipped), source: "PROGRESS.md" });
+    if (e.stubbed) techDebt.push({ title: e.title, detail: clip(e.stubbed), source: "PROGRESS.md" });
+    if (e.next) upcomingDecisions.push({ title: `Next: ${e.title}`, detail: clip(e.next), source: "PROGRESS.md" });
+  }
+
+  for (const a of adrs) {
+    if (isOpenDecision(a.status)) {
+      upcomingDecisions.push({ title: `${a.id} — ${clip(a.title, 90)}`, detail: clip(a.status, 120), source: a.id });
+    } else if (isShipped(a.status) && recentlyShipped.length < recentWindow + adrs.length) {
+      // recently-decided/built ADRs reinforce the shipped picture (deduped by title later by the caller)
+    }
+    if (/finding|deferred/i.test(a.status)) {
+      techDebt.push({ title: `${a.id} — deferred/finding`, detail: clip(a.title, 120), source: a.id });
+    }
+    for (const dep of a.dependsOn) {
+      loadBearingDependencies.push({ title: `${a.id} depends on ${dep}`, detail: clip(a.title, 100), source: a.id });
+    }
+  }
+
+  if (args.aar) {
+    const m = args.aar;
+    const tools = Object.values(m.toolCalls ?? {}).reduce((x, y) => x + y, 0);
+    if (m.errors?.length) risks.push({ title: `${m.errors.length} error(s) in the last loop run`, detail: clip(m.errors.map((e) => e.detail).join("; "), 200), source: "AAR" });
+    if (m.blocks?.length) risks.push({ title: `${m.blocks.length} security/risk block(s) in the last loop run`, detail: clip(m.blocks.map((b) => b.reason ?? "blocked").join("; "), 200), source: "AAR" });
+    if (m.outcome && m.outcome !== "met") risks.push({ title: `Last loop ended "${m.outcome}"`, detail: clip(m.outcomeReason ?? "", 160), source: "AAR" });
+    recentlyShipped.push({ title: "Latest automated run", detail: `${m.iterations ?? 0} iter · ${tools} tool calls · ${m.loc ? `+${m.loc.added}/-${m.loc.removed} LOC` : "LOC n/a"}`, source: "AAR" });
+  }
+
+  return { label: args.label, recentlyShipped, loadBearingDependencies, techDebt, upcomingDecisions, risks };
+}
+
+// ── written brief ───────────────────────────────────────────────────────────
+
+function section(title: string, items: UpdateItem[], emptyNote: string): string[] {
+  const out = [`## ${title}`, ""];
+  if (!items.length) { out.push(`_${emptyNote}_`, ""); return out; }
+  for (const it of items) out.push(`- **${it.title}** ${it.detail ? `— ${it.detail}` : ""} _(${it.source})_`.replace(/\s+—\s+$/, ""));
+  out.push("");
+  return out;
+}
+
+/** Render the written Executive Engineering Update (deterministic markdown). */
+export function renderEngineeringBrief(u: EngineeringUpdate): string {
+  const out: string[] = [];
+  out.push(`# Executive Engineering Update — ${u.label}`, "");
+  out.push(
+    `> ${u.recentlyShipped.length} shipped · ${u.loadBearingDependencies.length} load-bearing dependencies · ` +
+    `${u.techDebt.length} tech-debt items · ${u.upcomingDecisions.length} upcoming decisions · ${u.risks.length} risks`,
+    "",
+  );
+  out.push(...section("Recently shipped", u.recentlyShipped, "Nothing recorded."));
+  out.push(...section("Load-bearing dependencies", u.loadBearingDependencies, "No cross-increment dependencies recorded."));
+  out.push(...section("Tech debt", u.techDebt, "No deferred/stubbed work recorded. 🎉"));
+  out.push(...section("Upcoming decisions", u.upcomingDecisions, "No open decisions recorded."));
+  out.push(...section("Risks", u.risks, "No risks recorded."));
+  return out.join("\n");
+}
+
+// ── TTS-ready podcast script + the vendor-agnostic backend seam ───────────────
+
+export interface PodcastTurn { speaker: string; text: string }
+export interface PodcastScript { title: string; turns: PodcastTurn[] }
+
+export interface PodcastResult {
+  backendId: string;
+  script: PodcastScript;
+  /** Absolute path to generated audio, when a real backend produced it. */
+  audioPath?: string;
+  note: string;
+}
+
+/** The seam every audio vendor implements (NotebookLM Enterprise audioOverviews, ElevenLabs
+ *  studio/podcasts, Podcastfy+Kokoro, …). Backend-agnostic so the caller only sees this interface. */
+export interface PodcastBackend {
+  readonly id: string;
+  synthesize(script: PodcastScript): Promise<PodcastResult>;
+}
+
+/** Default backend: no audio vendor configured (or air-gapped with none chosen). Returns the script
+ *  itself so the pipeline always produces SOMETHING and never hard-fails on a missing cloud key. */
+export class ScriptOnlyBackend implements PodcastBackend {
+  readonly id = "script-only";
+  async synthesize(script: PodcastScript): Promise<PodcastResult> {
+    return { backendId: this.id, script, note: "script-only: no audio backend configured (NotebookLM/ElevenLabs/Podcastfy not wired)" };
+  }
+}
+
+const ANCHOR = "Host";
+const ANALYST = "Engineer";
+
+/** Build a NotebookLM-style two-host dialogue from the update - the TTS-ready input a PodcastBackend
+ *  consumes. Deterministic; reads like a briefing, leads with what shipped, lands on the decisions. */
+export function buildPodcastScript(u: EngineeringUpdate): PodcastScript {
+  const turns: PodcastTurn[] = [];
+  const say = (speaker: string, text: string) => turns.push({ speaker, text });
+  const list = (items: UpdateItem[], max = 4) => items.slice(0, max).map((i) => i.title).join("; ");
+
+  say(ANCHOR, `Welcome to the Executive Engineering Update for ${u.label}. I'm here with our engineering lead to walk through where things stand.`);
+  if (u.recentlyShipped.length) {
+    say(ANALYST, `The headline is what shipped: ${list(u.recentlyShipped)}.`);
+    say(ANCHOR, `Good momentum. What's holding the weight underneath all that?`);
+  } else {
+    say(ANALYST, `Quiet cycle on shipping, so let's focus on what's load-bearing and what's coming.`);
+  }
+  if (u.loadBearingDependencies.length) {
+    say(ANALYST, `On load-bearing dependencies: ${list(u.loadBearingDependencies)}. If any of those move, the work stacked on them moves with it.`);
+  } else {
+    say(ANALYST, `No tightly-coupled cross-dependencies recorded this cycle, which keeps our options open.`);
+  }
+  if (u.techDebt.length) {
+    say(ANCHOR, `Let's be honest about the debt.`);
+    say(ANALYST, `Tech debt we're carrying forward: ${list(u.techDebt)}. None of it is on fire, but it's the interest we'll pay later.`);
+  }
+  if (u.upcomingDecisions.length) {
+    say(ANCHOR, `So what needs a decision?`);
+    say(ANALYST, `The open calls are: ${list(u.upcomingDecisions, 5)}. Those are the forks where leadership input changes the next increment.`);
+  }
+  if (u.risks.length) {
+    say(ANCHOR, `Anything that should worry us?`);
+    say(ANALYST, `Risks from the latest automated run: ${list(u.risks)}.`);
+  }
+  say(ANCHOR, `That's the update — shipped work is landing, the dependencies are mapped, and the decisions are queued. We'll check back next cycle.`);
+  return { title: `Executive Engineering Update — ${u.label}`, turns };
+}
+
+/** Render a script as plain readable text (for the written report's appendix or a script-only export). */
+export function renderScript(s: PodcastScript): string {
+  return [`# ${s.title}`, "", ...s.turns.map((t) => `**${t.speaker}:** ${t.text}`)].join("\n");
+}

--- a/harness/scripts/demo_pbrief1.ts
+++ b/harness/scripts/demo_pbrief1.ts
@@ -1,0 +1,58 @@
+// harness/scripts/demo_pbrief1.ts
+//
+// P-BRIEF.1 (ADR-0070): generate an Executive Engineering Update from THIS repo's own change logs -
+// DECISIONS.md (ADRs) + PROGRESS.md - with zero network and no audio vendor. Proves the decision-
+// independent core: parse → structured update (load-bearing deps / tech debt / upcoming decisions) →
+// written brief + a TTS-ready two-host podcast script through the ScriptOnly backend seam.
+//
+// Run with: bun run harness/scripts/demo_pbrief1.ts
+
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import {
+  buildEngineeringUpdate, renderEngineeringBrief, buildPodcastScript, renderScript, ScriptOnlyBackend,
+} from "../brief/engineering_update.ts";
+
+const ROOT = join(import.meta.dir, "..", "..");
+const read = (f: string) => (existsSync(join(ROOT, f)) ? readFileSync(join(ROOT, f), "utf8") : "");
+const fail = (m: string): never => { console.error(`FAIL: ${m}`); process.exit(1); };
+
+// A real-ish label without Date.now (purity): read the branch from .git/HEAD if present.
+let branch = "unknown";
+try { const h = read(".git/HEAD"); const m = h.match(/ref:\s*refs\/heads\/(.+)/); if (m) branch = m[1]!.trim(); } catch { /* ignore */ }
+
+try {
+  const progressMd = read("PROGRESS.md");
+  const decisionsMd = read("DECISIONS.md");
+  if (!progressMd && !decisionsMd) fail("no PROGRESS.md/DECISIONS.md to read");
+
+  const update = buildEngineeringUpdate({ label: `LucidAgentIDE / ${branch}`, progressMd, decisionsMd, recentWindow: 6 });
+
+  console.log("== [1/3] structured Executive Engineering Update from the repo's own logs ==");
+  console.log(`   shipped=${update.recentlyShipped.length}  load-bearing=${update.loadBearingDependencies.length}  ` +
+    `tech-debt=${update.techDebt.length}  upcoming-decisions=${update.upcomingDecisions.length}  risks=${update.risks.length}`);
+  if (update.upcomingDecisions.length === 0) fail("expected at least one open decision from the live DECISIONS.md");
+  if (update.techDebt.length === 0) fail("expected tech-debt signal from PROGRESS 'stubbed' lines");
+
+  console.log("\n== [2/3] the written brief (first lines) ==");
+  const brief = renderEngineeringBrief(update);
+  for (const want of ["## Load-bearing dependencies", "## Tech debt", "## Upcoming decisions"]) {
+    if (!brief.includes(want)) fail(`brief missing section: ${want}`);
+  }
+  console.log(brief.split("\n").slice(0, 14).map((l) => "   " + l).join("\n"));
+
+  console.log("\n== [3/3] TTS-ready podcast script through the ScriptOnly backend (no cloud vendor) ==");
+  const script = buildPodcastScript(update);
+  const result = await new ScriptOnlyBackend().synthesize(script);
+  if (result.backendId !== "script-only" || result.audioPath) fail("default path must be script-only with no audio");
+  const speakers = new Set(script.turns.map((t) => t.speaker));
+  if (speakers.size !== 2) fail("podcast script must be a two-host dialogue");
+  console.log(`   backend=${result.backendId}  turns=${script.turns.length}  speakers=${[...speakers].join(" + ")}`);
+  console.log(`   note: ${result.note}`);
+  console.log(renderScript(script).split("\n").slice(0, 6).map((l) => "   " + l).join("\n"));
+
+  console.log("\nPASS: Executive Engineering Update generated from the repo's logs — written brief + two-host script, air-gap clean, audio backend behind the seam.");
+} catch (e) {
+  fail(String((e as Error)?.stack ?? e));
+}
+process.exit(0);

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "demo-P-RAG.1": "bun run harness/scripts/demo_prag1.ts",
     "demo-P-RAG.1b": "bun run harness/scripts/demo_prag1b.ts",
     "demo-P-RAG.1c": "bun run harness/scripts/demo_prag1c.ts",
+    "demo-P-BRIEF.1": "bun run harness/scripts/demo_pbrief1.ts",
     "demo-P-ASKSAGE.1": "bun run harness/scripts/demo_paskage1.ts",
     "dashboards": "bun run harness/scripts/materialize_dashboards.ts",
     "omp:secure": "omp -e harness/omp/security_extension.ts -e harness/omp/token_speed_extension.ts",


### PR DESCRIPTION
Builds the **decision-independent core** of the "Executive Engineering Update" (curated brief + podcast) the research pass scoped — air-gap-clean, no cloud vendor required.

## What shipped (slice 1)
- `harness/brief/engineering_update.ts` — **pure** (no I/O, no network, no `Date.now`): parses `PROGRESS.md` (shipped/stubbed/next) + `DECISIONS.md` (ADR status + `DEPENDS ON`/`Blocked by`) + an optional goal-loop AAR into a typed `EngineeringUpdate` focused on **load-bearing dependencies, tech debt, upcoming decisions** (+ shipped, risks). Renders a **written brief** AND a **TTS-ready two-host podcast script**.
- A vendor-agnostic **`PodcastBackend` seam** with a **`ScriptOnlyBackend` default** — the pipeline always produces something and never hard-fails on a missing cloud key. `AarLike` is declared locally so harness never imports the desktop layer.
- `demo-P-BRIEF.1` runs against **this repo's own logs**: 6 shipped, the `ADR-0067 → ADR-0066` dependency edge, 7 tech-debt items, 12 open decisions, a coherent two-host script.

## Backend chosen by the deep-research pass (in ADR-0070)
| Option | Role |
|---|---|
| NotebookLM Enterprise `audioOverviews` API (v1alpha) | primary cloud |
| ElevenLabs `/v1/studio/podcasts` (allowlist-gated) | hosted multi-vendor |
| Podcastfy + self-hosted **Kokoro** TTS (`LOCAL_ONLY`) | **air-gap** |
| Headless consumer NotebookLM | **rejected** (ToS suspension risk; API makes it unnecessary) |

Auth = GCP OAuth/service-account (not domain-wide delegation); Workspace/Drive via `google_workspace_mcp`; Slack via a dedicated bot. All deferred to **P-BRIEF.2** (audio adapters + delivery) and **P-BRIEF.3** (the Goal Loop accordion), each gated through egress (ADR-0062) + managed-config (ADR-0068).

## Checks
harness **528 pass / 1 skip / 0 fail** (+10 new); full typecheck clean; `make demo-P-BRIEF.1` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)