### PR TITLE
chore(license): enforce BUSL-1.1 headers in CI + auto-apply via pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# Auto-apply the BUSL-1.1 SPDX header to staged first-party source before each commit.
+# Installed by `make install-hooks` (points core.hooksPath at .githooks/).
+#
+# Only files the header tool actually rewrites get re-staged, so a partial `git add -p`
+# of an already-headered file is left exactly as you staged it. The tool itself filters by
+# extension and skips vendored/generated trees, so passing every staged path is safe.
+#
+# Fail-closed: if bun or the tool errors, the commit aborts rather than slipping a header past.
+set -eu
+
+staged=$(git diff --cached --name-only --diff-filter=ACMR)
+[ -n "$staged" ] || exit 0
+
+# shellcheck disable=SC2086
+modified=$(bun run tools/license_headers.ts --list-modified $staged | sed -n 's/^MODIFIED\t//p')
+
+[ -n "$modified" ] || exit 0
+
+echo "license: added the BUSL-1.1 header to newly-staged source:"
+echo "$modified" | sed 's/^/  /'
+echo "$modified" | while IFS= read -r f; do
+  [ -n "$f" ] && git add "$f"
+done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,12 @@ jobs:
       - name: Typecheck (root)
         run: bun x tsc --noEmit
 
+      # Every first-party source file must carry the BUSL-1.1 SPDX header. The pre-commit hook
+      # (make install-hooks) applies these automatically; this is the backstop for anything that
+      # slipped through (e.g. a commit made without the hook installed).
+      - name: License headers (BUSL-1.1)
+        run: bun run tools/license_headers.ts --check
+
       - name: Harness test suite
         run: bun test harness
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,12 @@ PY         := $(UV) run --project $(SIDECAR_DIR) python
 # ---------------------------------------------------------------------------
 
 .PHONY: install
-install: install-harness install-sidecar ## Install harness + sidecar deps
+install: install-harness install-sidecar install-hooks ## Install harness + sidecar deps + git hooks
+
+.PHONY: install-hooks
+install-hooks: ## Point git at .githooks/ so the pre-commit license-header hook runs
+	git config core.hooksPath .githooks
+	@echo "✓ core.hooksPath -> .githooks (pre-commit applies BUSL-1.1 headers to staged source)"
 
 .PHONY: install-harness
 install-harness: ## Install Bun/TypeScript harness deps

--- a/tools/license_headers.ts
+++ b/tools/license_headers.ts
@@ -3,13 +3,16 @@
 
 // tools/license_headers.ts — apply the BUSL-1.1 SPDX header to FIRST-PARTY source files (idempotent).
 //
-//   bun run tools/license_headers.ts          # add missing headers
-//   bun run tools/license_headers.ts --check   # exit 1 if any file is missing one (CI guard)
+//   bun run tools/license_headers.ts                 # add missing headers across all roots
+//   bun run tools/license_headers.ts --check          # exit 1 if any file is missing one (CI guard)
+//   bun run tools/license_headers.ts <file> [<file>…] # operate ONLY on the given files (used by the
+//                                                       # pre-commit hook to header just-staged source)
 //
 // Excludes vendored / third-party / generated trees (vendor/, node_modules/, desktop/release/, .venv,
-// __pycache__, dist/) — those keep their OWN licenses and must NOT be relicensed.
+// __pycache__, dist/) — those keep their OWN licenses and must NOT be relicensed. Explicitly-named files
+// are still filtered by the same comment-style + exclusion rules, so passing a vendored path is a no-op.
 
-import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 const COPYRIGHT = "Copyright (c) 2026 TechLead 187 LLC";
@@ -39,16 +42,39 @@ function commentStyle(path: string): "hash" | "slash" | null {
   return null;
 }
 
-const check = process.argv.includes("--check");
+// True when a path lives under an excluded tree — applies to both the walk and explicit file args,
+// so handing the hook a vendored/generated path is a safe no-op.
+function excluded(path: string): boolean {
+  const p = path.replace(/\\/g, "/");
+  if (EXCLUDE_PREFIXES.some((pre) => p.startsWith(pre))) return true;
+  return p.split("/").some((seg) => EXCLUDE_SEGMENTS.has(seg));
+}
+
+const args = process.argv.slice(2);
+const check = args.includes("--check");
+const explicit = args.filter((a) => !a.startsWith("--")); // bare paths → operate only on these
+const listModified = args.includes("--list-modified"); // print each rewritten path (pre-commit hook reads this)
 let added = 0;
 const missing: string[] = [];
