### PR TITLE
feat(kg): P-KG-INGEST.3 — chat stays responsive during an AI-mode ingest (#125)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -6408,3 +6408,45 @@ per compartment, surfaced only for the active scope); frozen prefix untouched (v
 ADR-0077 (P-VAULT-HINT.1, the boolean hint this enriches), `desktop/vault_hint.ts` (`lockedVaultHint`),
 `desktop/personal.ts` (`lockPersonal`/`lockCui` capture, `recallPreamble`), ADR-0068 (managed-config would
 gate an opt-in on-disk manifest), keystone #3.
+
+## ADR-0081 - P-KG-INGEST.3: chat stays responsive during an AI-mode ingest
+
+**Date:** 2026-06-27
+**Status:** Accepted - BUILT.
+**Increment:** P-KG-INGEST.3. The last import-UX item — finishes ADR-0076's "use the app while it ingests".
+
+### Context
+
+Model-mode ingest extracts facts by calling `backend.complete()` once per message, back-to-back, through
+the SINGLE omp ACP connection. P-KG-INGEST.1a moved the import OFF the request thread (the app stays usable),
+but a long AI import still fired extractions continuously, so a live chat turn competed with — and stalled
+behind — the stream of extractions on the shared connection. The user saw chat freeze during AI imports.
+
+### Decision - a ChatGate so background extraction YIELDS to a live chat turn (chat preempts the import)
+
+`desktop/chat_gate.ts ChatGate` is a tiny state machine: `begin()`/`end()` bracket a chat turn; `whenIdle()`
+resolves immediately when no chat turn is active, else when the current one ends. `prompt()` (chat) brackets
+its turn with `chatGate.begin()/end()`; `complete()` (every utility completion — import extraction AND the
+/goal checker) `await this.chatGate.whenIdle()` BEFORE creating its session. So while the user is chatting,
+the import pauses between extractions and resumes after the reply — chat preempts the import with at most one
+in-flight extraction of latency (seconds), instead of waiting out the whole import (minutes).
+
+### Consequences
+
+- Zero overhead when nobody is chatting (`whenIdle()` resolves synchronously). No change to import results —
+  it's the same extractions in the same order, just yielding to chat. The /goal checker also yields (already
+  sequenced after the maker turn, so a no-op there).
+- A truly concurrent design (a SECOND omp process dedicated to extraction) would remove even the one-
+  extraction latency, but it's a much larger change (a second backend instance) — deferred; the gate
+  delivers responsive chat with a tiny, well-tested surface.
+
+### Invariants preserved
+
+No change to scanning/gating of imported text (keystone #2) or to memory promotion; the gate only reorders
+WHEN extraction runs relative to chat. Fail-safe: `end()` always runs in `prompt()`'s `finally`, so a
+stalled/errored chat turn can't leave the import permanently paused.
+
+### Relates to
+
+ADR-0076 (P-KG-INGEST.1a/1b, the background ingest this completes), `desktop/acp_backend.ts`
+(`prompt`/`complete`/`utilLock`), `desktop/chat_gate.ts`.

--- a/Makefile
+++ b/Makefile
@@ -242,6 +242,10 @@ demo-P-KG-INGEST.2: ## P-KG-INGEST.2 (#123/ADR-0079): bulk-clear ingest sessions
 demo-P-VAULT-HINT.2: ## P-VAULT-HINT.2 (#124/ADR-0080): fact count in the locked-vault hint — in-memory at lock, never on disk, never content
 	$(BUN) run desktop/scripts/demo_p_vault_hint_2.ts
 
+.PHONY: demo-P-KG-INGEST.3
+demo-P-KG-INGEST.3: ## P-KG-INGEST.3 (#125/ADR-0081): chat preempts a back-to-back ingest loop via the ChatGate (yields, then resumes)
+	$(BUN) run desktop/scripts/demo_p_kg_ingest_3.ts
+
 .PHONY: dashboards
 dashboards: ## Materialize dashboard CSVs from a DuckDB into observable/docs/data (DB=path)
 	$(BUN) run harness/scripts/materialize_dashboards.ts $(DB) observable/docs/data

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,6 +4,11 @@ Three lines per session: **shipped / stubbed / next** (CLAUDE.md session ritual)
 
 -----
 
+## P-KG-INGEST.3: chat stays responsive during an AI-mode ingest (#125, ADR-0081)
+- **shipped:** a long AI import no longer freezes chat. `desktop/chat_gate.ts ChatGate` (begin/end/whenIdle) lets background extraction yield to a live chat turn: `acp_backend.prompt()` brackets a chat turn with `chatGate.begin()/end()`; `complete()` (every util completion — import extraction + the /goal checker) `await chatGate.whenIdle()` before creating its session. So while the user chats, the import pauses between extractions and resumes after the reply — chat preempts with ≤1 in-flight extraction of latency instead of waiting out the whole import. Zero overhead when idle (`whenIdle()` resolves synchronously). Fail-safe: `end()` is in `prompt()`'s `finally` so a stalled chat can't pause the import forever. Proof: `chat_gate.test.ts` (5) + `make demo-P-KG-INGEST.3`. ADR-0081 BUILT.
+- **stubbed:** a SECOND omp process dedicated to extraction would remove even the one-extraction latency (true concurrency) — deferred as a much larger change; the gate delivers responsive chat with a tiny surface.
+- **next:** ALL KG import-feedback work + the 4 backlog ADRs (0078-0081) are now shipped. Backlog clear.
+
 ## P-VAULT-HINT.2: fact count in the locked-vault hint (#124, ADR-0080)
 - **shipped:** the locked-vault hint now carries a COUNT (`facts="N"` / "about N stored facts") when known. Captured **in memory** at lock time (`lockPersonal`/`lockCui` snapshot `store.graph().facts.length` into `lastFactCount`) and passed to `lockedVaultHint` via `recallPreamble`. **Deliberately NOT an on-disk manifest** — a plaintext count next to the encrypted vault would leak "this user has N facts"; in-memory means no disk surface + no decrypt. Count appears in the common unlock→use→lock→ask flow; a fresh locked start falls back to the boolean form (ADR-0077). Still content-free (a number, never the facts); CUI counts kept per-compartment. Proof: `vault_hint.test.ts` (+3) + `make demo-P-VAULT-HINT.2`. ADR-0080 BUILT.
 - **stubbed:** a CROSS-RESTART count needs the on-disk manifest — left as an opt-in follow-up (managed-config gated per ADR-0077), off by default; the privacy tradeoff is the reason it's not the default.

--- a/desktop/acp_backend.ts
+++ b/desktop/acp_backend.ts
@@ -15,6 +15,7 @@ import { BUILD_POLICY, DELEGATION_POLICY } from "../harness/prompt/assembler.ts"
 import { currentWorkspace } from "./workspace.ts";
 import { learnFromTurn, recallPreamble } from "./personal.ts";
 import { buildUserTurnPreamble } from "./preamble.ts";
+import { ChatGate } from "./chat_gate.ts";
 import { recordTurns } from "./turns_log.ts";
 import { isLearnableAssistantText } from "./thinking_governance.ts";
 import { recordBlock } from "./security_log.ts";
@@ -475,6 +476,7 @@ class Backend {
     const sink = (e: ChatEvent) => { arm(); if (isLearnableAssistantText(e)) assistant += e.text; try { onEvent(e); } catch { enqueueErr++; } };
     this.listener = sink;
     this.askActive = true; // permission requests in THIS turn may be forwarded to the UI (Ask mode)
+    this.chatGate.begin(); // P-KG-INGEST.3: a chat turn is live → background extraction should yield to it
     this.turnDiag(`prompt.start session=${this.sessionId}`);
     try {
       await this.ensureSession();
@@ -505,6 +507,7 @@ class Backend {
     } finally {
       if (idle) clearTimeout(idle);
       this.askActive = false;
+      this.chatGate.end(); // P-KG-INGEST.3: chat turn done → release any extraction waiting to resume
       // Fail-closed: any permission still parked at turn's end (stall/disconnect) is denied.
       for (const [id, fn] of this.permPending) { this.permPending.delete(id); fn(null); }
       this.pendingPerms = 0;
@@ -853,6 +856,9 @@ class Backend {
 
   // Serializes utility completions so they never clobber a concurrent chat turn's listener.
   private utilLock: Promise<void> = Promise.resolve();
+  // P-KG-INGEST.3 (ADR-0081): lets background extraction (complete()) yield to a live chat turn, so a long
+  // AI-mode ingest can't starve chat on the shared omp connection.
+  private chatGate = new ChatGate();
 
   /** One-shot, non-streaming completion in a THROWAWAY session — never touches the chat
    *  session, persona, or recall. Returns the aggregated assistant text ("" on any failure).
@@ -869,6 +875,10 @@ class Backend {
       let onStall: (e: Error) => void = () => {};
       let myListener: ((e: ChatEvent) => void) | null = null;
       try {
+        // P-KG-INGEST.3: yield to a live chat turn before running this extraction. A long AI-mode import
+        // fires complete() back-to-back; pausing here while the user is chatting lets chat preempt the
+        // import (at most one in-flight extraction of latency), then the import resumes.
+        await this.chatGate.whenIdle();
         const s: any = await this.acp!.request("session/new", { cwd: currentWorkspace(), mcpServers: mcpServersForAcp() });
         sid = s?.sessionId ?? s?.id ?? null;
         if (!sid) return "";

--- a/desktop/chat_gate.test.ts
+++ b/desktop/chat_gate.test.ts
@@ -1,0 +1,65 @@
+// Tests for the chat-yield gate (P-KG-INGEST.3, ADR-0081): background extraction yields to a live chat.
+
+import { expect, test } from "bun:test";
+import { ChatGate } from "./chat_gate.ts";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+test("idle gate: whenIdle() resolves immediately", async () => {
+  const g = new ChatGate();
+  expect(g.active).toBe(false);
+  let resolved = false;
+  void g.whenIdle().then(() => { resolved = true; });
+  await tick();
+  expect(resolved).toBe(true);
+});
+
+test("active gate: whenIdle() pends until the chat turn ends", async () => {
+  const g = new ChatGate();
+  g.begin();
+  expect(g.active).toBe(true);
+  let resolved = false;
+  void g.whenIdle().then(() => { resolved = true; });
+  await tick();
+  expect(resolved).toBe(false); // chat is live → extraction waits
+  g.end();
+  expect(g.active).toBe(false);
+  await tick();
+  expect(resolved).toBe(true); // released when the chat turn finished
+});
+
+test("end() releases ALL queued waiters (several pending extractions)", async () => {
+  const g = new ChatGate();
+  g.begin();
+  let n = 0;
+  void g.whenIdle().then(() => n++);
+  void g.whenIdle().then(() => n++);
+  await tick();
+  expect(n).toBe(0);
+  g.end();
+  await tick();
+  expect(n).toBe(2);
+});
+
+test("end() when already idle is a harmless no-op", () => {
+  const g = new ChatGate();
+  g.end();
+  expect(g.active).toBe(false);
+});
+
+test("chat preempts a back-to-back extraction loop", async () => {
+  // Model the import: each extraction awaits whenIdle() before running. While chat is live none start; once
+  // it ends, they resume. So chat replies first even though extraction was already looping.
+  const g = new ChatGate();
+  const order: string[] = [];
+  const extraction = async (label: string) => { await g.whenIdle(); order.push(label); };
+  g.begin(); // user sends a chat mid-import
+  const e1 = extraction("ingest-1");
+  await tick();
+  order.push("chat-reply"); // chat does its work...
+  g.end();                   // ...and finishes
+  await Promise.all([e1, extraction("ingest-2")]);
+  expect(order[0]).toBe("chat-reply"); // chat went first; the import waited its turn
+  expect(order).toContain("ingest-1");
+  expect(order).toContain("ingest-2");
+});

--- a/desktop/chat_gate.ts
+++ b/desktop/chat_gate.ts
@@ -1,0 +1,31 @@
+// desktop/chat_gate.ts — P-KG-INGEST.3 (ADR-0081): let background extraction YIELD to a live chat turn.
+//
+// Model-mode ingest fires a model `complete()` per message, back-to-back, through the one omp connection.
+// Without a gate, a 25-minute AI import keeps the connection busy and live chat stalls. This tiny gate lets
+// `complete()` await `whenIdle()` before each extraction: while a chat turn is in flight the import pauses,
+// so chat preempts the import (at most one in-flight extraction of latency), then the import resumes.
+
+export class ChatGate {
+  #active = false;
+  #waiters: Array<() => void> = [];
+
+  /** Whether a chat turn is currently in flight. */
+  get active(): boolean { return this.#active; }
+
+  /** Mark a chat turn as started. */
+  begin(): void { this.#active = true; }
+
+  /** Mark the chat turn as finished and release anything waiting for idle. Safe to call when idle. */
+  end(): void {
+    if (!this.#active) return;
+    this.#active = false;
+    const waiters = this.#waiters;
+    this.#waiters = [];
+    for (const resolve of waiters) resolve();
+  }
+
+  /** Resolves immediately when no chat turn is active, otherwise when the current one ends. */
+  whenIdle(): Promise<void> {
+    return this.#active ? new Promise<void>((resolve) => this.#waiters.push(resolve)) : Promise.resolve();
+  }
+}

--- a/desktop/scripts/demo_p_kg_ingest_3.ts
+++ b/desktop/scripts/demo_p_kg_ingest_3.ts
@@ -1,0 +1,43 @@
+// desktop/scripts/demo_p_kg_ingest_3.ts
+//
+// Increment P-KG-INGEST.3 — chat stays responsive during an AI-mode ingest (issue #125, ADR-0081).
+// Model-mode import fires a model completion per message, back-to-back, over the one omp connection, so a
+// long import used to starve chat. Now each extraction awaits the ChatGate's whenIdle() first: while a chat
+// turn is live the import pauses, so chat preempts it (at most one in-flight extraction of latency).
+
+import { ChatGate } from "../chat_gate.ts";
+
+const fail = (msg: string): never => { console.error(`FAIL: ${msg}`); process.exit(1); };
+const ok = (msg: string): void => console.log(`   ${msg} ✓`);
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+console.log("== #125 chat preempts a back-to-back ingest loop ==");
+
+const g = new ChatGate();
+const order: string[] = [];
+// the import loop: every extraction yields to a live chat turn before running
+const extraction = async (label: string) => { await g.whenIdle(); order.push(label); };
+
+if (g.active) fail("a fresh gate must be idle");
+let immediate = false;
+void g.whenIdle().then(() => { immediate = true; });
+await tick();
+if (!immediate) fail("when idle, extraction should run immediately (no chat to yield to)");
+ok("idle: extraction runs immediately — zero overhead when nobody is chatting");
+
+g.begin(); // the user sends a chat message mid-import
+const e1 = extraction("ingest-A");
+const e2 = extraction("ingest-B");
+await tick();
+if (order.length !== 0) fail("no extraction may start while a chat turn is live");
+ok("a chat turn is live → queued extractions PAUSE (chat isn't starved)");
+
+order.push("chat-reply"); // chat does its work and finishes
+g.end();
+await Promise.all([e1, e2]);
+if (order[0] !== "chat-reply") fail("chat should have replied before the paused extractions resumed");
+if (!order.includes("ingest-A") || !order.includes("ingest-B")) fail("the import must resume after chat");
+ok("chat replied first, THEN the import resumed where it left off (no work lost)");
+
+console.log("demo-P-KG-INGEST.3 OK");
+process.exit(0);


### PR DESCRIPTION
ADR-0081. The last import-UX item — finishes ADR-0076's *"use the app while it ingests."*

Model-mode ingest calls `complete()` once per message, back-to-back, over the single omp ACP connection. P-KG-INGEST.1a moved the import off the request thread, but a long AI import still fired extractions continuously, so a live chat turn stalled behind them.

### Fix: a ChatGate so extraction yields to a live chat turn
`desktop/chat_gate.ts ChatGate` — `begin()`/`end()` bracket a chat turn; `whenIdle()` resolves immediately when idle, else when the current chat turn ends.
- `prompt()` (chat) brackets its turn with `chatGate.begin()/end()`.
- `complete()` (import extraction + the /goal checker) `await chatGate.whenIdle()` before creating its session.

So while the user is chatting, the import **pauses between extractions** and resumes after the reply — chat preempts with **≤1 in-flight extraction** of latency (seconds) instead of waiting out the whole import (minutes). Zero overhead when nobody's chatting (`whenIdle()` resolves synchronously). Fail-safe: `end()` lives in `prompt()`'s `finally`, so a stalled/errored chat turn can't leave the import permanently paused.

A second omp process dedicated to extraction would remove even the one-extraction latency, but it's a much larger change — deferred; the gate delivers responsive chat with a tiny, well-tested surface.

Tests: `chat_gate.test.ts` (5) + `make demo-P-KG-INGEST.3`. harness 545 ✓ · desktop 490 ✓ · tsc clean. Closes #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)