### PR TITLE
fix(goal-ui): goal modal — reachable footer, collapsible Loop history, no wasted padding

### DIFF
--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -2450,8 +2450,15 @@ function openGoalForm(): void {
   const TOTAL = steps.length;
   let mode: "guided" | "advanced" = (localStorage.getItem("lucid.goalMode") === "advanced" ? "advanced" : "guided");
   let cur = 1;
+  let statsTouched = false; // true once the user manually expands/collapses Loop history (stops auto-collapse)
   const setHidden = (sel: string, hidden: boolean) => { const e = $(sel, ov) as HTMLElement | null; if (e) e.hidden = hidden; };
   const cadenceSet = () => (($("#goalCadKind", ov) as HTMLSelectElement)?.value ?? "off") !== "off";
+  // Loop history auto-collapses once past step 1 (or in advanced) since the user already saw it; a manual
+  // click pins it. Safe to call before the async stats load — it no-ops until the panel exists.
+  const syncStats = () => {
+    const stats = ov.querySelector(".goal-stats");
+    if (stats && !statsTouched) stats.classList.toggle("collapsed", mode === "advanced" || cur > 1);
+  };
   const render = () => {
     modal.dataset.mode = mode;
     ($("#goalModeToggle", ov) as HTMLElement).textContent = mode === "guided" ? "Advanced" : "Guided walkthrough";
@@ -2470,7 +2477,15 @@ function openGoalForm(): void {
       const focusable = $(`.goal-step[data-step="${cur}"] textarea, .goal-step[data-step="${cur}"] input, .goal-step[data-step="${cur}"] select`, ov) as HTMLElement | null;
       setTimeout(() => focusable?.focus(), 30);
     }
+    syncStats();
   };
+  // Click the Loop-history header to expand/collapse it (pins the choice, overriding auto-collapse).
+  ov.addEventListener("click", (e) => {
+    if ((e.target as HTMLElement).closest?.(".gs-head")) {
+      statsTouched = true;
+      ov.querySelector(".goal-stats")?.classList.toggle("collapsed");
+    }
+  });
   $("#goalModeToggle", ov)?.addEventListener("click", () => { mode = mode === "guided" ? "advanced" : "guided"; localStorage.setItem("lucid.goalMode", mode); if (mode === "guided") cur = 1; render(); });
   $("#goalNext", ov)?.addEventListener("click", () => {
     if (cur === 1 && !($("#goalGoal", ov) as HTMLTextAreaElement).value.trim()) { showToast({ tone: "warn", title: "Add a goal", desc: "Describe what the loop should accomplish.", timeout: 2400 }); return; }
@@ -2559,7 +2574,7 @@ function openGoalForm(): void {
     }));
   });
   // P-GOAL.10 (ADR-0055): the cross-run evaluation banner (success rate / avg iters / top blocker).
-  void loadLoopStats(ov);
+  void loadLoopStats(ov).then(syncStats);
   // P-GOAL.12 (ADR-0057): the optional Pre-Flight Audit (design + readiness before building the loop).
   adoptedCriteria = "";
   $("#goalPreflight", ov)?.addEventListener("click", () => openPreflight(ov));
