### PR TITLE
fix(build): unblock the macOS release — drop the never-working .pkg target

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -79,22 +79,12 @@
         {
           "target": "zip",
           "arch": ["arm64", "x64"]
-        },
-        {
-          "target": "pkg",
-          "arch": ["arm64", "x64"]
         }
       ],
       "hardenedRuntime": true,
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist",
       "gatekeeperAssess": false
-    },
-    "pkg": {
-      "isRelocatable": false,
-      "installLocation": "/Applications",
-      "mustClose": ["com.lucidagentide.desktop"],
-      "overwriteAction": "upgrade"
     },
     "win": {
       "icon": "build/icon.ico",


### PR DESCRIPTION
The macOS release build is **broken on master**: #147's `.pkg` target fails with `⨯ <projectDir> not a file`, and because the whole `dist:mac` script exits 1, it also blocks the working `.zip` artifacts from shipping. The `.pkg` was **never shipped** — v1.8.7 was zip-only (the `.pkg` target post-dates it).

## Fix
Restore the proven **zip-only** macOS build (byte-for-byte the `mac` config that shipped v1.8.7) by removing the `.pkg` target + `pkg` config block. electron-builder's unsigned-`.pkg` flow throws a cryptic path error that can't be debugged from CI alone — the `.pkg` + Homebrew cask enterprise path is **deferred until it can be iterated on a real Mac**.

The Linux **deb/rpm** work (#147's actual contribution, fixed in #151) is unaffected. Leftover `Casks/` + `*.pkg` release globs are harmless (the globs match nothing → `if-no-files-found: warn`).

## Validated with a real 3-platform build
Triggered `build-desktop.yml` on this branch — **all three jobs succeeded**:
- macOS: `LucidAgentIDE-mac-arm64.zip` + `-mac-x64.zip` ✅
- Linux: AppImage + deb + rpm ✅
- Windows: NSIS + portable ✅

Follow-up (tracked): revisit the macOS `.pkg` + cask on a real Mac, or remove the now-dangling `Casks/lucidagentide.rb` + `*.pkg` CI globs + the cask section of the macOS runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)