### PR TITLE
feat(about): P-ABOUT.1 — About panel + dynamic app version (v1.8.7) (ADR-0087)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,3 +145,25 @@ as a stop-the-line event.
 - DuckDB uses the Node binding (less mature than DuckDB-Python). If a specific
   analytics task is blocked by it, that’s a localized future ADR — not a reason
   to revisit the harness language.
+
+-----
+
+## Licensing & commit hygiene
+
+Every first-party source file under `harness/`, `desktop/`, `tools/`, and
+`scanner-sidecar/` carries the BUSL-1.1 SPDX header (`Copyright (c) 2026 TechLead
+187 LLC` + `SPDX-License-Identifier: BUSL-1.1`; `#` for Python). This is enforced
+two ways and you must keep both working:
+
+- A **pre-commit hook** (`.githooks/pre-commit`) auto-applies the header to staged
+  source. Run **`make install-hooks` once per clone** to activate it — git cannot
+  self-install hooks on clone, so a fresh checkout (yours or a collaborator’s) has
+  NO hook until this runs. `make install` runs it for you.
+- **CI** runs `tools/license_headers.ts --check` as a backstop, so nothing
+  unheadered can land on master even if the hook was never installed.
+
+Vendored / generated trees (`vendor/`, `node_modules/`, `desktop/release/`,
+`.venv`, `__pycache__`, `dist/`) keep their own licenses and are NEVER
+relicensed. New first-party files get the header automatically (hook) or via
+`make license-headers`. When adding the header in code, read the file then write —
+never `existsSync`-then-read (CodeQL flags that pair as a TOCTOU race).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,3 +145,25 @@ as a stop-the-line event.
 - DuckDB uses the Node binding (less mature than DuckDB-Python). If a specific
   analytics task is blocked by it, that’s a localized future ADR — not a reason
   to revisit the harness language.
