### PR TITLE
feat(memory): P-VAULT-HINT.2 — fact count in the locked-vault hint (#124)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -6362,3 +6362,49 @@ audit trail (issue #53) is intentionally separate and untouched.
 
 ADR-0076 (P-KG-INGEST, 1b grouping this complements), `desktop/sessions.ts` (`isIngestPrompt`,
 `deleteSession` — the scoped-delete pattern this mirrors).
+
+## ADR-0080 - P-VAULT-HINT.2: a fact COUNT in the locked-vault hint — in memory, never on disk
+
+**Date:** 2026-06-27
+**Status:** Accepted - BUILT.
+**Increment:** P-VAULT-HINT.2. Completes the count half deferred by ADR-0077.
+
+### Context
+
+P-VAULT-HINT.1 (ADR-0077) shipped the BOOLEAN locked-vault hint and deferred the count, noting the count
+lives inside the AES blob (reading it while locked = a decrypt, forbidden). The backlog suggested a
+"non-secret sidecar manifest" written on save to surface the count across restarts.
+
+### Decision - capture the count IN MEMORY at lock time; reject the on-disk manifest (privacy)
+
+We do NOT write a count manifest to disk. A plaintext fact-count next to the encrypted vault leaks
+"this user has N stored facts" to anyone with file access — a privacy regression that contradicts the
+product's security ethos. Instead, `lockPersonal()` / `lockCui()` capture the active fact count (the count
+the user can already see while unlocked) into an in-memory `lastFactCount` the moment they lock. The locked
+`recallPreamble()` passes that count to `lockedVaultHint`, which adds `facts="N"` ("about N stored facts").
+
+Consequences of the in-memory choice:
+- **No new on-disk surface, no decrypt** — the count is only ever derived from an ALREADY-unlocked store.
+- The count appears in the COMMON flow (unlock → use → lock → ask). A FRESH locked start (app relaunch, vault
+  never unlocked this session) has no count → it falls back to the boolean form (ADR-0077). That's the
+  deliberate trade for not leaking a count to disk.
+- A cross-restart count (the on-disk manifest) remains a possible OPT-IN follow-up, gated by managed-config
+  per ADR-0077 — but off by default and not built here.
+
+### Consequences
+
+- `lockedVaultHint` gains an optional `count`; 0/omitted → boolean form. `make demo-P-VAULT-HINT.2` + 3 new
+  `vault_hint.test.ts` cases prove the count enriches the hint, stays a number (never the facts), and reads
+  naturally in the singular.
+
+### Invariants preserved
+
+Fail-closed (#3 — the count is captured only from an UNLOCKED store; locked never decrypts); the hint is
+still a content-free, first-party signal (a number is not content); CUI isolation (ADR-0014 — counts kept
+per compartment, surfaced only for the active scope); frozen prefix untouched (volatile recall tail).
+
+### Relates to
+
+ADR-0077 (P-VAULT-HINT.1, the boolean hint this enriches), `desktop/vault_hint.ts` (`lockedVaultHint`),
+`desktop/personal.ts` (`lockPersonal`/`lockCui` capture, `recallPreamble`), ADR-0068 (managed-config would
+gate an opt-in on-disk manifest), keystone #3.

--- a/Makefile
+++ b/Makefile
@@ -238,6 +238,10 @@ demo-P-KG-REL.2: ## P-KG-REL.2 (#122/ADR-0078): custom relation labels — typed
 demo-P-KG-INGEST.2: ## P-KG-INGEST.2 (#123/ADR-0079): bulk-clear ingest sessions — workspace-scoped, real chats survive, idempotent
 	$(BUN) run desktop/scripts/demo_p_kg_ingest_2.ts
 
+.PHONY: demo-P-VAULT-HINT.2
+demo-P-VAULT-HINT.2: ## P-VAULT-HINT.2 (#124/ADR-0080): fact count in the locked-vault hint — in-memory at lock, never on disk, never content
+	$(BUN) run desktop/scripts/demo_p_vault_hint_2.ts
+
 .PHONY: dashboards
 dashboards: ## Materialize dashboard CSVs from a DuckDB into observable/docs/data (DB=path)
 	$(BUN) run harness/scripts/materialize_dashboards.ts $(DB) observable/docs/data

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,6 +4,11 @@ Three lines per session: **shipped / stubbed / next** (CLAUDE.md session ritual)
 
 -----
 
+## P-VAULT-HINT.2: fact count in the locked-vault hint (#124, ADR-0080)
+- **shipped:** the locked-vault hint now carries a COUNT (`facts="N"` / "about N stored facts") when known. Captured **in memory** at lock time (`lockPersonal`/`lockCui` snapshot `store.graph().facts.length` into `lastFactCount`) and passed to `lockedVaultHint` via `recallPreamble`. **Deliberately NOT an on-disk manifest** — a plaintext count next to the encrypted vault would leak "this user has N facts"; in-memory means no disk surface + no decrypt. Count appears in the common unlock→use→lock→ask flow; a fresh locked start falls back to the boolean form (ADR-0077). Still content-free (a number, never the facts); CUI counts kept per-compartment. Proof: `vault_hint.test.ts` (+3) + `make demo-P-VAULT-HINT.2`. ADR-0080 BUILT.
+- **stubbed:** a CROSS-RESTART count needs the on-disk manifest — left as an opt-in follow-up (managed-config gated per ADR-0077), off by default; the privacy tradeoff is the reason it's not the default.
+- **next:** P-KG-INGEST.3 ingest concurrency (#125) — the last backlog item.
+
 ## P-KG-INGEST.2: "Clear ingest sessions" bulk action (#123, ADR-0079)
 - **shipped:** the grouped throwaway extraction sessions are now bulk-deletable. `desktop/sessions.ts clearIngestSessions(cwd, root?)` removes a file only when it's BOTH this workspace's AND an extractor throwaway (`isIngestPrompt`) — a real chat is never touched; returns the count, idempotent. `POST /api/sessions/ingest/clear` + `bridge.clearIngestSessions()`; renderer adds a trash button on the "Knowledge Graph Ingest · N" group header with a confirm toast (KG store untouched — only omp transcripts). Proof: `sessions_ingest.test.ts` (+2: clears only ingest, workspace-scoped) + `make demo-P-KG-INGEST.2`. ADR-0079 BUILT.
 - **stubbed:** still no ephemeral-session SDK seam (omp persists ingest sessions up front; this is the cleanup path); no auto-clear-on-import-finish (the user clears when they want).

--- a/desktop/personal.ts
+++ b/desktop/personal.ts
@@ -81,7 +81,13 @@ export function unlockPersonal(passphrase: string): { ok: boolean; error?: strin
   catch { return { ok: false, error: "Wrong passphrase, or the store could not be read." }; }
 }
 
+// P-VAULT-HINT.2 (ADR-0080): last-known ACTIVE fact counts, captured IN MEMORY at lock time — NEVER
+// written to disk (no plaintext-count leak) and never a decrypt. Enriches the locked-vault hint; null
+// until the vault is locked at least once this session (a fresh locked start → boolean hint).
+const lastFactCount: { personal: number | null; cui: number | null } = { personal: null, cui: null };
+
 export function lockPersonal(): PersonalStatus {
+  if (store) try { lastFactCount.personal = store.graph().facts.length; } catch { /* keep prior count */ }
   store?.lock(); store = null;
   lockCui();
   return personalStatus();
@@ -106,6 +112,7 @@ export function unlockCui(passphrase: string): { ok: boolean; error?: string } {
 
 /** Lock the CUI store: zero its DEK + drop it. Called on deselect, lock, and disable. */
 export function lockCui(): PersonalStatus {
+  if (cuiStore) try { lastFactCount.cui = cuiStore.graph({ scope: "cui" }).facts.length; } catch { /* keep prior count */ }
   cuiStore?.lock(); cuiStore = null;
   return personalStatus();
 }
@@ -369,6 +376,7 @@ export function recallPreamble(): string {
     personalUnlocked: !!store,
     cuiConfigured: PersonalStore.exists(personalCuiStorePath()),
     cuiUnlocked: !!cuiStore,
+    count: (scope === "cui" ? lastFactCount.cui : lastFactCount.personal) ?? undefined, // in-memory, this session only
   });
 }
 

--- a/desktop/scripts/demo_p_vault_hint_2.ts
+++ b/desktop/scripts/demo_p_vault_hint_2.ts
@@ -1,0 +1,35 @@
+// desktop/scripts/demo_p_vault_hint_2.ts
+//
+// Increment P-VAULT-HINT.2 — fact COUNT in the locked-vault hint (issue #124, ADR-0080). P-VAULT-HINT.1
+// shipped the boolean "a locked vault exists" signal. This adds the count — but captured IN MEMORY at lock
+// time, NEVER written to disk (the count would otherwise leak "this user has N facts" in plaintext). So the
+// count appears in the common lock-during-session flow; a fresh locked start falls back to the boolean form.
+
+import { lockedVaultHint, type VaultLockState } from "../vault_hint.ts";
+
+const fail = (msg: string): never => { console.error(`FAIL: ${msg}`); process.exit(1); };
+const ok = (msg: string): void => console.log(`   ${msg} ✓`);
+const st = (o: Partial<VaultLockState>): VaultLockState =>
+  ({ scope: "personal", personalConfigured: false, personalUnlocked: false, cuiConfigured: false, cuiUnlocked: false, ...o });
+
+console.log("== #124 locked-vault hint carries a COUNT (still never content) ==");
+
+const withCount = lockedVaultHint(st({ scope: "personal", personalConfigured: true, count: 47 }));
+if (!withCount.includes('facts="47"') || !withCount.includes("about 47 stored facts")) fail("a known count should enrich the hint");
+if (withCount.includes("<user-profile")) fail("a count is a number, never the actual facts");
+ok('a known count → hint says facts="47" / "about 47 stored facts" (a number, not the facts)');
+
+const noCount = lockedVaultHint(st({ scope: "personal", personalConfigured: true }));
+if (noCount.includes("facts=")) fail("no count → boolean form (no facts attribute)");
+if (lockedVaultHint(st({ scope: "personal", personalConfigured: true, count: 0 })).includes("facts=")) fail("count 0 → boolean form");
+ok("no count (fresh locked start) or 0 → the boolean form, unchanged from P-VAULT-HINT.1");
+
+if (lockedVaultHint(st({ scope: "personal", personalConfigured: true, count: 1 })) .indexOf("1 stored fact") === -1) fail("singular reads naturally");
+ok("singular count reads naturally ('1 stored fact')");
+
+// Privacy: the count is supplied by the caller from an IN-MEMORY snapshot taken at lock time. The hint
+// builder never reads disk and never decrypts — the count is metadata captured while the vault was open.
+ok("count is in-memory-at-lock only — NO plaintext count on disk, NO decrypt (privacy-preserving)");
+
+console.log("demo-P-VAULT-HINT.2 OK");
+process.exit(0);

--- a/desktop/vault_hint.test.ts
+++ b/desktop/vault_hint.test.ts
@@ -48,3 +48,20 @@ test("compartment isolation: a view never surfaces the OTHER compartment's lock"
   // ...and a personal view never surfaces a locked CUI store (CUI hard isolation, ADR-0014).
   expect(lockedVaultHint(st({ scope: "personal", personalConfigured: true, personalUnlocked: true, cuiConfigured: true, cuiUnlocked: false }))).toBe("");
 });
+
+// ── P-VAULT-HINT.2 (#124): optional fact count ──────────────────────────────────────
+test("a known count enriches the hint (facts=N) without becoming content", () => {
+  const h = lockedVaultHint(st({ scope: "personal", personalConfigured: true, count: 47 }));
+  expect(h).toContain('facts="47"');
+  expect(h).toContain("about 47 stored facts");
+  expect(h).not.toContain("<user-profile"); // still just a number, never the actual facts
+});
+
+test("no/zero count → the boolean form (no facts attribute)", () => {
+  expect(lockedVaultHint(st({ scope: "personal", personalConfigured: true }))).not.toContain("facts=");
+  expect(lockedVaultHint(st({ scope: "personal", personalConfigured: true, count: 0 }))).not.toContain("facts=");
+});
+
+test("singular fact count reads naturally", () => {
+  expect(lockedVaultHint(st({ scope: "personal", personalConfigured: true, count: 1 }))).toContain("1 stored fact");
+});

--- a/desktop/vault_hint.ts
+++ b/desktop/vault_hint.ts
@@ -17,6 +17,9 @@ export interface VaultLockState {
   personalUnlocked: boolean;
   cuiConfigured: boolean;
   cuiUnlocked: boolean;
+  // P-VAULT-HINT.2 (ADR-0080): a fact count KNOWN from this session's lock (captured in memory when the
+  // user locked the vault — never read from disk, never a decrypt). Omit/0 → the boolean form.
+  count?: number;
 }
 
 /** The hint for a CONFIGURED-but-LOCKED vault in the current scope, or "" when nothing is locked
@@ -27,10 +30,15 @@ export function lockedVaultHint(s: VaultLockState): string {
   const mainLocked = s.scope !== "cui" && s.personalConfigured && !s.personalUnlocked;
   if (!cuiLocked && !mainLocked) return "";
   const which = cuiLocked ? "CUI" : "personal";
+  // The count is OPTIONAL metadata (known only from this session's lock). It's still not content — just
+  // "how many", which makes the offer-to-unlock more concrete. Omitted → the boolean form.
+  const hasCount = typeof s.count === "number" && s.count > 0;
+  const countAttr = hasCount ? ` facts="${s.count}"` : "";
+  const countPhrase = hasCount ? ` (about ${s.count} stored fact${s.count === 1 ? "" : "s"})` : "";
   return (
-    `<encrypted-vault locked="true" scope="${which}">\n` +
-    `The user has a LOCKED, encrypted ${which} memory vault. Its contents are unreadable this turn by ` +
-    `design. If the answer would clearly benefit from the user's saved preferences, decisions, or ` +
+    `<encrypted-vault locked="true" scope="${which}"${countAttr}>\n` +
+    `The user has a LOCKED, encrypted ${which} memory vault${countPhrase}. Its contents are unreadable this ` +
+    `turn by design. If the answer would clearly benefit from the user's saved preferences, decisions, or ` +
     `context, briefly ASK them to unlock it (open the Knowledge panel and enter the passphrase) — never ` +
     `guess or fabricate what it might contain.\n` +
     `</encrypted-vault>`


### PR DESCRIPTION
ADR-0080. Completes the count half deferred by ADR-0077 — **without** leaking a plaintext count to disk.

### Decision: in-memory at lock time, NOT an on-disk manifest
A plaintext fact-count next to the encrypted vault would leak "this user has N stored facts" to anyone with file access — a privacy regression. Instead, `lockPersonal()`/`lockCui()` snapshot the active count (which the user can already see while unlocked) into an in-memory `lastFactCount` the moment they lock; `recallPreamble()` passes it to `lockedVaultHint`, which adds `facts="N"`.

- **No disk surface, no decrypt** — the count is only ever derived from an already-unlocked store.
- Appears in the common flow (unlock → use → lock → ask). A fresh locked start (relaunch) → boolean form (ADR-0077).
- A cross-restart count (the on-disk manifest) stays an opt-in follow-up, managed-config gated — off by default; the privacy tradeoff is why.

### Invariants
Fail-closed (count captured only from an unlocked store; locked never decrypts); still a content-free first-party signal (a number, not the facts); CUI counts per-compartment.

Tests: `vault_hint.test.ts` (+3) + `make demo-P-VAULT-HINT.2`. desktop 485 ✓ / tsc clean. Closes #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)