### PR TITLE
feat(kg): P-KG-INGEST.2 — Clear ingest sessions (#123)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -6323,3 +6323,42 @@ First-party authored edges (no scanner, no semantic promotion — keystone #2); 
 
 ADR-0075 (P-KG-REL.1, which this completes), `desktop/personal.ts` (`relateEntities`/`sanitizeRelation`),
 `desktop/renderer/kg_ops.ts` (`resolveRelationLabel`).
+
+## ADR-0079 - P-KG-INGEST.2: "Clear ingest sessions" bulk action
+
+**Date:** 2026-06-27
+**Status:** Accepted - BUILT.
+**Increment:** P-KG-INGEST.2. Completes the housekeeping half of ADR-0076 (1b grouped them; this clears them).
+
+### Context
+
+P-KG-INGEST.1b grouped the throwaway "Extract DURABLE facts…" extraction sessions an import (and live
+AI-learn) mint, but omp still persists each to disk; over time they accumulate. The user wanted them
+cleanable in bulk, not one-by-one.
+
+### Decision - one workspace-scoped bulk delete, gated by the SAME ingest detection
+
+`desktop/sessions.ts clearIngestSessions(cwd, root?)` walks the omp session files and removes a file only
+when it is BOTH (a) in the current workspace AND (b) an extractor throwaway (`isIngestPrompt` on its first
+user message) — so a real chat is never deleted. Returns the count cleared (idempotent). Surfaced at
+`POST /api/sessions/ingest/clear` + `bridge.clearIngestSessions()`; the renderer adds a trash affordance on
+the "Knowledge Graph Ingest · N" group header with a confirm toast. The knowledge graph itself is a separate
+encrypted store and is never touched — only the throwaway omp transcripts are removed.
+
+### Consequences
+
+- `make demo-P-KG-INGEST.2` proves: 9 throwaways cleared, the real chat survives, another workspace's
+  ingest is left alone, and a second clear is a no-op. Two unit tests lock the same (incl. workspace scope).
+- Still no ephemeral-session SDK seam (omp persists them up front); this is the cleanup path. If omp later
+  exposes non-persisted sessions, the distiller's `complete()` should prefer that (then this becomes rare).
+
+### Invariants preserved
+
+The knowledge-graph store is untouched (only omp transcripts are deleted); deletion is workspace-scoped
+(defense in depth, like `deleteSession`); no change to scanning/memory promotion; the append-only DuckDB
+audit trail (issue #53) is intentionally separate and untouched.
+
+### Relates to
+
+ADR-0076 (P-KG-INGEST, 1b grouping this complements), `desktop/sessions.ts` (`isIngestPrompt`,
+`deleteSession` — the scoped-delete pattern this mirrors).

--- a/Makefile
+++ b/Makefile
@@ -234,6 +234,10 @@ demo-P-VAULT-HINT.1: ## P-VAULT-HINT.1 (#111/ADR-0077): locked vault → content
 demo-P-KG-REL.2: ## P-KG-REL.2 (#122/ADR-0078): custom relation labels — typed label round-trips through the store; blank defaults to "related"
 	$(BUN) run desktop/scripts/demo_p_kg_rel_2.ts
 
+.PHONY: demo-P-KG-INGEST.2
+demo-P-KG-INGEST.2: ## P-KG-INGEST.2 (#123/ADR-0079): bulk-clear ingest sessions — workspace-scoped, real chats survive, idempotent
+	$(BUN) run desktop/scripts/demo_p_kg_ingest_2.ts
+
 .PHONY: dashboards
 dashboards: ## Materialize dashboard CSVs from a DuckDB into observable/docs/data (DB=path)
 	$(BUN) run harness/scripts/materialize_dashboards.ts $(DB) observable/docs/data

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,6 +4,11 @@ Three lines per session: **shipped / stubbed / next** (CLAUDE.md session ritual)
 
 -----
 
+## P-KG-INGEST.2: "Clear ingest sessions" bulk action (#123, ADR-0079)
+- **shipped:** the grouped throwaway extraction sessions are now bulk-deletable. `desktop/sessions.ts clearIngestSessions(cwd, root?)` removes a file only when it's BOTH this workspace's AND an extractor throwaway (`isIngestPrompt`) — a real chat is never touched; returns the count, idempotent. `POST /api/sessions/ingest/clear` + `bridge.clearIngestSessions()`; renderer adds a trash button on the "Knowledge Graph Ingest · N" group header with a confirm toast (KG store untouched — only omp transcripts). Proof: `sessions_ingest.test.ts` (+2: clears only ingest, workspace-scoped) + `make demo-P-KG-INGEST.2`. ADR-0079 BUILT.
+- **stubbed:** still no ephemeral-session SDK seam (omp persists ingest sessions up front; this is the cleanup path); no auto-clear-on-import-finish (the user clears when they want).
+- **next:** P-VAULT-HINT.2 locked count (#124), P-KG-INGEST.3 ingest concurrency (#125).
+
 ## P-KG-REL.2: custom relation labels (#122, ADR-0078)
 - **shipped:** the Relate bar gains an optional label input (`#kgRelateLabel`, max 40, placeholder "related"); both gestures (drag-to-relate + multi-select chain) read it via `currentRelationLabel()` → pure `kg_ops.ts resolveRelationLabel` (trimmed, or "related" when blank). The label flows through the existing optimistic path + `bridge.personalRelate`; backend `relateEntities`/`sanitizeRelation` already sanitize + cap it (no backend change). Proof: `kg_ops.test.ts` resolveRelationLabel cases + `make demo-P-KG-REL.2` (custom "deploys with" round-trips through the encrypted store). ADR-0078 BUILT.
 - **stubbed:** Enter-to-relate in the label input (Relate button works); no per-edge label editing after creation.

--- a/desktop/dev.ts
+++ b/desktop/dev.ts
@@ -16,7 +16,7 @@ import { approveBlock, dismissBlock, liveBlocks } from "./security_log.ts";
 import { probeRateLimits } from "./ratelimit_probe.ts";
 import { OBS_DB_PATH, codeActivity, memorySnapshot, rateLimits, sessionPathById, usageLedger } from "../tools/memory_data.ts";
 import { backend } from "./acp_backend.ts";
-import { deleteSession, listSessions, sessionMessages } from "./sessions.ts";
+import { clearIngestSessions, deleteSession, listSessions, sessionMessages } from "./sessions.ts";
 import { providerAuth } from "./auth_status.ts";
 import { cloneRepo, setWorkspace, workspaceInfo } from "./workspace.ts";
 import { applyEnv, attribution, chinaModelsAcknowledged, listMcpServers, load as loadSettings, removeMcpServer, setAsksage, setAttributionSkip, setChinaModelsAcknowledged, setDeveloperMode, setKey, setMcpServerEnabled, setPersonalAiExtract, setProfile, setRateLimitProbe, upsertMcpServer } from "./settings_store.ts";
@@ -330,6 +330,7 @@ const server = Bun.serve({
 
       // real omp ACP backend (genuine model replies + live session config)
       if (p === "/api/sessions") return json({ ok: true, data: listSessions() });
+      if (p === "/api/sessions/ingest/clear" && req.method === "POST") return json({ ok: true, data: clearIngestSessions() }); // P-KG-INGEST.2
       if (p === "/api/session" && url.searchParams.get("id")) return json({ ok: true, data: sessionMessages(url.searchParams.get("id")!) });
       if (p === "/api/session/load" && req.method === "POST") { const { id } = await readBody<{ id?: unknown }>(req); await backend.loadSession(String(id)); return json({ ok: true }); }
       if (p === "/api/session/delete" && req.method === "POST") {

--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -260,12 +260,33 @@ async function renderSessions(): Promise<void> {
   // P-KG-INGEST.1b: collapse the throwaway "Extract DURABLE facts…" extraction sessions an import mints
   // into ONE foldable group so they don't pollute the chat history (they stay inspectable when expanded).
   const ingestGroup = ingest.length ? `<div class="sess-group">
-      <button class="sess-group-head" data-ingest-toggle aria-expanded="${ingestExpanded}" data-tip="Throwaway model-extraction sessions from imports + AI learning. Grouped so they don't clutter your chats.">
-        <span class="sess-group-chev ${ingestExpanded ? "open" : ""}">${icon("chevron", 12)}</span> Knowledge Graph Ingest <span class="sess-group-count">${ingest.length}</span>
-      </button>
+      <div class="sess-group-head">
+        <button class="sess-group-toggle" data-ingest-toggle aria-expanded="${ingestExpanded}" data-tip="Throwaway model-extraction sessions from imports + AI learning. Grouped so they don't clutter your chats.">
+          <span class="sess-group-chev ${ingestExpanded ? "open" : ""}">${icon("chevron", 12)}</span> Knowledge Graph Ingest <span class="sess-group-count">${ingest.length}</span>
+        </button>
+        <button class="sess-group-clear" data-ingest-clear data-tip="Clear ingest sessions|Delete all ${ingest.length} throwaway extraction sessions from disk. Your chats and knowledge graph are untouched.">${icon("trash", 12)}</button>
+      </div>
       <div class="sess-group-body" ${ingestExpanded ? "" : "hidden"}>${ingest.map((s) => sessRow(s, false)).join("")}</div>
     </div>` : "";
   list.innerHTML = chats + ingestGroup;
+}
+// P-KG-INGEST.2: bulk-delete the throwaway extraction sessions (chats + knowledge graph untouched).
+function confirmClearIngest(): void {
+  showToast({
+    title: "Clear ingest sessions?",
+    desc: "Deletes the throwaway 'Extract DURABLE facts…' extraction sessions from disk. Your chats and your knowledge graph are NOT affected.",
+    tone: "warn",
+    actions: [
+      { label: "Cancel" },
+      { label: "Clear", kind: "danger", run: async () => {
+        const r = await bridge.clearIngestSessions().catch(() => null);
+        if (!r?.ok) { showToast({ tone: "danger", title: "Couldn't clear", desc: "Some sessions may still be open. Try again.", actions: [{ label: "OK" }], timeout: 5000 }); return; }
+        showToast({ title: r.cleared ? `Cleared ${r.cleared} ingest session${r.cleared === 1 ? "" : "s"}` : "Nothing to clear", desc: "Your chats and knowledge graph are unchanged.", timeout: 3000 });
+        void renderSessions();
+      } },
+    ],
+    timeout: 0,
+  });
 }
 
 // ───────────────────────── chat ─────────────────────────
@@ -3752,6 +3773,7 @@ function wire(): void {
   $("#wsBar")!.addEventListener("click", () => openSettings());
   $("#sessList")!.addEventListener("click", (e) => {
     const t = e.target as HTMLElement;
+    if (t.closest("[data-ingest-clear]")) { e.stopPropagation(); confirmClearIngest(); return; } // P-KG-INGEST.2
     if (t.closest("[data-ingest-toggle]")) { ingestExpanded = !ingestExpanded; void renderSessions(); return; } // P-KG-INGEST.1b
     const del = t.closest(".sess-del") as HTMLElement | null;
     if (del?.dataset.del) { e.stopPropagation(); confirmDeleteSession(del.dataset.del); return; }

--- a/desktop/renderer/bridge.ts
+++ b/desktop/renderer/bridge.ts
@@ -282,6 +282,7 @@ export interface LucidBridge {
   sessionMessages(id: string): Promise<{ role: string; text: string }[] | null>;
   resumeSession(id: string): Promise<void>;
   deleteSession(id: string): Promise<{ ok: boolean; error?: string }>;
+  clearIngestSessions(): Promise<{ ok: boolean; cleared: number } | null>; // P-KG-INGEST.2: bulk-delete ingest throwaways
   newSession(): Promise<void>;
   setZoom(factor: number): void;
   // settings + provider auth
@@ -490,6 +491,7 @@ export const bridge: LucidBridge = {
   sessionMessages: (id) => getData(`/api/session?id=${encodeURIComponent(id)}`),
   resumeSession: async (id) => { await post("/api/session/load", { id }); },
   deleteSession: async (id) => (await post("/api/session/delete", { id })) ?? { ok: false, error: "no response" },
+  clearIngestSessions: () => post("/api/sessions/ingest/clear", {}),
   newSession: async () => { await post("/api/newSession", {}); },
   getSettings: () => getData("/api/settings"),
   saveUsername: (username) => post("/api/settings", { username }),

--- a/desktop/renderer/styles.css
+++ b/desktop/renderer/styles.css
@@ -249,10 +249,17 @@ body.resizing .sidebar,body.resizing .inspector{transition:none}
 .sess-del:hover{opacity:1;background:color-mix(in srgb,var(--danger,#e5484d) 16%,transparent);color:var(--danger,#e5484d)}
 /* P-KG-INGEST.1b: the collapsible "Knowledge Graph Ingest" group for throwaway extraction sessions */
 .sess-group{margin-top:6px}
-.sess-group-head{display:flex;align-items:center;gap:7px;width:100%;padding:8px 11px;border:0;border-radius:9px;
-  background:transparent;color:var(--txt-2);font-size:12px;font-weight:600;cursor:pointer;text-align:left;
-  transition:background var(--t) var(--ease)}
-.sess-group-head:hover{background:var(--bg-2);color:var(--txt)}
+.sess-group-head{display:flex;align-items:center}
+.sess-group-toggle{display:flex;align-items:center;gap:7px;flex:1;min-width:0;padding:8px 11px;border:0;
+  border-radius:9px;background:transparent;color:var(--txt-2);font-size:12px;font-weight:600;cursor:pointer;
+  text-align:left;transition:background var(--t) var(--ease)}
+.sess-group-toggle:hover{background:var(--bg-2);color:var(--txt)}
+/* P-KG-INGEST.2: bulk "clear ingest sessions" — hidden until group hover, danger tint */
+.sess-group-clear{display:grid;place-items:center;width:26px;height:26px;border:0;border-radius:7px;
+  background:transparent;color:var(--txt-3);cursor:pointer;opacity:0;
+  transition:opacity var(--t) var(--ease),color var(--t) var(--ease),background var(--t) var(--ease)}
+.sess-group:hover .sess-group-clear{opacity:.8}
+.sess-group-clear:hover{opacity:1;color:var(--danger,#e5484d);background:color-mix(in srgb,var(--danger,#e5484d) 16%,transparent)}
 .sess-group-chev{display:inline-grid;place-items:center;transition:transform var(--t) var(--ease)}
 .sess-group-chev.open{transform:rotate(90deg)}
 .sess-group-count{margin-left:auto;font-size:11px;font-weight:600;color:var(--txt-3);background:var(--bg-2);

--- a/desktop/scripts/demo_p_kg_ingest_2.ts
+++ b/desktop/scripts/demo_p_kg_ingest_2.ts
@@ -1,0 +1,52 @@
+// desktop/scripts/demo_p_kg_ingest_2.ts
+//
+// Increment P-KG-INGEST.2 — "Clear ingest sessions" bulk action (issue #123, ADR-0079). P-KG-INGEST.1b
+// grouped the throwaway extraction sessions; this deletes them in one click. Defense in depth: only files
+// that are BOTH this workspace's AND extractor throwaways are removed — real chats are never touched.
+
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { EXTRACT_SYSTEM } from "../../harness/personal/distiller.ts";
+import { clearIngestSessions, listSessions } from "../sessions.ts";
+
+const fail = (msg: string): never => { console.error(`FAIL: ${msg}`); process.exit(1); };
+const ok = (msg: string): void => console.log(`   ${msg} ✓`);
+
+console.log("== #123 clear ingest sessions (chats + KG untouched) ==");
+const root = join(tmpdir(), `demo-ingest2-${process.pid}`);
+const dir = join(root, "enc");
+mkdirSync(dir, { recursive: true });
+const ln = (o: unknown) => JSON.stringify(o);
+const file = (id: string, cwd: string, userText: string) => [
+  ln({ type: "session", id, cwd }),
+  ln({ type: "message", message: { role: "user", content: [{ type: "text", text: userText }] } }),
+].join("\n");
+try {
+  const cwd = "/demo/repo";
+  writeFileSync(join(dir, "chat.jsonl"), file("c1", cwd, "real conversation"));
+  for (let i = 0; i < 9; i++) writeFileSync(join(dir, `ing${i}.jsonl`), file(`i${i}`, cwd, `${EXTRACT_SYSTEM}\n\nfact ${i}`));
+  writeFileSync(join(dir, "other.jsonl"), file("o1", "/other/repo", `${EXTRACT_SYSTEM}\n\nother repo`));
+
+  if (listSessions(cwd, root).ingest.length !== 9) fail("setup: expected 9 ingest sessions");
+
+  const r = clearIngestSessions(cwd, root);
+  if (!r.ok || r.cleared !== 9) fail(`expected to clear 9, cleared ${r.cleared}`);
+  ok("cleared all 9 ingest throwaways in one action");
+
+  const after = listSessions(cwd, root);
+  if (after.ingest.length !== 0) fail("ingest sessions should be gone");
+  if (after.sessions.map((s) => s.id).join() !== "c1") fail("the real chat must survive");
+  ok("the real chat survived; knowledge graph is a separate store (untouched)");
+
+  if (listSessions("/other/repo", root).ingest.map((s) => s.id).join() !== "o1") fail("another workspace's ingest must NOT be cleared");
+  ok("workspace-scoped: another repo's ingest sessions were left alone");
+
+  if (clearIngestSessions(cwd, root).cleared !== 0) fail("a second clear should be a no-op");
+  ok("idempotent: clearing again removes nothing");
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}
+
+console.log("demo-P-KG-INGEST.2 OK");
+process.exit(0);

--- a/desktop/sessions.ts
+++ b/desktop/sessions.ts
@@ -125,6 +125,37 @@ export function listSessions(cwd: string = currentWorkspace(), root: string = jo
   };
 }
 
+/** P-KG-INGEST.2 (ADR-0079): delete ALL kg-ingest throwaway sessions for one workspace. Defense in depth:
+ *  only removes files that BOTH (a) belong to the current workspace AND (b) are extractor throwaways
+ *  (`isIngestPrompt` on the first user message) — a real chat is never touched. Returns the count removed. */
+export function clearIngestSessions(cwd: string = currentWorkspace(), root: string = join(homedir(), ".omp", "agent", "sessions")): { ok: boolean; cleared: number } {
+  if (!existsSync(root)) return { ok: true, cleared: 0 };
+  const want = norm(cwd);
+  let cleared = 0;
+  for (const d of readdirSync(root)) {
+    const dir = join(root, d);
+    try {
+      if (!statSync(dir).isDirectory()) continue;
+      for (const f of readdirSync(dir)) {
+        if (!f.endsWith(".jsonl")) continue;
+        const p = join(dir, f);
+        try {
+          let scwd = "", isIngest = false, sawUser = false;
+          for (const ln of readFileSync(p, "utf8").split("\n")) {
+            if (!ln) continue;
+            let o: any; try { o = JSON.parse(ln); } catch { continue; }
+            if (o.type === "session") scwd = o.cwd ?? "";
+            else if (o.type === "message" && o.message?.role === "user" && !sawUser) { sawUser = true; isIngest = isIngestPrompt(firstUserText(o.message)); }
+            if (scwd && sawUser) break; // we know cwd + ingest-ness — stop reading
+          }
+          if (isIngest && norm(scwd) === want) { rmSync(p, { force: true }); cleared++; }
+        } catch { /* skip unreadable/locked file */ }
+      }
+    } catch { /* skip dir */ }
+  }
+  return { ok: true, cleared };
+}
+
 function msgText(message: any): string {
   const c = message?.content;
   if (typeof c === "string") return c;

--- a/desktop/sessions_ingest.test.ts
+++ b/desktop/sessions_ingest.test.ts
@@ -6,7 +6,7 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { EXTRACT_SYSTEM } from "../harness/personal/distiller.ts";
-import { ingestPreview, isIngestPrompt, listSessions } from "./sessions.ts";
+import { clearIngestSessions, ingestPreview, isIngestPrompt, listSessions } from "./sessions.ts";
 
 test("isIngestPrompt detects extractor throwaways, not real chats", () => {
   expect(isIngestPrompt(`${EXTRACT_SYSTEM}\n\nI like Rust`)).toBe(true);
@@ -42,6 +42,33 @@ test("listSessions splits ingest throwaways out of the chat list (titled by the 
     expect(ingest.map((s) => s.id).sort()).toEqual(["i1", "i2"]);
     expect(ingest.every((s) => s.kind === "kg-ingest")).toBe(true);
     expect(ingest.find((s) => s.id === "i1")!.title).toBe("I like Rust"); // NOT "Extract DURABLE facts…"
+
+    // P-KG-INGEST.2: clearing removes ONLY the ingest throwaways; the real chat survives.
+    const cleared = clearIngestSessions(cwd, root);
+    expect(cleared).toEqual({ ok: true, cleared: 2 });
+    const after = listSessions(cwd, root);
+    expect(after.ingest).toHaveLength(0);
+    expect(after.sessions.map((s) => s.id)).toEqual(["c1"]); // chat untouched
+    expect(clearIngestSessions(cwd, root).cleared).toBe(0); // idempotent — nothing left to clear
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("clearIngestSessions only touches the CURRENT workspace's ingest sessions", () => {
+  const root = join(tmpdir(), `lucid-sess-ws-${process.pid}-${Math.floor(performance.now())}`);
+  const dir = join(root, "enc");
+  mkdirSync(dir, { recursive: true });
+  const lnj = (o: unknown) => JSON.stringify(o);
+  const fileFor = (id: string, c: string, userText: string) => [
+    lnj({ type: "session", id, cwd: c }),
+    lnj({ type: "message", message: { role: "user", content: [{ type: "text", text: userText }] } }),
+  ].join("\n");
+  writeFileSync(join(dir, "mine.jsonl"), fileFor("m1", "/me/repo", `${EXTRACT_SYSTEM}\n\nmine`));
+  writeFileSync(join(dir, "other.jsonl"), fileFor("o1", "/other/repo", `${EXTRACT_SYSTEM}\n\nother`));
+  try {
+    expect(clearIngestSessions("/me/repo", root).cleared).toBe(1); // only my workspace's ingest session
+    expect(listSessions("/other/repo", root).ingest.map((s) => s.id)).toEqual(["o1"]); // the other repo's is intact
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
ADR-0079. Completes the housekeeping half of ADR-0076 (1b grouped the throwaway extraction sessions; this clears them in bulk).

- `sessions.ts clearIngestSessions(cwd, root?)` removes a file only when it is BOTH the current workspace's AND an extractor throwaway (`isIngestPrompt` on the first user message) — **a real chat is never deleted**. Idempotent, returns the count.
- `POST /api/sessions/ingest/clear` + `bridge.clearIngestSessions()`; the renderer adds a trash button on the 'Knowledge Graph Ingest · N' group header with a confirm toast.
- The knowledge-graph store is a separate encrypted file — **untouched**; only throwaway omp transcripts are removed. Deletion is workspace-scoped (defense in depth).

Tests: `sessions_ingest.test.ts` (+2 — clears only ingest, workspace-scoped) + `make demo-P-KG-INGEST.2`. desktop 482 ✓ / tsc clean. Closes #123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)