+
+-----
+
+## Licensing & commit hygiene
+
+Every first-party source file under `harness/`, `desktop/`, `tools/`, and
+`scanner-sidecar/` carries the BUSL-1.1 SPDX header (`Copyright (c) 2026 TechLead
+187 LLC` + `SPDX-License-Identifier: BUSL-1.1`; `#` for Python). This is enforced
+two ways and you must keep both working:
+
+- A **pre-commit hook** (`.githooks/pre-commit`) auto-applies the header to staged
+  source. Run **`make install-hooks` once per clone** to activate it — git cannot
+  self-install hooks on clone, so a fresh checkout (yours or a collaborator’s) has
+  NO hook until this runs. `make install` runs it for you.
+- **CI** runs `tools/license_headers.ts --check` as a backstop, so nothing
+  unheadered can land on master even if the hook was never installed.
+
+Vendored / generated trees (`vendor/`, `node_modules/`, `desktop/release/`,
+`.venv`, `__pycache__`, `dist/`) keep their own licenses and are NEVER
+relicensed. New first-party files get the header automatically (hook) or via
+`make license-headers`. When adding the header in code, read the file then write —
+never `existsSync`-then-read (CodeQL flags that pair as a TOCTOU race).

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -6667,3 +6667,49 @@ omp tree is untouched (extend-don't-fork, and its license is preserved).
 
 `LICENSE`, `tools/license_headers.ts`, `package.json`, `README.md`. BSL 1.1 text © MariaDB (used per its
 permission grant). Change License: Mozilla Public License 2.0.
+
+-----
+
+## ADR-0087 - About panel + a single-sourced, dynamic app version (launch baseline v1.8.7)
+
+**Date:** 2026-06-27
+**Status:** Accepted - BUILT.
+**Increment:** P-ABOUT.1.
+
+### Context
+
+Approaching launch, the product had no in-app "About": no place stating what LUCID Agent IDE is, who owns
+it (TechLead 187 LLC), the BUSL-1.1 license, or the version. The version also lived only in
+`desktop/package.json` (and was a pre-launch `0.1.0`); nothing surfaced it to the user, and any UI display
+would have been a hardcoded literal that drifts. Launch wants the version to jump to **v1.8.7**.
+
+### Decision
+
+- **Single-sourced version.** `desktop/version.ts` exports `APP_VERSION = "1.8.7"`; `desktop/package.json`
+  `"version"` MIRRORS it (electron `app.getVersion()` / electron-builder read package.json). `about.test.ts`
+  + `demo-P-ABOUT.1` assert the two are equal, so a bump in one is forced into the other. The renderer
+  imports `APP_VERSION` (bundled), so the About panel shows the live version — never a hardcoded duplicate.
+- **About panel.** A new animated rail glyph (`#railAbout`, a book + twinkling sparkle in the existing
+  24×24 / 1.6-stroke icon family) sits ABOVE Commands + Settings on the activity rail. It opens a polished
+  dark-mode modal (`desktop/renderer/about.ts`, a PURE string builder so it is demo/test-able without a
+  DOM): the LUCID · AGENT IDE wordmark hero, a one-paragraph product summary, and a TechLead 187 LLC card
+  with the emblem + the BUSL-1.1 terms (Change Date 2030-06-27 → MPL-2.0; "source-available, not OSI
+  open-source"). Closes on the X / Close button, a backdrop click, or Escape; single instance.
+
+### Consequences
+
+- One number to bump per release (`version.ts`), guarded against drift by a test.
+- `about.ts` is pure → the panel's content is unit-tested and demo-proven; `app.ts` only owns open/close.
+- The interpolated version is HTML-escaped at the boundary (defensive; the value is first-party).
+- Honors `prefers-reduced-motion` (all About animations disabled).
+
+### Invariants preserved
+
+Renderer-only + additive: no prompt prefix, no scanner, no trust-label, no schema change. New first-party
+files carry the BUSL-1.1 header (ADR-0086).
+
+### Relates to
+
+`desktop/version.ts`, `desktop/package.json`, `desktop/renderer/about.ts`, `desktop/renderer/app.ts`
+(`#railAbout` + `openAbout`), `desktop/renderer/styles.css` (`.about-*`), `desktop/about.test.ts`,
+`desktop/scripts/demo_p_about_1.ts`.

--- a/Makefile
+++ b/Makefile
@@ -267,6 +267,10 @@ demo-P-PERF.1: ## P-PERF.1 (#134/ADR-0084): instant cached session list + transc
 demo-P-KG-INGEST.4: ## P-KG-INGEST.4 (#136/ADR-0085): true ingest concurrency — dedicated util omp connection; fail-safe fallback; routing contract
 	$(BUN) run desktop/scripts/demo_p_kg_ingest_4.ts
 
+.PHONY: demo-P-ABOUT.1
+demo-P-ABOUT.1: ## P-ABOUT.1 (ADR-0087): About panel — single-sourced app version (v1.8.7), LUCID + TechLead 187 + BUSL-1.1 licensing, animated rail glyph
+	$(BUN) run desktop/scripts/demo_p_about_1.ts
+
 .PHONY: dashboards
 dashboards: ## Materialize dashboard CSVs from a DuckDB into observable/docs/data (DB=path)
 	$(BUN) run harness/scripts/materialize_dashboards.ts $(DB) observable/docs/data

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2441,3 +2441,9 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
 - **shipped:** dev-mode `turnDiag` instrumentation in `acp_backend.ts` - `prompt.resolved … stopReason=` (omp turn stop reason, now captured) + per-iteration `goal.iter <i> maker-turn: answer_chars=… thinking=…/…c tools=… blocks=… acted=…`. Pinpoints whether a Claude maker turn is thinking-only (answer_chars=0, tools=0, thinking_chars>0), tools-not-surfacing, or empty/early-ended. No behavior change; developerMode-gated; typecheck clean.
 - **stubbed:** the FIX awaits one Claude `/goal` run's data (manage maker thinking / feed thinking to the checker / fix event mapping or file an omp issue). The GPT "stall" is the by-design maker->checker pause (optional "Checking…" indicator is a separate follow-up).
 - **next:** run a Claude goal loop with Developer mode on, read the `[TURN_DIAG] goal.iter` lines, then ship the targeted fix.
+
+---
+**P-ABOUT.1 - About panel + single-sourced dynamic app version (ADR-0087)**
+- **shipped:** animated `#railAbout` rail glyph (book + twinkling sparkle, above Commands/Settings) opens a polished dark-mode About modal (`about.ts`, pure builder) — LUCID · AGENT IDE hero, product blurb, TechLead 187 LLC emblem + BUSL-1.1 terms (Change Date 2030-06-27 → MPL-2.0). Version single-sourced in `desktop/version.ts` (`APP_VERSION`), mirrored by `desktop/package.json`, drift-guarded by a test; launch baseline bumped to **v1.8.7**. Also: BUSL header + `make install-hooks`-per-clone note added to CLAUDE.md/AGENTS.md invariants. `make demo-P-ABOUT.1` green; `about.test.ts` 10/10; desktop typecheck + renderer bundle clean.
+- **stubbed:** none. (Optional future: surface the version in the titlebar/status bar too; add an "About" command-palette entry.)
+- **next:** live-verify the panel in the preview, then merge to master.

--- a/desktop/about.test.ts
+++ b/desktop/about.test.ts
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 TechLead 187 LLC
+// SPDX-License-Identifier: BUSL-1.1
+
+// desktop/about.test.ts — P-ABOUT.1 (ADR-0087): the About panel builders + the version single-source.
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { aboutHtml, lucidLogo, readmeMark, techLeadLogo } from "./renderer/about.ts";
+import { APP_VERSION } from "./version.ts";
+
+describe("version is single-sourced", () => {
+  test("APP_VERSION matches desktop/package.json (no drift)", () => {
+    const pkg = JSON.parse(readFileSync(join(import.meta.dir, "package.json"), "utf8")) as { version: string };
+    expect(pkg.version).toBe(APP_VERSION);
+  });
+
+  test("launch baseline is v1.8.7", () => {
+    expect(APP_VERSION).toBe("1.8.7");
+  });
+});
+
+describe("aboutHtml", () => {
+  const html = aboutHtml(APP_VERSION);
+
+  test("shows the dynamic version with a v prefix", () => {
+    expect(html).toContain(`v${APP_VERSION}`);
+    expect(html).toContain("v1.8.7");
+  });
+
+  test("carries the product + company identity", () => {
+    expect(html).toContain("LUCID");
+    expect(html).toContain("AGENT&nbsp;IDE");
+    expect(html).toContain("TechLead&nbsp;187&nbsp;LLC");
+  });
+
+  test("states the BUSL-1.1 license, the change date, and that it is not OSI open-source", () => {
+    expect(html).toContain("Business Source License 1.1");
+    expect(html).toContain("2030-06-27 → MPL-2.0");
+    expect(html).toContain("source-available, not OSI open-source");
+  });
+
+  test("is a labelled, modal dialog with closable controls", () => {
+    expect(html).toContain('role="dialog"');
+    expect(html).toContain('aria-modal="true"');
+    expect(html).toContain("data-about-close");
+  });
+
+  test("escapes the interpolated version (no raw injection)", () => {
+    const evil = aboutHtml('1<script>"&');
+    expect(evil).not.toContain("<script>");
+    expect(evil).toContain("&lt;script&gt;");
+  });
+});
+
+describe("logos + rail glyph match the icon family", () => {
+  test("readmeMark is a 24×24 / 1.6-stroke svg with animated parts", () => {
+    const m = readmeMark();
+    expect(m).toContain('viewBox="0 0 24 24"');
+    expect(m).toContain('stroke-width="1.6"');
+    expect(m).toContain("about-mark");
+    expect(m).toContain("about-spark"); // the twinkling sparkle the CSS animates
+  });
+
+  test("lucidLogo renders the wordmark + π", () => {
+    const l = lucidLogo();
+    expect(l).toContain("about-lucid");
+    expect(l).toContain("about-pi");
+  });
+
+  test("techLeadLogo renders the 187 emblem with a gradient", () => {
+    const t = techLeadLogo();
+    expect(t).toContain("187");
+    expect(t).toContain("tlGrad");
+  });
+});

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lucidagentide-desktop",
   "private": true,
-  "version": "0.1.0",
+  "version": "1.8.7",
   "description": "Electron desktop shell for LucidAgentIDE + omp — gated agent chat + live security/memory dashboards.",
   "main": "dist/main.js",
   "scripts": {

--- a/desktop/renderer/about.ts
+++ b/desktop/renderer/about.ts
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 TechLead 187 LLC
+// SPDX-License-Identifier: BUSL-1.1
+
+// desktop/renderer/about.ts — the "About LUCID Agent IDE" panel.
+//
+// Pure string builders (no DOM), so the demo + test can assert on the markup without a browser.
+// app.ts owns open/close + Escape wiring; styles.css owns the animation + dark-mode polish.
+//
+//  - readmeMark()      the animated rail glyph (book + twinkling sparkle), 24×24 / 1.6 stroke to
+//                      match the icon family, with CSS-animated parts (#railAbout in styles.css).
+//  - lucidLogo()       the big LUCID · AGENT IDE wordmark for the panel hero.
+//  - techLeadLogo()    the TechLead 187 emblem (gradient rounded square + "187" monogram).
+//  - aboutHtml(ver)    the full panel inner HTML; `ver` comes from APP_VERSION (single source).
+
+// Small HTML escape for any interpolated value (version string is ours, but stay disciplined).
+const e = (s: string) =>
+  s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+
+/** The animated rail/README glyph: an open book with a twinkling sparkle. Matches the line-icon family. */
+export function readmeMark(): string {
+  return `<svg class="ic about-mark" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <path class="about-book" d="M12 7.2C10.2 6 7.9 5.7 5.8 6.1V17.6C7.9 17.2 10.2 17.5 12 18.7"/>
+    <path class="about-book" d="M12 7.2C13.8 6 16.1 5.7 18.2 6.1V17.6C16.1 17.2 13.8 17.5 12 18.7"/>
+    <path class="about-book" d="M12 7.2V18.7"/>
+    <path class="about-spark" d="M18.4 3.1l.62 1.46 1.46.62-1.46.62-.62 1.46-.62-1.46-1.46-.62 1.46-.62z"/>
+  </svg>`;
+}
+
+/** The LUCID · AGENT IDE wordmark for the panel hero (animated glow via styles.css). */
+export function lucidLogo(): string {
+  // A bigger sibling of the titlebar π mark.
+  const pi = `<svg class="about-pi" viewBox="0 0 24 24" width="26" height="26" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" aria-hidden="true"><path d="M5 8h14"/><path d="M9 8v9"/><path d="M16 8v7a2 2 0 0 0 2 2"/></svg>`;
+  return `<div class="about-word"><span class="about-lucid">LUCID</span>${pi}</div>
+    <div class="about-subword">AGENT&nbsp;IDE</div>`;
+}
+
+/** The TechLead 187 emblem — a gradient rounded square with a "187" monogram and an upward "lead" tick. */
+export function techLeadLogo(): string {
+  return `<svg class="about-tl" viewBox="0 0 40 40" width="38" height="38" aria-hidden="true">
+    <defs>
+      <linearGradient id="tlGrad" x1="0" y1="0" x2="1" y2="1">
+        <stop offset="0" stop-color="var(--accent-2)"/><stop offset="1" stop-color="var(--accent)"/>
+      </linearGradient>
+    </defs>
+    <rect x="2" y="2" width="36" height="36" rx="11" fill="url(#tlGrad)"/>
+    <path d="M9 25l6-7 5 4 11-12" fill="none" stroke="#fff" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" opacity=".95"/>
+    <text x="20" y="32" text-anchor="middle" font-family="var(--mono)" font-size="9.5" font-weight="700" fill="#fff" opacity=".96">187</text>
+  </svg>`;
+}
+
+/** Full inner HTML for the About panel. `version` is APP_VERSION (single source of truth). */
+export function aboutHtml(version: string): string {
+  const v = e(version);
+  return `<div class="about-modal" role="dialog" aria-modal="true" aria-labelledby="aboutTitle">
+    <button class="about-x" data-about-close aria-label="Close">
+      <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"><path d="M6 6l12 12"/><path d="M18 6 6 18"/></svg>
+    </button>
+
+    <div class="about-hero">
+      <div class="about-glow" aria-hidden="true"></div>
+      <div class="about-logo" id="aboutTitle">${lucidLogo()}</div>
+      <div class="about-tag">Secure agentic IDE · provenance · memory</div>
+      <div class="about-ver" data-tip="App version">v${v}</div>
+    </div>
+
+    <p class="about-blurb">
+      <b>LUCID Agent IDE</b> wraps the open agent runtime in a security, provenance, and memory layer.
+      Every tool call is scanned <i>before</i> it runs, untrusted content is delimited and quarantined,
+      and your personalization graph stays encrypted on your own machine. Fail-closed by design.
+    </p>
+
+    <div class="about-card">
+      <div class="about-brand">
+        ${techLeadLogo()}
+        <div class="about-brand-txt">
+          <b>TechLead&nbsp;187&nbsp;LLC</b>
+          <span>© 2026 TechLead 187 LLC · All rights reserved</span>
+        </div>
+      </div>
+
+      <div class="about-lic">
+        <div class="about-lic-row"><span>License</span><b>Business Source License 1.1</b></div>
+        <div class="about-lic-row"><span>Model</span><b>Source-available · production use OK*</b></div>
+        <div class="about-lic-row"><span>Change date</span><b>2030-06-27 → MPL-2.0</b></div>
+      </div>
+      <p class="about-fine">
+        *Except offering a hosted or embedded product competitive with TechLead 187 LLC. BUSL-1.1 is
+        <b>source-available, not OSI open-source</b>; each version converts to the Mozilla Public License 2.0
+        on its Change Date. See the bundled <span class="about-mono">LICENSE</span> for the full terms.
+      </p>
+    </div>
+
+    <div class="about-actions">
+      <button class="btn-mini ok" data-about-close>Close</button>
+    </div>
+  </div>`;
+}

--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -13,6 +13,8 @@ import { cachedSessions, cachedTranscript, setCachedSessions, setCachedTranscrip
 import { $, $$, accordion, el, fmtNum, gauge, spark, table } from "./dom.ts";
 import { ageStr, esc, fmtUSD, goodColor, loadColor } from "./format.ts";
 import { icon, piMark } from "./icons.ts";
+import { aboutHtml, readmeMark } from "./about.ts";
+import { APP_VERSION } from "../version.ts";
 import { renderMarkdown } from "./markdown.ts";
 import { type GraphHandle, kindLabel, mountGraph } from "./graph.ts";
 import { addEdgeOptimistic, applyForget, chainPairs, matchNodes, removeEdgeOptimistic, resolveRelationLabel } from "./kg_ops.ts";
@@ -135,6 +137,7 @@ function buildShell(): void {
         <button class="rail-btn" data-rail="knowledge" data-tip="Knowledge graph|Your private, encrypted personalization graph - nodes, edges, drill-down" data-tip-icon="graph">${icon("graph", 20)}</button>
         <button class="rail-btn" id="railLogs" data-rail="dev" hidden data-tip="Logs|Read-only developer logs: telemetry, run lineage, transcripts, gate-block audit, AskSage tool-call diagnostics" data-tip-icon="logs">${icon("logs", 20)}</button>
         <div class="spacer"></div>
+        <button class="rail-btn rail-about" id="railAbout" data-tip="About LUCID Agent IDE|Version, license & credits" data-tip-icon="info">${readmeMark()}</button>
         <button class="rail-btn" id="railCmd" data-tip="Commands|Ctrl / ⌘ K" data-tip-icon="command">${icon("command", 20)}</button>
         <button class="rail-btn" data-rail="settings" data-tip="Settings" data-tip-icon="sliders">${icon("sliders", 20)}</button>
       </nav>
@@ -3298,6 +3301,21 @@ function openFolderBrowser(opts: { title?: string; confirm?: string } = {}): Pro
   });
 }
 
+// P-ABOUT.1 (ADR-0087): the About panel — version (single-source APP_VERSION), license & credits.
+// Single instance; closes on the X / Close button, a backdrop click, or Escape.
+function openAbout(): void {
+  if ($("#aboutModal")) return; // already open — don't stack
+  const ov = el(`<div id="aboutModal" class="modal-ov about-ov">${aboutHtml(APP_VERSION)}</div>`);
+  const close = () => { ov.remove(); document.removeEventListener("keydown", onKey); };
+  const onKey = (ev: KeyboardEvent) => { if (ev.key === "Escape") { ev.preventDefault(); close(); } };
+  ov.addEventListener("click", (ev) => {
+    const t = ev.target as HTMLElement;
+    if (t === ov || t.closest("[data-about-close]")) close(); // backdrop or a close control
+  });
+  document.addEventListener("keydown", onKey);
+  document.body.append(ov);
+}
+
 function wire(): void {
   // rail
   $$(".rail-btn[data-rail]").forEach((b) => b.addEventListener("click", () => {
@@ -3422,6 +3440,7 @@ function wire(): void {
   });
   $("#railCmd")!.addEventListener("click", () => palette.show());
   $("#cmdkBtn")!.addEventListener("click", () => palette.show());
+  $("#railAbout")?.addEventListener("click", () => openAbout());
   // Per-message copy (markdown) + save-as-.md
   $("#thread")!.addEventListener("click", async (e) => {
     const t = e.target as HTMLElement;

--- a/desktop/renderer/styles.css
+++ b/desktop/renderer/styles.css
@@ -1356,6 +1356,75 @@ body.resizing .sidebar,body.resizing .inspector{transition:none}
 .modal-actions{display:flex;justify-content:center;gap:9px;margin-top:14px}
 .modal-actions .btn-mini{padding:6px 16px}
 @keyframes fade{from{opacity:0}to{opacity:1}}
+
+/* ───────────────────────── About panel (P-ABOUT.1 / ADR-0087) ───────────────────────── */
+/* The animated rail glyph: book gently breathes, the sparkle twinkles + drifts. */
+.rail-about .about-mark{overflow:visible}
+.rail-about .about-book{transform-box:fill-box;transform-origin:center;animation:aboutBreathe 5.5s var(--ease) infinite}
+.rail-about .about-spark{fill:var(--accent-2);stroke:none;transform-box:fill-box;transform-origin:60% 40%;
+  animation:aboutTwinkle 3.4s var(--ease) infinite}
+.rail-about:hover{color:var(--accent-2)}
+.rail-about:hover .about-spark{animation-duration:1.5s}
+@keyframes aboutBreathe{0%,100%{transform:scale(1)}50%{transform:scale(1.04)}}
+@keyframes aboutTwinkle{
+  0%,100%{opacity:.35;transform:scale(.7) rotate(0deg)}
+  45%{opacity:1;transform:scale(1.15) rotate(20deg)}
+  60%{opacity:.8;transform:scale(1) rotate(8deg)}}
+
+.about-ov{z-index:300}
+.about-modal{position:relative;width:min(540px,94vw);max-height:92vh;overflow-y:auto;scrollbar-gutter:stable;
+  background:linear-gradient(180deg,var(--bg-2),var(--bg-1));border:1px solid var(--line-strong);border-radius:18px;
+  padding:0 24px 22px;box-shadow:0 40px 90px -28px rgba(0,0,0,.78),0 0 0 1px var(--accent-dim),inset 0 1px 0 rgba(255,255,255,.05);
+  animation:rise var(--t-slow) var(--ease-out)}
+.about-x{position:absolute;top:13px;right:13px;z-index:2;-webkit-app-region:no-drag;display:grid;place-items:center;
+  width:30px;height:30px;border-radius:9px;border:1px solid transparent;background:transparent;color:var(--txt-3);cursor:pointer;
+  transition:background var(--t),color var(--t),border-color var(--t)}
+.about-x:hover{background:var(--bg-3);color:var(--txt);border-color:var(--line)}
+
+/* hero — wordmark over a soft accent glow */
+.about-hero{position:relative;text-align:center;padding:30px 0 18px;overflow:hidden;
+  border-bottom:1px solid var(--line-soft);margin:0 -24px 18px;border-radius:18px 18px 0 0}
+.about-glow{position:absolute;inset:-40% 0 auto 0;height:200px;pointer-events:none;
+  background:radial-gradient(60% 80% at 50% 0%,var(--accent-dim),transparent 70%);
+  animation:aboutGlow 6s ease-in-out infinite}
+@keyframes aboutGlow{0%,100%{opacity:.7}50%{opacity:1}}
+.about-logo{position:relative}
+.about-word{display:inline-flex;align-items:center;gap:10px;justify-content:center}
+.about-lucid{font-size:38px;font-weight:800;letter-spacing:5px;color:var(--accent);
+  text-shadow:0 0 18px rgba(198,75,214,.45);animation:lucidGlow 4.5s ease-in-out infinite}
+.about-pi{color:var(--cyan);animation:piGlow 4.5s ease-in-out infinite}
+.about-subword{margin-top:2px;font-size:13px;font-weight:700;letter-spacing:7px;color:var(--txt-2);text-indent:7px}
+.about-tag{position:relative;margin-top:11px;font-size:12px;color:var(--txt-3);letter-spacing:.3px}
+.about-ver{position:relative;display:inline-block;margin-top:12px;padding:3px 12px;border-radius:999px;
+  font:600 12px var(--mono);color:var(--accent-2);background:var(--accent-dim);
+  border:1px solid color-mix(in srgb,var(--accent) 34%,transparent)}
+
+.about-blurb{font-size:13px;line-height:1.65;color:var(--txt-2);margin:0 2px 16px}
+.about-blurb b{color:var(--txt)}
+.about-blurb i{color:var(--txt);font-style:italic}
+
+/* TechLead 187 + license card */
+.about-card{border:1px solid var(--line-soft);border-radius:13px;padding:15px 16px;
+  background:linear-gradient(180deg,var(--bg-1),color-mix(in srgb,var(--bg-1) 90%,#000));
+  box-shadow:inset 0 1px 0 rgba(255,255,255,.03),0 1px 2px rgba(0,0,0,.3)}
+.about-brand{display:flex;align-items:center;gap:12px;padding-bottom:13px;margin-bottom:13px;border-bottom:1px solid var(--line-soft)}
+.about-tl{flex:none;filter:drop-shadow(0 6px 16px rgba(198,75,214,.42))}
+.about-brand-txt{display:flex;flex-direction:column;gap:2px;min-width:0}
+.about-brand-txt b{font-size:14.5px;color:var(--txt);font-weight:700}
+.about-brand-txt span{font-size:11px;color:var(--txt-4)}
+.about-lic{display:flex;flex-direction:column;gap:7px}
+.about-lic-row{display:flex;align-items:baseline;gap:10px;font-size:12px}
+.about-lic-row>span{flex:none;width:88px;color:var(--txt-4);text-transform:uppercase;letter-spacing:.05em;font-size:10px}
+.about-lic-row>b{color:var(--txt-2);font-weight:600}
+.about-fine{margin:12px 0 0;font-size:10.5px;line-height:1.6;color:var(--txt-4)}
+.about-fine b{color:var(--txt-3)}
+.about-mono{font-family:var(--mono);color:var(--txt-3)}
+.about-actions{display:flex;justify-content:center;margin-top:18px}
+.about-actions .btn-mini{padding:7px 26px}
+
+@media (prefers-reduced-motion:reduce){
+  .rail-about .about-book,.rail-about .about-spark,.about-glow,.about-lucid,.about-pi{animation:none}
+}
 .kg-side-empty{display:flex;flex-direction:column;align-items:center;gap:9px;color:var(--txt-4);font-size:12px;margin-top:34px;text-align:center}
 .kg-svg{display:block;position:relative;z-index:1}
 .kg-edge{fill:none;stroke:var(--line-strong);stroke-width:1.1;opacity:.32;stroke-linecap:round;transition:opacity var(--t)}

--- a/desktop/scripts/demo_p_about_1.ts
+++ b/desktop/scripts/demo_p_about_1.ts
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 TechLead 187 LLC
+// SPDX-License-Identifier: BUSL-1.1
+
+// desktop/scripts/demo_p_about_1.ts
+//
+// Increment P-ABOUT.1 (ADR-0087) — the About panel + a dynamically-sourced app version.
+// Proves: (1) the version is single-sourced (version.ts === desktop/package.json) and starts at the
+// launch baseline v1.8.7; (2) the About panel renders the LUCID Agent IDE identity, the TechLead 187
+// company + BUSL-1.1 licensing, and the live version; (3) the animated rail glyph matches the icon family.
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { aboutHtml, readmeMark } from "../renderer/about.ts";
+import { APP_VERSION } from "../version.ts";
+
+const fail = (msg: string): never => { console.error(`FAIL: ${msg}`); process.exit(1); };
+const ok = (msg: string): void => console.log(`   ${msg} ✓`);
+
+console.log("== P-ABOUT.1 — About panel + dynamic version ==");
+
+// 1. Single-sourced version, launch baseline v1.8.7.
+const pkg = JSON.parse(readFileSync(join(import.meta.dir, "..", "package.json"), "utf8")) as { version: string };
+if (pkg.version !== APP_VERSION) fail(`desktop/package.json (${pkg.version}) and version.ts (${APP_VERSION}) drifted`);
+ok(`version single-sourced: version.ts === desktop/package.json === ${APP_VERSION}`);
+if (APP_VERSION !== "1.8.7") fail(`launch baseline must be 1.8.7, got ${APP_VERSION}`);
+ok("launch baseline jumps to v1.8.7");
+
+// 2. The panel surfaces identity, company, license, and the live version (no hardcoded duplicate).
+const html = aboutHtml(APP_VERSION);
+const must = [
+  ["product wordmark", "LUCID"],
+  ["product subtitle", "AGENT&nbsp;IDE"],
+  ["dynamic version", `v${APP_VERSION}`],
+  ["company", "TechLead&nbsp;187&nbsp;LLC"],
+  ["license", "Business Source License 1.1"],
+  ["change date → MPL", "2030-06-27 → MPL-2.0"],
+  ["not OSI open-source", "source-available, not OSI open-source"],
+  ["dialog semantics", 'role="dialog"'],
+] as const;
+for (const [label, needle] of must) {
+  if (!html.includes(needle)) fail(`About panel missing ${label} (${needle})`);
+  ok(`panel shows ${label}`);
+}
+
+// The version is interpolated, never hardcoded in the markup — bumping version.ts moves the UI.
+if (aboutHtml("9.9.9").includes("v1.8.7")) fail("version is hardcoded in the markup");
+ok("version is interpolated (dynamic), not hardcoded");
+
+// 3. The animated rail glyph matches the 24×24 / 1.6-stroke icon family and has the twinkle hook.
+const mark = readmeMark();
+if (!mark.includes('viewBox="0 0 24 24"') || !mark.includes('stroke-width="1.6"')) fail("rail glyph off-family");
+if (!mark.includes("about-spark")) fail("rail glyph missing the animated sparkle the CSS twinkles");
+ok("animated rail glyph matches the icon family (book + twinkling sparkle)");
+
+console.log("demo-P-ABOUT.1 OK");
+process.exit(0);

--- a/desktop/version.ts
+++ b/desktop/version.ts
@@ -1,0 +1,12 @@
+// Copyright (c) 2026 TechLead 187 LLC
+// SPDX-License-Identifier: BUSL-1.1
+
+// desktop/version.ts — the single source of truth for the LUCID Agent IDE app version.
+//
+// The About panel reads APP_VERSION (bundled into the renderer), so bumping the version here
+// updates the UI everywhere with no hardcoded duplicate in the markup. desktop/package.json
+// MIRRORS this string (electron's app.getVersion() / electron-builder read package.json);
+// version.test.ts asserts the two stay equal, so a bump in one is forced into the other.
+//
+// Launch baseline: v1.8.7.
+export const APP_VERSION = "1.8.7";


### PR DESCRIPTION
Adds an in-app **About LUCID Agent IDE** panel and makes the app version dynamic + single-sourced, bumped to the launch baseline **v1.8.7**. Also lands the license-hook note into the invariant files.

## What

**About panel (ADR-0087 / P-ABOUT.1)**
- A new **animated rail glyph** (`#railAbout` — an open book with a twinkling, drifting sparkle) in the existing 24×24 / 1.6-stroke icon family, placed **above Commands + Settings** on the activity rail.
- Opens a polished **dark-mode modal**: the glowing **LUCID · AGENT IDE** wordmark hero (with the cyan π), a one-paragraph product summary, and a **TechLead 187 LLC** card with the emblem + **BUSL-1.1** terms (Change Date `2030-06-27 → MPL-2.0`; "source-available, not OSI open-source").
- `desktop/renderer/about.ts` is a **pure string builder** (no DOM) so the content is unit-tested + demo-proven; `app.ts` only owns open/close. Closes on **X / Close / backdrop / Escape**; single instance; honors `prefers-reduced-motion`; the interpolated version is HTML-escaped.

**Dynamic, single-sourced version**
- `desktop/version.ts` exports `APP_VERSION = "1.8.7"`; `desktop/package.json` mirrors it (electron `app.getVersion()` reads package.json). `about.test.ts` + `demo-P-ABOUT.1` assert the two never drift, and the panel shows the **live** version — no hardcoded duplicate.

**Invariants**
- Added the BUSL-1.1-header + **`make install-hooks` once-per-clone** note (with the CI backstop + the TOCTOU gotcha) to `CLAUDE.md` and `AGENTS.md`, kept byte-identical below line 1 (CI enforces).

## Verification
- `make demo-P-ABOUT.1` green · `about.test.ts` 10/10 · desktop typecheck + renderer bundle clean · license-headers check ✓ · AGENTS/CLAUDE in sync.
- **Live-verified in the preview**: rail order (`…knowledge, railLogs, railAbout, railCmd, settings`), modal renders `v1.8.7` + LUCID + TechLead 187 + BUSL-1.1 + change date, all four close paths work, single-instance guard holds, **no console errors**. Screenshot in the thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)