### PR TITLE
macOS enterprise packaging: .pkg + Homebrew cask + MDM runbook

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -88,10 +88,6 @@ jobs:
           # unsigned, so it must resolve to empty — don't let it inherit the Windows cert.
           CSC_LINK: ${{ runner.os == 'macOS' && secrets.MAC_CSC_LINK || runner.os == 'Windows' && secrets.WIN_CSC_LINK || '' }}
           CSC_KEY_PASSWORD: ${{ runner.os == 'macOS' && secrets.MAC_CSC_KEY_PASSWORD || runner.os == 'Windows' && secrets.WIN_CSC_KEY_PASSWORD || '' }}
-          # PKG installer signing needs a SEPARATE "Developer ID Installer" cert
-          # (distinct from the "Developer ID Application" cert in MAC_CSC_LINK).
-          CSC_INSTALLER_LINK: ${{ runner.os == 'macOS' && secrets.MAC_INSTALLER_CSC_LINK || '' }}
-          CSC_INSTALLER_KEY_PASSWORD: ${{ runner.os == 'macOS' && secrets.MAC_INSTALLER_CSC_KEY_PASSWORD || '' }}
           # Only hunt the keychain for a mac identity when a mac cert is provided.
           CSC_IDENTITY_AUTO_DISCOVERY: ${{ runner.os == 'macOS' && secrets.MAC_CSC_LINK != '' }}
           # macOS notarization (electron-builder runs notarytool when these are set).

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -88,6 +88,10 @@ jobs:
           # unsigned, so it must resolve to empty — don't let it inherit the Windows cert.
           CSC_LINK: ${{ runner.os == 'macOS' && secrets.MAC_CSC_LINK || runner.os == 'Windows' && secrets.WIN_CSC_LINK || '' }}
           CSC_KEY_PASSWORD: ${{ runner.os == 'macOS' && secrets.MAC_CSC_KEY_PASSWORD || runner.os == 'Windows' && secrets.WIN_CSC_KEY_PASSWORD || '' }}
+          # PKG installer signing needs a SEPARATE "Developer ID Installer" cert
+          # (distinct from the "Developer ID Application" cert in MAC_CSC_LINK).
+          CSC_INSTALLER_LINK: ${{ runner.os == 'macOS' && secrets.MAC_INSTALLER_CSC_LINK || '' }}
+          CSC_INSTALLER_KEY_PASSWORD: ${{ runner.os == 'macOS' && secrets.MAC_INSTALLER_CSC_KEY_PASSWORD || '' }}
           # Only hunt the keychain for a mac identity when a mac cert is provided.
           CSC_IDENTITY_AUTO_DISCOVERY: ${{ runner.os == 'macOS' && secrets.MAC_CSC_LINK != '' }}
           # macOS notarization (electron-builder runs notarytool when these are set).
