### PR TITLE
feat(kg): P-KG-REL.3 — remove a relationship (#130)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -6450,3 +6450,41 @@ stalled/errored chat turn can't leave the import permanently paused.
 
 ADR-0076 (P-KG-INGEST.1a/1b, the background ingest this completes), `desktop/acp_backend.ts`
 (`prompt`/`complete`/`utilLock`), `desktop/chat_gate.ts`.
+
+## ADR-0082 - P-KG-REL.3: remove a relationship from the graph
+
+**Date:** 2026-06-27
+**Status:** Accepted - BUILT.
+**Increment:** P-KG-REL.3. Completes manual relationship authoring — create (REL.1), label (REL.2), remove.
+
+### Context
+
+P-KG-REL.1/.2 let the user author relationships but never delete one — you could add an edge by mistake and
+be stuck with it. The data layer had `addLink` but no removal.
+
+### Decision - a removable relationships list in the node panel; mirror the relate path
+
+`harness/personal/store.ts removeLink(from, to, relation?)` deletes matching user-authored link(s) (exact
+relation, or all between the pair) and returns the count. `desktop/personal.ts unrelateEntities` wraps it
+for the active scope (mirrors `relateEntities`); served at `POST /api/personal/unrelate` +
+`bridge.personalUnrelate`. The node detail panel (`renderKgSide`) gains a **Relationships** section listing
+each edge touching the node (with a direction arrow + the label) and a remove (×) button; clicking it
+removes the edge OPTIMISTICALLY (`kg_ops.ts removeEdgeOptimistic`, rollback-safe) then calls the server.
+
+### Consequences
+
+- Symmetric with the forget-fact flow (optimistic mutate + reconcile + rollback). `make demo-P-KG-REL.3`
+  proves the optimistic removal is rollback-safe AND `store.removeLink` persists the deletion through the
+  encrypted store (only the targeted edge goes). Unit tests cover `removeEdgeOptimistic`.
+
+### Invariants preserved
+
+User-authored edges remain first-party (no scanner, no semantic promotion — keystone #2); removal is
+scope-confined (the active store only); nodes/facts are untouched (only the edge is deleted); closed trust
+set; no `contracts.ts` change.
+
+### Relates to
+
+ADR-0075/0078 (P-KG-REL.1/.2, which this completes), `harness/personal/store.ts` (`addLink`/`removeLink`),
+`desktop/personal.ts` (`relateEntities`/`unrelateEntities`), `desktop/renderer/kg_ops.ts`
+(`addEdgeOptimistic`/`removeEdgeOptimistic`).

--- a/Makefile
+++ b/Makefile
@@ -246,6 +246,10 @@ demo-P-VAULT-HINT.2: ## P-VAULT-HINT.2 (#124/ADR-0080): fact count in the locked
 demo-P-KG-INGEST.3: ## P-KG-INGEST.3 (#125/ADR-0081): chat preempts a back-to-back ingest loop via the ChatGate (yields, then resumes)
 	$(BUN) run desktop/scripts/demo_p_kg_ingest_3.ts
 
+.PHONY: demo-P-KG-REL.3
+demo-P-KG-REL.3: ## P-KG-REL.3 (#130/ADR-0082): remove a relationship — optimistic edge removal + store.removeLink persists (only the targeted edge)
+	$(BUN) run desktop/scripts/demo_p_kg_rel_3.ts
+
 .PHONY: dashboards
 dashboards: ## Materialize dashboard CSVs from a DuckDB into observable/docs/data (DB=path)
 	$(BUN) run harness/scripts/materialize_dashboards.ts $(DB) observable/docs/data

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,6 +4,11 @@ Three lines per session: **shipped / stubbed / next** (CLAUDE.md session ritual)
 
 -----
 
+## P-KG-REL.3: remove a relationship (#130, ADR-0082)
+- **shipped:** the node panel now lists a node's **Relationships** (direction arrow + label) each with a remove (×) — closing the create-only asymmetry of REL.1/.2. New `store.removeLink(from, to, relation?)` (data layer) + `unrelateEntities` (`desktop/personal.ts`, mirrors `relateEntities`) + `POST /api/personal/unrelate` + `bridge.personalUnrelate`. Removal is optimistic (`kg_ops.ts removeEdgeOptimistic`, rollback-safe) then reconciled with the server — symmetric with the forget flow. Authored edges stay first-party; nodes/facts untouched. Proof: `kg_ops.test.ts` removeEdgeOptimistic + `make demo-P-KG-REL.3` (optimistic + `store.removeLink` persists only the targeted edge). ADR-0082 BUILT.
+- **stubbed:** no edit-in-place of a relation's label (remove + re-add); no multi-edge bulk remove.
+- **next:** KG import-feedback epic + all follow-ups (ADR-0075-0082) shipped.
+
 ## P-KG-INGEST.3: chat stays responsive during an AI-mode ingest (#125, ADR-0081)
 - **shipped:** a long AI import no longer freezes chat. `desktop/chat_gate.ts ChatGate` (begin/end/whenIdle) lets background extraction yield to a live chat turn: `acp_backend.prompt()` brackets a chat turn with `chatGate.begin()/end()`; `complete()` (every util completion — import extraction + the /goal checker) `await chatGate.whenIdle()` before creating its session. So while the user chats, the import pauses between extractions and resumes after the reply — chat preempts with ≤1 in-flight extraction of latency instead of waiting out the whole import. Zero overhead when idle (`whenIdle()` resolves synchronously). Fail-safe: `end()` is in `prompt()`'s `finally` so a stalled chat can't pause the import forever. Proof: `chat_gate.test.ts` (5) + `make demo-P-KG-INGEST.3`. ADR-0081 BUILT.
 - **stubbed:** a SECOND omp process dedicated to extraction would remove even the one-extraction latency (true concurrency) — deferred as a much larger change; the gate delivers responsive chat with a tiny surface.

--- a/desktop/dev.ts
+++ b/desktop/dev.ts
@@ -30,7 +30,7 @@ import { currentWorkspace } from "./workspace.ts";
 import { recordSkillActivated } from "./skills_log.ts";
 import { recentTurns } from "./turns_log.ts";
 import { headroomStatus, setHeadroomEnabled, startHeadroom } from "./headroom.ts";
-import { destroyCui, enablePersonal, estimateChatExport, exportCuiArchive, exportHistory, exportVault, forgetFact, importChatExport, lockCui, lockPersonal, migrateCuiIntoStore, personalGraph, personalStatus, relateEntities, setScope, setupCui, setupPersonal, unlockCui, unlockPersonal } from "./personal.ts";
+import { destroyCui, enablePersonal, estimateChatExport, exportCuiArchive, exportHistory, exportVault, forgetFact, importChatExport, lockCui, lockPersonal, migrateCuiIntoStore, personalGraph, personalStatus, relateEntities, setScope, setupCui, setupPersonal, unlockCui, unlockPersonal, unrelateEntities } from "./personal.ts";
 import { readEditorFile, saveEditorFile } from "./editor.ts";
 import { cancelImport, importJobStatus, startImport } from "./import_job.ts";
 import { homedir } from "node:os";
@@ -483,6 +483,7 @@ const server = Bun.serve({
       // P-KG-REL.1 (ADR-0075): user-authored relationship between two existing, visible nodes. First-party
       // (not external content) → no scanner; relateEntities validates both nodes + sanitizes the label.
       if (p === "/api/personal/relate" && req.method === "POST") { const b = await readBody<{ from?: unknown; to?: unknown; relation?: unknown }>(req); return json({ ok: true, data: relateEntities(String(b.from ?? ""), String(b.to ?? ""), b.relation == null ? undefined : String(b.relation)) }); }
+      if (p === "/api/personal/unrelate" && req.method === "POST") { const b = await readBody<{ from?: unknown; to?: unknown; relation?: unknown }>(req); return json({ ok: true, data: unrelateEntities(String(b.from ?? ""), String(b.to ?? ""), b.relation == null ? undefined : String(b.relation)) }); } // P-KG-REL.3
       // P9.7: import a ChatGPT / Claude / Gemini export (folder, .json, or .zip). Every imported
       // user message is scanned by the fail-closed gate first. `model:true` runs the richer LLM
       // extractor via a throwaway omp completion (capped); otherwise the offline heuristic.

--- a/desktop/personal.ts
+++ b/desktop/personal.ts
@@ -203,6 +203,22 @@ export function relateEntities(fromId: string, toId: string, relation?: string):
   return { ok: true, id };
 }
 
+/** Remove a user-authored relationship between two nodes (P-KG-REL.3, ADR-0082). With `relation`, only
+ *  that exact edge; otherwise every edge between the pair (in that direction). Operates on the
+ *  currently-scoped store; returns how many edges were removed. */
+export function unrelateEntities(fromId: string, toId: string, relation?: string): { ok: boolean; error?: string; removed?: number } {
+  const s = load();
+  if (!s.personalizationEnabled || !store) return { ok: false, error: "Personalization is off." };
+  const scope = (s.personalScope ?? "personal") as ScopeView;
+  const src = storeForScope(scope);
+  if (!src) return { ok: false, error: "That compartment is locked." };
+  const from = String(fromId ?? ""), to = String(toId ?? "");
+  if (!from || !to) return { ok: false, error: "Pick two nodes." };
+  const removed = src.removeLink(from, to, relation == null ? undefined : String(relation)); // match the stored label as-is
+  if (removed) src.save();
+  return { ok: true, removed };
+}
+
 // ── P9.4: audited Obsidian vault export + NARA-aligned CUI archive ─────────────────
 export interface ExportSummary {
   ok: boolean; error?: string; dest?: string;

--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -11,7 +11,7 @@ import { ageStr, esc, fmtUSD, goodColor, loadColor } from "./format.ts";
 import { icon, piMark } from "./icons.ts";
 import { renderMarkdown } from "./markdown.ts";
 import { type GraphHandle, kindLabel, mountGraph } from "./graph.ts";
-import { addEdgeOptimistic, applyForget, chainPairs, resolveRelationLabel } from "./kg_ops.ts";
+import { addEdgeOptimistic, applyForget, chainPairs, removeEdgeOptimistic, resolveRelationLabel } from "./kg_ops.ts";
 import type { PersonalGraphData } from "./bridge.ts";
 import { type Action, type ToastAction, attachRichTip, createPalette, initTooltips, popover, showToast } from "./ui.ts";
 import { exportActionPlan } from "./kg_export.ts";
@@ -1709,8 +1709,19 @@ function renderKgSide(id: string | null): void {
       <div class="kg-fact-meta"><span class="pill ${esc(f.trust)}">${esc(f.trust)}</span> <span>conf ${Math.round((f.confidence ?? 0) * 100)}%</span>
         <button class="kg-forget" data-forget="${esc(f.id)}" data-tip="Forget this|Soft-delete - the agent stops recalling it.">${icon("close", 12)} forget</button></div>
     </div>`).join("");
+  // P-KG-REL.3: this node's relationships, each removable. Arrow shows direction (→ from this node, ← into it).
+  const nameOf = (nid: string): string => kgData!.nodes.find((n) => n.id === nid)?.name ?? "(removed)";
+  const edges = kgData.edges.filter((e) => e.from === id || e.to === id);
+  const relRows = edges.map((e) => {
+    const other = e.from === id ? e.to : e.from;
+    return `<div class="kg-rel">
+      <div class="kg-rel-text"><span class="kg-rel-arrow">${e.from === id ? "→" : "←"}</span> <b>${esc(nameOf(other))}</b> <span class="kg-rel-label">${esc(e.relation)}</span></div>
+      <button class="kg-unrelate" data-unrelate data-from="${esc(e.from)}" data-to="${esc(e.to)}" data-rel="${esc(e.relation)}" data-tip="Remove this relationship|Deletes the edge; the nodes stay.">${icon("close", 11)}</button>
+    </div>`;
+  }).join("");
+  const relSection = edges.length ? `<div class="kg-side-sub">Relationships</div><div class="kg-side-rels">${relRows}</div>` : "";
   side.innerHTML = `<div class="kg-side-head"><span class="kg-side-kind" style="background:${kindTint(node.kind)}">${esc(kindLabel(node.kind))}</span><b>${esc(node.name)}</b></div>
-    <div class="kg-side-facts">${rows || `<div class="empty">No active facts.</div>`}</div>`;
+    <div class="kg-side-facts">${rows || `<div class="empty">No active facts.</div>`}</div>${relSection}`;
 }
 const kindTint = (k: string): string => {
   const c: Record<string, string> = { preference: "var(--cyan-dim)", interest: "var(--green-dim)", decision: "var(--blue-dim)", behavior: "var(--amber-dim)", personality: "var(--accent-dim)" };
@@ -3325,6 +3336,23 @@ function wire(): void {
     if (t.closest("#kgRelate")) { setRelateMode(!kgRelateMode); return; } // P-KG-REL.1 toggle relate mode
     if (t.closest("#kgRelateDo")) { void relatePicked(); return; }
     if (t.closest("#kgRelateClear")) { kgHandle?.clearRelatePicks(); return; }
+    const unrel = t.closest("[data-unrelate]") as HTMLElement | null; // P-KG-REL.3 remove a relationship
+    if (unrel) {
+      const from = unrel.dataset.from!, to = unrel.dataset.to!, rel = unrel.dataset.rel ?? "";
+      if (kgData) {
+        const before = kgData;
+        kgData = removeEdgeOptimistic(kgData, from, to, rel); // vanish on click
+        kgSig = kgSignature(kgData);
+        kgHandle?.update(kgData);
+        renderKgSide(kgSelId);
+        const r = await bridge.personalUnrelate(from, to, rel).catch(() => null);
+        if (!r?.ok) { // server refused → roll back
+          kgData = before; kgSig = kgSignature(kgData); kgHandle?.update(kgData); renderKgSide(kgSelId);
+          showToast({ tone: "danger", title: "Couldn't remove that", desc: r?.error ?? "Try again.", actions: [{ label: "OK" }], timeout: 4000 });
+        }
+      }
+      return;
+    }
     const forget = t.closest("[data-forget]") as HTMLElement | null;
     if (forget) {
       const fid = forget.dataset.forget!;

--- a/desktop/renderer/bridge.ts
+++ b/desktop/renderer/bridge.ts
@@ -330,6 +330,7 @@ export interface LucidBridge {
   personalForget(factId: string): Promise<{ ok: boolean } | null>;
   // P-KG-REL.1 (ADR-0075): user-authored relationship between two existing, visible nodes.
   personalRelate(from: string, to: string, relation?: string): Promise<{ ok: boolean; error?: string; id?: string } | null>;
+  personalUnrelate(from: string, to: string, relation?: string): Promise<{ ok: boolean; error?: string; removed?: number } | null>; // P-KG-REL.3
   // P9.7: import a ChatGPT / Claude / Gemini data export (folder, .json, or .zip) into the active
   // compartment, through the fail-closed gate. `model` runs the richer LLM extractor (capped).
   // P-KG-INGEST.1: starts a BACKGROUND import job (returns a jobId); poll status + cancel below.
@@ -527,6 +528,7 @@ export const bridge: LucidBridge = {
   personalGraph: (scope) => getData(`/api/personal/graph${scope ? `?scope=${encodeURIComponent(scope)}` : ""}`),
   personalForget: (factId) => post("/api/personal/forget", { factId }),
   personalRelate: (from, to, relation) => post("/api/personal/relate", { from, to, relation }),
+  personalUnrelate: (from, to, relation) => post("/api/personal/unrelate", { from, to, relation }),
   personalImport: (path, model) => post("/api/personal/import", { path, model: !!model }),
   personalImportStatus: (jobId) => getData(`/api/personal/import/status${jobId ? `?jobId=${encodeURIComponent(jobId)}` : ""}`),
   personalImportCancel: (jobId) => post("/api/personal/import/cancel", { jobId }),

--- a/desktop/renderer/kg_ops.test.ts
+++ b/desktop/renderer/kg_ops.test.ts
@@ -3,7 +3,26 @@
 
 import { describe, expect, test } from "bun:test";
 import type { PersonalGraphData } from "./bridge.ts";
-import { addEdgeOptimistic, applyForget, chainPairs, fitTransform, frameWork, nodeAtPoint, resolveRelationLabel, togglePick } from "./kg_ops.ts";
+import { addEdgeOptimistic, applyForget, chainPairs, fitTransform, frameWork, nodeAtPoint, removeEdgeOptimistic, resolveRelationLabel, togglePick } from "./kg_ops.ts";
+
+describe("#130 removeEdgeOptimistic (P-KG-REL.3)", () => {
+  const data = (): PersonalGraphData => ({
+    nodes: [],
+    edges: [{ from: "a", to: "b", relation: "related" }, { from: "a", to: "b", relation: "deploys with" }],
+    facts: [],
+  });
+  test("removes the exact from+to+relation triple, never mutating the input", () => {
+    const d = data();
+    const out = removeEdgeOptimistic(d, "a", "b", "related");
+    expect(out.edges).toEqual([{ from: "a", to: "b", relation: "deploys with" }]); // only the matching one
+    expect(d.edges).toHaveLength(2); // input untouched → caller can roll back
+  });
+  test("a non-matching removal is a no-op (same ref back)", () => {
+    const d = data();
+    expect(removeEdgeOptimistic(d, "a", "b", "nope")).toBe(d);
+    expect(removeEdgeOptimistic(d, "x", "y", "related")).toBe(d);
+  });
+});
 
 describe("#122 resolveRelationLabel (P-KG-REL.2)", () => {
   test("uses a typed label, defaults to 'related' when blank", () => {

--- a/desktop/renderer/kg_ops.ts
+++ b/desktop/renderer/kg_ops.ts
@@ -123,3 +123,10 @@ export function addEdgeOptimistic(data: PersonalGraphData, from: string, to: str
   if (data.edges.some((e) => e.from === from && e.to === to && e.relation === relation)) return data;
   return { ...data, edges: [...data.edges, { from, to, relation }] };
 }
+
+/** Optimistically remove an edge (P-KG-REL.3) without mutating the input — so it vanishes on click and the
+ *  caller can roll back on server failure. Matches the exact from+to+relation triple. */
+export function removeEdgeOptimistic(data: PersonalGraphData, from: string, to: string, relation: string): PersonalGraphData {
+  const edges = data.edges.filter((e) => !(e.from === from && e.to === to && e.relation === relation));
+  return edges.length === data.edges.length ? data : { ...data, edges };
+}

--- a/desktop/renderer/styles.css
+++ b/desktop/renderer/styles.css
@@ -1394,6 +1394,17 @@ body.resizing .sidebar,body.resizing .inspector{transition:none}
 .kg-fact-meta{display:flex;align-items:center;gap:8px;margin-top:7px;font-size:10.5px;color:var(--txt-4)}
 .kg-forget{-webkit-app-region:no-drag;margin-left:auto;border:1px solid var(--line);background:var(--bg-3);color:var(--txt-3);border-radius:6px;padding:2px 7px;font-size:10px;cursor:pointer;display:inline-flex;align-items:center;gap:3px;transition:border-color var(--t),color var(--t),background var(--t)}
 .kg-forget:hover{border-color:var(--red);color:#ff9b9b;background:var(--red-dim)}
+/* P-KG-REL.3: per-node relationships list with remove buttons */
+.kg-side-sub{font-size:10.5px;letter-spacing:1.1px;text-transform:uppercase;color:var(--txt-3);margin:14px 0 7px}
+.kg-side-rels{display:flex;flex-direction:column;gap:5px}
+.kg-rel{display:flex;align-items:center;gap:8px;padding:6px 9px;border:1px solid var(--line-soft);border-radius:8px;background:var(--bg-2)}
+.kg-rel-text{flex:1;min-width:0;font-size:11.5px;color:var(--txt-2);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.kg-rel-text b{color:var(--txt)}
+.kg-rel-arrow{color:var(--accent);font-weight:700}
+.kg-rel-label{color:var(--txt-3);font-style:italic}
+.kg-unrelate{-webkit-app-region:no-drag;display:grid;place-items:center;width:22px;height:22px;border:0;border-radius:6px;background:transparent;color:var(--txt-3);cursor:pointer;opacity:.65;transition:opacity var(--t),color var(--t),background var(--t)}
+.kg-rel:hover .kg-unrelate{opacity:1}
+.kg-unrelate:hover{color:var(--red);background:var(--red-dim)}
 .set-sec{margin-bottom:9px;animation:setSecIn var(--t-slow) var(--ease-out) both}
 @keyframes setSecIn{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:none}}
 .set-lbl{font-size:11px;letter-spacing:1.3px;text-transform:uppercase;color:var(--txt-3);margin-bottom:7px;display:flex;align-items:center;gap:8px}

--- a/desktop/scripts/demo_p_kg_rel_3.ts
+++ b/desktop/scripts/demo_p_kg_rel_3.ts
@@ -1,0 +1,52 @@
+// desktop/scripts/demo_p_kg_rel_3.ts
+//
+// Increment P-KG-REL.3 — remove a relationship (issue/ADR-0082). You could CREATE edges (P-KG-REL.1/.2) but
+// never delete one. The node panel now lists a node's relationships with a remove (×) button. Two proofs:
+//   A. removeEdgeOptimistic: the edge vanishes from the live graph instantly, input untouched (rollback-safe).
+//   B. store.removeLink: the removal persists through the encrypted store; only the targeted edge goes.
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PersonalStore } from "../../harness/personal/store.ts";
+import { randomKey } from "../../harness/personal/crypto.ts";
+import type { PersonalGraphData } from "../renderer/bridge.ts";
+import { removeEdgeOptimistic } from "../renderer/kg_ops.ts";
+
+const fail = (msg: string): never => { console.error(`FAIL: ${msg}`); process.exit(1); };
+const ok = (msg: string): void => console.log(`   ${msg} ✓`);
+
+console.log("== [1/2] #ADR-0082 optimistic edge removal (instant + rollback-safe) ==");
+const data: PersonalGraphData = { nodes: [], facts: [], edges: [
+  { from: "a", to: "b", relation: "related" }, { from: "a", to: "b", relation: "deploys with" },
+] };
+const after = removeEdgeOptimistic(data, "a", "b", "related");
+if (after.edges.length !== 1 || after.edges[0]!.relation !== "deploys with") fail("only the matching edge should be removed");
+if (data.edges.length !== 2) fail("input must not be mutated (rollback-safe)");
+if (removeEdgeOptimistic(data, "a", "b", "nope") !== data) fail("a non-matching removal must be a no-op");
+ok('removed exactly a→b "related"; the other edge + the input array are untouched');
+
+console.log("== [2/2] #ADR-0082 removal persists through the encrypted store ==");
+const dir = mkdtempSync(join(tmpdir(), "demo-pkgrel3-"));
+try {
+  const path = join(dir, "p.enc");
+  const s = PersonalStore.createWithPassphrase(path, "correct horse battery staple");
+  const a = s.upsertEntity("Rust", "user:preference", "trusted");
+  const b = s.upsertEntity("Kubernetes", "user:skill", "trusted");
+  s.addFact({ entityId: a, statement: "likes Rust", trustLabel: "trusted" });
+  s.addFact({ entityId: b, statement: "uses Kubernetes", trustLabel: "trusted" });
+  s.addLink(a, b, "related");
+  s.addLink(a, b, "deploys with");
+  const removed = s.removeLink(a, b, "related"); // exactly what unrelateEntities does
+  if (removed !== 1) fail(`expected to remove 1 link, removed ${removed}`);
+  s.save();
+
+  const links = PersonalStore.openWithPassphrase(path, "correct horse battery staple").graph().links;
+  if (links.length !== 1 || links[0]!.relation !== "deploys with") fail("the wrong link survived (or removal didn't persist)");
+  ok('removeLink deleted a→b "related" and persisted; a→b "deploys with" survived');
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+console.log("demo-P-KG-REL.3 OK");
+process.exit(0);

--- a/harness/personal/store.ts
+++ b/harness/personal/store.ts
@@ -161,6 +161,14 @@ export class PersonalStore {
     this.#graph.links.push({ id, from_entity_id: fromEntityId, to_entity_id: toEntityId, relation, created_at: now() });
     return id;
   }
+  /** Remove user-authored link(s) between two entities (P-KG-REL.3). With `relation`, only that exact
+   *  relation; otherwise every link between the pair (in that direction). Returns how many were removed. */
+  removeLink(fromEntityId: string, toEntityId: string, relation?: string): number {
+    const before = this.#graph.links.length;
+    this.#graph.links = this.#graph.links.filter((l) =>
+      !(l.from_entity_id === fromEntityId && l.to_entity_id === toEntityId && (relation === undefined || l.relation === relation)));
+    return before - this.#graph.links.length;
+  }
   /** Record an audited export (P9.4). Appends to the encrypted, in-store trail and
    *  returns the event id. The caller persists with save(). Metadata only. */
   recordExport(ev: Omit<PersonalExportEvent, "id" | "at">): string {


### PR DESCRIPTION
ADR-0082. Completes manual relationship authoring — create (REL.1), label (REL.2), **remove**. You could add an edge by mistake and be stuck with it; now each relationship has a remove button.

- `store.removeLink(from, to, relation?)` (data layer) + `unrelateEntities` (mirrors `relateEntities`) + `POST /api/personal/unrelate` + `bridge.personalUnrelate`.
- The node detail panel gains a **Relationships** section: each edge touching the node (direction arrow + label) with a remove (×). Click → optimistic removal (`removeEdgeOptimistic`, rollback-safe) → server reconcile. Symmetric with the forget-fact flow.
- Authored edges stay first-party (no scanner, no promotion); nodes/facts untouched; scope-confined.

Tests: `kg_ops.test.ts` removeEdgeOptimistic + `make demo-P-KG-REL.3` (optimistic + `store.removeLink` persists only the targeted edge). harness 545 ✓ · desktop 492 ✓ · renderer bundle ✓ · tsc clean. Closes #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)