+const modified: string[] = [];
 
-for (const root of ROOTS) {
-  let files: string[];
-  try { files = [...walk(root)]; } catch { continue; } // a root may not exist in every checkout
-  for (const path of files) {
+// Either an explicit file list (pre-commit hook) or a full walk of the first-party roots.
+function* candidates(): Generator<string> {
+  if (explicit.length) {
+    for (const f of explicit) yield f.replace(/\\/g, "/");
+    return;
+  }
+  for (const root of ROOTS) {
+    try { yield* walk(root); } catch { /* a root may not exist in every checkout */ }
+  }
+}
+
+{
+  for (const path of candidates()) {
+    if (excluded(path)) continue;
     const style = commentStyle(path);
     if (!style) continue;
+    if (!existsSync(path)) continue; // explicit arg may be a staged deletion/rename — nothing to header
     const src = readFileSync(path, "utf8");
     if (src.includes(SPDX)) continue; // already headered — idempotent
     if (check) { missing.push(path); continue; }
@@ -64,9 +90,12 @@ for (const root of ROOTS) {
       out = header + "\n" + src;
     }
     writeFileSync(path, out);
+    modified.push(path);
     added++;
   }
 }
+
+if (listModified) for (const p of modified) console.log(`MODIFIED\t${p}`);
 
 if (check) {
   if (missing.length) { console.error(`Missing BUSL-1.1 header in ${missing.length} file(s):\n  ${missing.slice(0, 40).join("\n  ")}`); process.exit(1); }

--- a/tools/license_headers.ts
+++ b/tools/license_headers.ts
@@ -12,7 +12,7 @@
 // __pycache__, dist/) — those keep their OWN licenses and must NOT be relicensed. Explicitly-named files
 // are still filtered by the same comment-style + exclusion rules, so passing a vendored path is a no-op.
 
-import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 const COPYRIGHT = "Copyright (c) 2026 TechLead 187 LLC";
@@ -74,8 +74,10 @@ function* candidates(): Generator<string> {
     if (excluded(path)) continue;
     const style = commentStyle(path);
     if (!style) continue;
-    if (!existsSync(path)) continue; // explicit arg may be a staged deletion/rename — nothing to header
-    const src = readFileSync(path, "utf8");
+    // Read directly (no existsSync pre-check — that's a TOCTOU race). An explicit arg may be a
+    // staged deletion/rename, so a missing file is simply skipped.
+    let src: string;
+    try { src = readFileSync(path, "utf8"); } catch { continue; }
     if (src.includes(SPDX)) continue; // already headered — idempotent
     if (check) { missing.push(path); continue; }
     const c = style === "hash" ? "#" : "//";


### PR DESCRIPTION
Makes the BUSL-1.1 licensing self-enforcing so future commits and source files always carry the header.

## What
- **CI** (`.github/workflows/ci.yml`): new `License headers (BUSL-1.1)` step in the harness job runs `tools/license_headers.ts --check`. Any first-party source file missing the SPDX header fails the build. This is the backstop for commits made without the hook installed.
- **Pre-commit hook** (`.githooks/pre-commit`): auto-applies the header to newly-staged source and re-stages **only** the files it actually rewrites — a partial `git add -p` of an already-headered file is left untouched. Fail-closed: if `bun` or the tool errors, the commit aborts. Installed via `make install-hooks` (sets `core.hooksPath`), which is now wired into `make install`.
- **`tools/license_headers.ts`**: now accepts an explicit file list (used by the hook) plus a `--list-modified` machine-readable mode; the vendored/generated exclusion rules apply to explicit paths too, so handing it a `vendor/`/`node_modules/` path is a safe no-op.

## Verification
- `bun run tools/license_headers.ts --check` → all first-party source carries the header ✓
- Hook tested on a throwaway unheadered `.ts`: header landed in the staged blob; cleaned up.
- No-op confirmed for: nothing-staged, non-source staged (Makefile), and an already-headered staged file.
- Root typecheck clean.

The new CI step validates itself on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)