@@ -105,6 +109,7 @@ jobs:
           path: |
             desktop/release/*.dmg
             desktop/release/*.zip
+            desktop/release/*.pkg
             desktop/release/*Setup*.exe
             desktop/release/*portable*.exe
             desktop/release/*.AppImage
@@ -120,6 +125,7 @@ jobs:
           files: |
             desktop/release/*.dmg
             desktop/release/*.zip
+            desktop/release/*.pkg
             desktop/release/*Setup*.exe
             desktop/release/*portable*.exe
             desktop/release/*.AppImage
@@ -178,5 +184,6 @@ jobs:
             dist/*portable*.exe
             dist/*.AppImage
             dist/*.zip
+            dist/*.pkg
             dist/*.blockmap
             dist/latest*.yml

--- a/Casks/lucidagentide.rb
+++ b/Casks/lucidagentide.rb
@@ -1,14 +1,10 @@
 cask "lucidagentide" do
+  arch arm: "arm64", intel: "x64"
+
   version :latest
   sha256 :no_check
 
-  on_arm do
-    url "https://github.com/mlcyclops/lucidagentide/releases/download/latest/LucidAgentIDE-mac-arm64.zip"
-  end
-  on_intel do
-    url "https://github.com/mlcyclops/lucidagentide/releases/download/latest/LucidAgentIDE-mac-x64.zip"
-  end
-
+  url "https://github.com/mlcyclops/lucidagentide/releases/download/latest/LucidAgentIDE-mac-#{arch}.pkg"
   name "LucidAgentIDE"
   desc "Fail-closed security, provenance, and memory layer around oh-my-pi (omp)"
   homepage "https://github.com/mlcyclops/lucidagentide"
@@ -22,7 +18,14 @@ cask "lucidagentide" do
 
   depends_on macos: :big_sur
 
-  app "LucidAgentIDE.app"
+  # The .pkg installs LucidAgentIDE.app into /Applications (isRelocatable=false,
+  # overwriteAction=upgrade), so `brew upgrade` replaces the app atomically in
+  # place. User data under ~/Library is never touched on upgrade — only `zap`
+  # (i.e. `brew uninstall --zap`) removes it.
+  pkg "LucidAgentIDE-mac-#{arch}.pkg"
+
+  uninstall quit:    "com.lucidagentide.desktop",
+            pkgutil: "com.lucidagentide.desktop"
 
   zap trash: [
     "~/Library/Application Support/LucidAgentIDE",
@@ -34,15 +37,14 @@ cask "lucidagentide" do
   ]
 
   caveats <<~EOS
-    LucidAgentIDE is currently distributed UNSIGNED and is NOT notarized, so
-    macOS Gatekeeper will block it after install. (Homebrew 6 removed the
-    `--no-quarantine` install flag, so clear the quarantine attribute yourself
-    once, after installing:)
+    LucidAgentIDE ships as a signed + notarized .pkg once the project's Apple
+    signing secrets are configured. If you install an interim UNSIGNED build,
+    macOS Gatekeeper blocks it — install once from Terminal:
 
-      xattr -dr com.apple.quarantine "/Applications/LucidAgentIDE.app"
+      sudo installer -pkg "$(brew --cache --cask lucidagentide)" -target /
 
-    Then open it normally. The app keeps itself current afterwards
-    (electron-updater pulls from the GitHub "latest" release), so `brew upgrade`
-    is rarely needed.
+    The app keeps itself current afterwards via electron-updater. For managed
+    fleet deployment (Jamf / Munki / Intune), do NOT use this cask — see
+    docs/MACOS-ENTERPRISE-DEPLOYMENT.md and push the .pkg through your MDM.
   EOS
 end

--- a/Casks/lucidagentide.rb
+++ b/Casks/lucidagentide.rb
@@ -18,12 +18,26 @@ cask "lucidagentide" do
 
   depends_on macos: :big_sur
 
-  # The .pkg installs LucidAgentIDE.app into /Applications (isRelocatable=false,
-  # overwriteAction=upgrade), so `brew upgrade` replaces the app atomically in
-  # place. User data under ~/Library is never touched on upgrade — only `zap`
-  # (i.e. `brew uninstall --zap`) removes it.
-  pkg "LucidAgentIDE-mac-#{arch}.pkg"
+  # The build is NOT notarized (that needs a paid Apple Developer account). The
+  # app IS ad-hoc-signed by electron-builder, so it runs on Apple Silicon, and
+  # `installer(8)` (which Homebrew uses for a pkg cask) places it in /Applications
+  # WITHOUT the quarantine flag — so it launches with no Gatekeeper prompt.
+  # `allow_untrusted` lets installer accept the unsigned package; it's permitted
+  # in third-party taps like this one (just not in homebrew/cask).
+  pkg "LucidAgentIDE-mac-#{arch}.pkg", allow_untrusted: true
 
+  # Belt-and-suspenders: strip quarantine if anything set it, so the very first
+  # launch never trips Gatekeeper.
+  postflight do
+    system_command "/usr/bin/xattr",
+                   args: ["-dr", "com.apple.quarantine", "/Applications/LucidAgentIDE.app"],
+                   sudo: true
+  end
+
+  # `overwriteAction=upgrade` + `isRelocatable=false` (see desktop/package.json)
+  # mean `brew upgrade` replaces the app atomically in /Applications. User data
+  # under ~/Library is never touched on upgrade — only `zap` (i.e.
+  # `brew uninstall --zap`) removes it.
   uninstall quit:    "com.lucidagentide.desktop",
             pkgutil: "com.lucidagentide.desktop"
 
@@ -35,16 +49,4 @@ cask "lucidagentide" do
     "~/Library/Preferences/com.lucidagentide.desktop.plist",
     "~/Library/Saved Application State/com.lucidagentide.desktop.savedState",
   ]
-
-  caveats <<~EOS
-    LucidAgentIDE ships as a signed + notarized .pkg once the project's Apple
-    signing secrets are configured. If you install an interim UNSIGNED build,
-    macOS Gatekeeper blocks it — install once from Terminal:
-
-      sudo installer -pkg "$(brew --cache --cask lucidagentide)" -target /
-
-    The app keeps itself current afterwards via electron-updater. For managed
-    fleet deployment (Jamf / Munki / Intune), do NOT use this cask — see
-    docs/MACOS-ENTERPRISE-DEPLOYMENT.md and push the .pkg through your MDM.
-  EOS
 end

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -77,12 +77,22 @@
         {
           "target": "zip",
           "arch": ["arm64", "x64"]
+        },
+        {
+          "target": "pkg",
+          "arch": ["arm64", "x64"]
         }
       ],
       "hardenedRuntime": true,
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist",
       "gatekeeperAssess": false
+    },
+    "pkg": {
+      "isRelocatable": false,
+      "installLocation": "/Applications",
+      "mustClose": ["com.lucidagentide.desktop"],
+      "overwriteAction": "upgrade"
     },
     "win": {
       "icon": "build/icon.ico",

--- a/docs/MACOS-ENTERPRISE-DEPLOYMENT.md
+++ b/docs/MACOS-ENTERPRISE-DEPLOYMENT.md
@@ -1,0 +1,171 @@
+# macOS deployment runbook (Homebrew + Jamf / Munki / Intune)
+
+How to install **LucidAgentIDE** on macOS from the `.pkg`: the Homebrew cask for
+single users, and Jamf / Munki / Intune for a managed fleet.
+
+> **Part of PI-4 / ADR-A009.** The `.pkg` is built by
+> [`build-desktop.yml`](../.github/workflows/build-desktop.yml). Managed-config
+> enforcement is the #74 channel; air-gap distribution is #73.
+
+## Signing reality (no Apple Developer account)
+
+This project does **not** notarize — notarization requires a paid Apple Developer
+account. It doesn't need one for these install paths:
+
+- The app is **ad-hoc-signed** by electron-builder (free), which is all Apple
+  Silicon requires to *execute* native arm64 code.
+- A `.pkg` installed by **`installer(8)`** — what Homebrew's pkg cask and every
+  MDM use — lands the app in `/Applications` **without the quarantine flag**, so
+  there is **no Gatekeeper prompt**. (Double-clicking the `.pkg` in Finder *would*
+  prompt; install via brew or your MDM instead.)
+
+If you ever do enroll, add the Apple signing secrets in
+[`desktop/SIGNING.md`](../desktop/SIGNING.md) and the same build notarizes
+automatically — nothing else changes.
+
+## Package facts
+
+| Property | Value |
+| --- | --- |
+| Artifact | `LucidAgentIDE-mac-arm64.pkg`, `LucidAgentIDE-mac-x64.pkg` |
+| Install location | `/Applications/LucidAgentIDE.app` (fixed; `isRelocatable=false`) |
+| Bundle / package id | `com.lucidagentide.desktop` |
+| Signature | ad-hoc (unsigned for Gatekeeper) |
+| Upgrade behavior | `overwriteAction=upgrade` — atomic in-place replace; `mustClose` quits a running copy first |
+| User data | `~/Library/Application Support/LucidAgentIDE` — **never touched** on install/upgrade |
+| Min OS | macOS 11 (Big Sur) |
+
+Apple Silicon and Intel are **separate** packages — scope each to the matching
+architecture.
+
+## 1. Homebrew (single user)
+
+```bash
+brew tap mlcyclops/lucid https://github.com/mlcyclops/lucidagentide
+brew install --cask lucidagentide   # installs the .pkg, no Gatekeeper prompt
+brew upgrade --cask lucidagentide   # in-place upgrade, keeps user data
+brew uninstall --cask lucidagentide          # remove app, keep user data
+brew uninstall --zap --cask lucidagentide    # remove app AND user data
+```
+
+The cask uses `allow_untrusted` (legal in a third-party tap) so `installer`
+accepts the unsigned pkg, and strips any quarantine flag in a `postflight`.
+
+## 2. Verify the package before fleet deployment
+
+```bash
+PKG=LucidAgentIDE-mac-arm64.pkg
+pkgutil --check-signature "$PKG"      # expect: no signing certificate (ad-hoc) — that's intended
+pkgutil --payload-files "$PKG" | head # sanity: the .app payload is present
+sudo installer -pkg "$PKG" -target /  # installs (installer(8) bypasses Gatekeeper)
+spctl --assess -vv /Applications/LucidAgentIDE.app 2>&1 || true   # "rejected" is expected for unsigned; it still launches because it's not quarantined
+codesign -dv /Applications/LucidAgentIDE.app 2>&1 | grep -i 'Signature=adhoc'  # confirms it'll run on Apple Silicon
+```
+
+MDM-deployed and `installer(8)`-deployed packages are not quarantined, so the
+unsigned app launches without a prompt — the same reason the Homebrew path works.
+
+## 3. Disable the in-app updater (let MDM own the version)
+
+In managed fleets IT owns the version, so turn off electron-updater and push new
+`.pkg`s through the MDM. Drop this admin-only file at the canonical path (see
+[`desktop/managed_config.ts`](../desktop/managed_config.ts)):
+
+`/Library/Application Support/LucidAgentIDE/managed-config.json`
+
+```json
+{
+  "orgName": "Acme Corp",
+  "updateChannel": "managed"
+}
+```
+
+`updateChannel: "managed"` disables the in-app update check. (Use `"feed"` +
+`updateFeedUrl` to point at a customer-hosted mirror instead.) The file MUST be
+root-owned and **not** group/world-writable or the app ignores it (tamper guard):
+
+```bash
+sudo install -d -m 755 "/Library/Application Support/LucidAgentIDE"
+sudo install -m 644 managed-config.json "/Library/Application Support/LucidAgentIDE/managed-config.json"
+```
+
+It only ever *adds* constraints — it can never relax the security gate.
+
+## 4. Jamf Pro
+
+1. **Upload** both `.pkg`s to your distribution point (Jamf Cloud or on-prem).
+2. **Policy → Packages:** add the pkg, action **Install**. Jamf installs via
+   `installer`, so the unsigned pkg deploys with no Gatekeeper prompt.
+3. **Scope:** a smart group on `Architecture Type` so each Mac gets the right pkg.
+4. **Trigger:** Recurring Check-in (silent) and/or Self Service.
+5. **Managed config:** deploy `managed-config.json` as a second pkg, or via
+   **Files and Processes → Execute Command** (root, mode 644).
+6. **Upgrades:** upload the new pkg (same id), flush the policy log, re-run.
+   `overwriteAction=upgrade` replaces the app in place; user data survives. For
+   staged rollouts, scope on an *Application Version is less than* smart group.
+
+## 5. Munki
+
+```bash
+munkiimport LucidAgentIDE-mac-arm64.pkg \
+  --name LucidAgentIDE --displayname "LucidAgentIDE" --catalog testing
+```
+
+In the pkginfo:
+
+- `unattended_install: true` / `unattended_uninstall: true` for silent runs.
+- Keep the auto-detected `receipts` (id `com.lucidagentide.desktop`) so
+  `uninstall_method: removepackages` works.
+- `minimum_os_version: "11.0"`; optionally `force_install_after_date`.
+
+Ship `managed-config.json` as a tiny companion payload-pkg in the same manifest.
+
+## 6. Microsoft Intune (macOS)
+
+1. **Apps → macOS → Add → macOS app (PKG)** and upload the `.pkg`. Intune
+   normally wants a signed pkg; for an unsigned build, wrap the `.pkg` with the
+   **Intune App Wrapping Tool** (`IntuneAppUtil`) into a `.intunemac` and upload
+   that, or deploy it via a **shell script** running `installer -pkg`.
+2. Set **minimum OS = 11.0**.
+3. **Managed config:** a **shell script** (root, once) that writes
+   `/Library/Application Support/LucidAgentIDE/managed-config.json` (mode 644).
+4. **Upgrades:** replace the pkg with the new version; the in-place upgrade
+   preserves user data.
+
+## 7. Uninstall
+
+In-place upgrades preserve user data on purpose. A **full** uninstall removes both
+the app and the per-user data:
+
+```bash
+# 1. Quit + remove the app and forget the receipt
+osascript -e 'quit app "LucidAgentIDE"' 2>/dev/null || true
+sudo rm -rf /Applications/LucidAgentIDE.app
+sudo pkgutil --forget com.lucidagentide.desktop
+
+# 2. Remove user data (the cask `zap` equivalent) — per user, as that user
+rm -rf ~/Library/Application\ Support/LucidAgentIDE \
+       ~/Library/Caches/com.lucidagentide.desktop \
+       ~/Library/Caches/com.lucidagentide.desktop.ShipIt \
+       ~/Library/Logs/LucidAgentIDE \
+       ~/Library/Preferences/com.lucidagentide.desktop.plist \
+       ~/Library/Saved\ Application\ State/com.lucidagentide.desktop.savedState
+sudo rm -rf "/Library/Application Support/LucidAgentIDE"   # managed config
+```
+
+Skip step 2 to preserve user data across a reinstall.
+
+## 8. Air-gapped sites (#73)
+
+The pkg is self-contained (Bun + uv runtimes are bundled), so install needs no
+network. Mirror the `.pkg` to your internal distribution point. For internal
+updates, host the electron-updater feed internally and set `updateChannel: "feed"`
++ `updateFeedUrl`; otherwise keep `"managed"` and push each version via the MDM.
+
+## Validation checklist (issue #77 "done when")
+
+- [ ] `brew install --cask lucidagentide` installs and launches with no Gatekeeper prompt.
+- [ ] `brew upgrade --cask lucidagentide` upgrades **in place**; `~/Library/Application Support/LucidAgentIDE` is intact.
+- [ ] A fleet deploy (Jamf/Munki/Intune) of the `.pkg` installs silently and launches.
+- [ ] Installing a newer `.pkg` over the old one upgrades in place, preserving user data.
+- [ ] `brew uninstall --zap` (or the step-7 commands) removes the app **and** user data.


### PR DESCRIPTION
## What

macOS enterprise packaging for **issue TechLead187/lucidagentIDEaddon#77** (PI-4 / ADR-A009): a `.pkg` installer, the Homebrew cask switched onto it, and a Jamf/Munki/Intune deployment runbook.

## Changes

- **`build(desktop)`** — add a `pkg` mac target beside the existing `zip` (kept for the electron-updater feed). `isRelocatable=false` pins `/Applications`, `mustClose` quits the running copy on upgrade, `overwriteAction=upgrade` atomically replaces the app and leaves `~/Library` user data intact.
- **`ci(desktop)`** — attach `*.pkg` to the artifact upload, tagged-release, and rolling-`latest` jobs.
- **`feat(cask)`** — install from the `.pkg`. `pkgutil` uninstall removes the receipt; `zap` still owns user-data deletion; `on_arm`/`on_intel` collapsed into the `arch` stanza.
- **`docs`** — `docs/MACOS-ENTERPRISE-DEPLOYMENT.md` runbook.

## Signing decision (no Apple Developer account)

The owner does not have, and does not want, a paid Apple Developer account — so **notarization is out** (it has no free path). It isn't needed for these install paths:

- The app is **ad-hoc-signed** by electron-builder (free), which is all Apple Silicon requires to run native arm64 code.
- A `.pkg` installed by `installer(8)` — what the Homebrew pkg cask **and** every MDM use — lands the app in `/Applications` **without** the quarantine flag, so it launches with **no Gatekeeper prompt**. The cask adds `allow_untrusted: true` (legal in a third-party tap, not homebrew/cask) plus a `postflight` quarantine strip as belt-and-suspenders.

If an account is ever added, the existing Apple secrets in `desktop/SIGNING.md` make the same build notarize automatically — no other change.

## Verification

- `desktop/package.json` parses; mac targets = `zip,pkg`; `pkg.isRelocatable=false`, `overwriteAction=upgrade`.
- Workflow has `*.pkg` in all three globs; no dead installer-cert env.
- `ruby -c Casks/lucidagentide.rb` → Syntax OK.
- End-to-end install/upgrade/notarization validation needs a real Mac build run (CI must produce the `.pkg` asset on the `latest` release) and the #73/#74 foundations — the issue scopes that as the finish/validate step. Checklist is in the runbook.

Refs TechLead187/lucidagentIDEaddon#77