@@ -2731,7 +2746,7 @@ async function loadLoopStats(ov: HTMLElement): Promise<void> {
   const mix = spend + Object.entries(s.toolsByType).sort((a, b) => b[1] - a[1]).slice(0, 4)
     .map(([k, v]) => `<span class="gs-tool">${esc(k)} <b>${v}</b></span>`).join("");
   sec.innerHTML = `<div class="goal-stats" data-tone="${tone}">
-    <div class="gs-head">${icon("graph", 13)} Loop history <span class="gs-sum">${esc(data!.summary)}</span></div>
+    <div class="gs-head">${icon("graph", 13)} Loop history <span class="gs-sum">${esc(data!.summary)}</span><span class="gs-caret">${icon("chevron", 12)}</span></div>
     <div class="gs-grid">
       <div class="gs-cell"><span class="gs-n">${pct}%</span><span class="gs-l">met</span></div>
       <div class="gs-cell"><span class="gs-n">${esc(iters)}</span><span class="gs-l">avg iters to win</span></div>

--- a/desktop/renderer/styles.css
+++ b/desktop/renderer/styles.css
@@ -538,7 +538,12 @@ body.resizing .sidebar,body.resizing .inspector{transition:none}
 .goal-scrim{position:fixed;inset:0;z-index:200;background:rgba(0,0,0,.55);display:grid;place-items:center;animation:fade var(--t) var(--ease)}
 /* P-GOAL.7: larger, higher-contrast text across the whole module for easier reading */
 .goal-modal{width:min(560px,93vw);background:var(--bg-1);border:1px solid var(--line-strong);border-radius:16px;padding:22px;
-  box-shadow:0 20px 60px rgba(0,0,0,.55);display:flex;flex-direction:column;gap:9px;animation:rise var(--t-slow) var(--ease-out)}
+  box-shadow:0 20px 60px rgba(0,0,0,.55);display:flex;flex-direction:column;gap:9px;animation:rise var(--t-slow) var(--ease-out);
+  /* cap height + scroll so the action buttons (Run/Cancel) are always reachable even after the
+     Engineering-Update brief renders; without this the centered modal overflowed the viewport. */
+  max-height:92vh;overflow-y:auto;scrollbar-gutter:stable}
+/* Empty optional sections must not reserve flex-gap space (the wasted padding above Step N). */
+#goalStatsSec:empty,#goalResumeSec:empty,#goalAutoSec:empty{display:none}
 .goal-modal-h{display:flex;align-items:center;justify-content:space-between;gap:8px;font-size:16.5px;font-weight:650;color:var(--txt)}
 .goal-modal-h .ic{color:var(--accent-2)}
 .goal-h-title{display:flex;align-items:center;gap:8px}
@@ -666,6 +671,14 @@ body.resizing .sidebar,body.resizing .inspector{transition:none}
 .gs-mix .gs-tool{font-size:10.5px;color:var(--txt-3);background:var(--bg-1);border:1px solid var(--line);border-radius:6px;padding:2px 7px}
 .gs-mix .gs-tool b{color:var(--txt-1)}
 .gs-blocker{display:flex;align-items:center;gap:5px;margin-top:8px;font-size:11px;color:var(--txt-4)}
+/* Collapsible Loop history: auto-collapses once past step 1 (guided) or in advanced mode — the user
+   already saw it — and the header is clickable to expand (`.expanded` is the manual override). */
+.goal-stats .gs-head{cursor:pointer;user-select:none;margin-bottom:0}
+.goal-stats:not(.collapsed) .gs-head{margin-bottom:8px}
+.gs-caret{margin-left:7px;display:inline-flex;color:var(--txt-4);transition:transform var(--t)}
+.goal-stats.collapsed .gs-caret{transform:rotate(-90deg)}
+.goal-stats.collapsed .gs-grid,.goal-stats.collapsed .gs-mix,.goal-stats.collapsed .gs-blocker{display:none}
+.goal-stats.collapsed{padding-top:9px;padding-bottom:9px}
 .gs-blocker span{color:var(--txt-3)}
 /* P-GOAL.12: Pre-Flight Audit — the optional design/readiness pass that pauses the builder. */
 .goal-preflight-btn{margin:0 0 8px;display:inline-flex;align-items:center;gap:6px}


### PR DESCRIPTION
Fixes three layout bugs in the **Run a goal loop** modal (reported on step 5 with the Engineering Update accordion).

## Bugs → fixes
1. **Footer cut off / buttons unreachable** — the centered modal had no `max-height`/scroll, so once the brief rendered the content overflowed the viewport and **Run/Cancel** dropped off-screen. → `.goal-modal { max-height: 92vh; overflow-y: auto }` so the footer is always reachable.
2. **Wasted padding above the step** — empty optional sections (`#goalResumeSec` / `#goalAutoSec` / `#goalStatsSec`) still reserved flex-gap space. → `:empty { display: none }`.
3. **Loop history always expanded** — wasted ~120px on every step. → **collapsible**: auto-collapses once past step 1 (or in advanced mode) since the user already saw it; the header is **clickable to expand/pin** (caret indicator). Driven by a `syncStats()` hook in `render()` + a delegated header click; a manual toggle pins the choice.

## Verified live (preview)
- Step 1: Loop history **expanded**; step 2+: **collapsed** (171 → 53px).
- Generating the brief **no longer cuts off the footer** — modal scrolls, "Run loop" reachable (`modalFitsViewport`, `runVisibleAfterScroll` both true).
- Empty `#goalAutoSec` now `display:none`; the remaining panel is the real **Resume a stopped loop** (legit content).
- Manual header click toggles; no console errors.

Renderer-only (CSS + a small `render()` hook); desktop typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)