### PR TITLE
feat(homebrew): add macOS cask install

### DIFF
--- a/Casks/lucidagentide.rb
+++ b/Casks/lucidagentide.rb
@@ -1,0 +1,48 @@
+cask "lucidagentide" do
+  version :latest
+  sha256 :no_check
+
+  on_arm do
+    url "https://github.com/mlcyclops/lucidagentide/releases/download/latest/LucidAgentIDE-mac-arm64.zip"
+  end
+  on_intel do
+    url "https://github.com/mlcyclops/lucidagentide/releases/download/latest/LucidAgentIDE-mac-x64.zip"
+  end
+
+  name "LucidAgentIDE"
+  desc "Fail-closed security, provenance, and memory layer around oh-my-pi (omp)"
+  homepage "https://github.com/mlcyclops/lucidagentide"
+
+  # The project ships a single rolling "latest" GitHub release and the app
+  # updates itself in place via electron-updater, so there is no per-version
+  # tag for Homebrew to track.
+  livecheck do
+    skip "Rolling 'latest' release; the app self-updates via electron-updater"
+  end
+
+  depends_on macos: :big_sur
+
+  app "LucidAgentIDE.app"
+
+  zap trash: [
+    "~/Library/Application Support/LucidAgentIDE",
+    "~/Library/Caches/com.lucidagentide.desktop",
+    "~/Library/Caches/com.lucidagentide.desktop.ShipIt",
+    "~/Library/Logs/LucidAgentIDE",
+    "~/Library/Preferences/com.lucidagentide.desktop.plist",
+    "~/Library/Saved Application State/com.lucidagentide.desktop.savedState",
+  ]
+
+  caveats <<~EOS
+    LucidAgentIDE is currently distributed UNSIGNED and is NOT notarized, so
+    macOS Gatekeeper will block it after install. (Homebrew 6 removed the
+    `--no-quarantine` install flag, so clear the quarantine attribute yourself
+    once, after installing:)
+
+      xattr -dr com.apple.quarantine "/Applications/LucidAgentIDE.app"
+
+    Then open it normally. The app keeps itself current afterwards
+    (electron-updater pulls from the GitHub "latest" release), so `brew upgrade`
+    is rarely needed.
+  EOS
+end

--- a/README.md
+++ b/README.md
@@ -396,6 +396,26 @@ needs **zero prerequisites**. Code-signing and notarization are supported when c
 > **Linux:** the download is a portable `AppImage` - `chmod +x LucidAgentIDE-x86_64.AppImage` and run it,
 > no install needed.
 
+### Homebrew (macOS)
+
+Install the desktop app with Homebrew Cask straight from this repo - no manual unzip, and `brew upgrade`
+keeps the cask wiring current (the app itself also self-updates via electron-updater):
+
+```bash
+brew tap mlcyclops/lucid https://github.com/mlcyclops/lucidagentide
+brew trust --cask mlcyclops/lucid/lucidagentide   # Homebrew >= 6 gates third-party taps
+brew install --cask lucidagentide
+
+# Builds are UNSIGNED, so clear macOS quarantine once before first launch:
+xattr -dr com.apple.quarantine "/Applications/LucidAgentIDE.app"
+```
+
+`brew trust` is required on Homebrew 6+, which refuses to load casks from a third-party tap until you
+explicitly trust it (older Homebrew skips this step). The `xattr` step is needed because builds are currently
+**unsigned and not notarized** - macOS Gatekeeper blocks them otherwise, and Homebrew 6 removed the
+`--no-quarantine` install flag. The cask serves both Apple Silicon and Intel automatically. To remove it
+later: `brew uninstall --cask lucidagentide` (add `--zap` to also delete app data).
+
 ## <img src=".github/assets/icons/roadmap.svg" width="28" align="top" alt=""> Roadmap
 
 **Shipped and green.** The full security lifecycle, provenance lineage + replay, the cache-optimized prompt,


### PR DESCRIPTION
## What

Adds a Homebrew **Cask** so the macOS desktop app can be installed with `brew`
instead of a manual zip download + drag to Applications.

- `Casks/lucidagentide.rb` — installs `LucidAgentIDE.app` from the rolling GitHub
  `latest` release zips, Apple Silicon + Intel. `version :latest` +
  `sha256 :no_check` matches the rolling release model; `zap` stanza cleans app
  data on `--zap`.
- README gains a "Homebrew (macOS)" section with the install flow.

## How to use

```bash
brew tap mlcyclops/lucid https://github.com/mlcyclops/lucidagentide
brew trust --cask mlcyclops/lucid/lucidagentide   # Homebrew >= 6 only
brew install --cask lucidagentide

# Builds are unsigned — clear macOS quarantine once before first launch:
xattr -dr com.apple.quarantine "/Applications/LucidAgentIDE.app"
```

Uninstall: `brew uninstall --cask lucidagentide` (add `--zap` to also remove app data).

## Why these choices

- **`version :latest` + `sha256 :no_check`** — the project ships a single rolling
  `latest` GitHub release and the app self-updates via electron-updater, so there
  is no per-version tag for Homebrew to pin. Once `v*` tags ship versioned assets,
  switch to a pinned `version` + real `sha256`.
- **`brew trust`** — Homebrew 6 refuses to load casks from a third-party tap until
  trusted. Older Homebrew skips this.
- **Manual `xattr`** — builds are unsigned/un-notarized and Homebrew 6 removed the
  `--no-quarantine` install flag, so quarantine must be cleared once by hand. The
  durable fix is signing/notarization in `build-desktop.yml`.

## Validation

- `brew style` and `brew audit --cask --strict` pass.
- `brew info` and a dry-run `brew install --cask` resolve the cask and pick the
  correct per-arch URL.
- Both release zip URLs return HTTP 200.

Closes #106
