### PR TITLE
fix(build): make the Linux deb/rpm targets actually build

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -79,6 +79,13 @@ jobs:
           node -e "const fs=require('fs'),p=require('./package.json');p.version=process.argv[1];fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')" "$V"
           echo "build version = $V"
 
+      # electron-builder's deb/rpm targets shell out to fpm; building an .rpm on the Ubuntu runner needs
+      # the `rpm` toolchain (rpmbuild), which isn't installed by default. (.deb needs only fpm + dpkg,
+      # already present.) No-op on macOS/Windows.
+      - name: Install rpm tooling (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y rpm
+
       - name: Build installer (${{ matrix.script }})
         run: bun run ${{ matrix.script }}
         working-directory: desktop

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -3,6 +3,8 @@
   "private": true,
   "version": "1.8.7",
   "description": "Electron desktop shell for LucidAgentIDE + omp — gated agent chat + live security/memory dashboards.",
+  "homepage": "https://github.com/mlcyclops/lucidagentide",
+  "author": "TechLead 187 LLC <support@lucidagentide.com>",
   "main": "dist/main.js",
   "scripts": {
     "build": "bun build main.ts --target=node --format=cjs --external electron --outfile dist/main.js && bun build preload.ts --target=node --format=cjs --external electron --outfile dist/preload.js",


### PR DESCRIPTION
Follow-up to #147. The new Linux **deb/rpm** targets passed the standard PR CI but **failed the actual package build** (which is tag/`workflow_dispatch`-gated, so PRs don't exercise it). Two causes:

1. electron-builder's **fpm** deb/rpm targets require a `homepage` (and author) in `desktop/package.json` metadata — the AppImage target doesn't, which is why this slipped through. → added `homepage` + `author`.
2. Building an **.rpm** on the Ubuntu runner needs the `rpm`/`rpmbuild` toolchain, absent by default. → `apt-get install -y rpm` on the Linux runner before the build.

## Validated with a real build
Triggered `build-desktop.yml` on this branch — the **Linux job succeeded** and produced all three:
- `LucidAgentIDE-x86_64.AppImage`
- `lucidagentide-desktop_0.1.29_amd64.deb`
- `lucidagentide-desktop-0.1.29.x86_64.rpm`

(macOS + Windows jobs unaffected.) Without this, #147's deb/rpm targets fail every tag/release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)