### PR TITLE
Fix macOS .pkg build so the Homebrew cask installs (#153)

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -86,15 +86,31 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y rpm
 
+      # electron-builder's pkg target resolves the signing cert even for an unsigned (identity:null)
+      # build. An EMPTY CSC_LINK is NOT the same as unset: '' != null in JS, so electron-builder treats
+      # '' as a cert path, resolves it to the project dir, and dies "<projectDir> not a file" (only the
+      # pkg target trips this — the zip/app path short-circuits on identity:null). So export CSC_LINK /
+      # CSC_KEY_PASSWORD ONLY when a real cert secret exists; never as empty strings.
+      - name: Configure code-signing (only when a cert secret exists)
+        shell: bash
+        env:
+          MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+          MAC_CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+          WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
+          WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
+        run: |
+          if [[ "$RUNNER_OS" == "macOS" && -n "$MAC_CSC_LINK" ]]; then
+            { echo "CSC_LINK=$MAC_CSC_LINK"; echo "CSC_KEY_PASSWORD=$MAC_CSC_KEY_PASSWORD"; } >> "$GITHUB_ENV"
+          elif [[ "$RUNNER_OS" == "Windows" && -n "$WIN_CSC_LINK" ]]; then
+            { echo "CSC_LINK=$WIN_CSC_LINK"; echo "CSC_KEY_PASSWORD=$WIN_CSC_KEY_PASSWORD"; } >> "$GITHUB_ENV"
+          fi
+
       - name: Build installer (${{ matrix.script }})
         run: bun run ${{ matrix.script }}
         working-directory: desktop
         env:
-          # --- Code signing (all optional; absent secrets ⇒ unsigned build) ---
-          # Per-OS Authenticode / Apple Developer cert as base64-encoded PKCS#12. Linux (AppImage) is
-          # unsigned, so it must resolve to empty — don't let it inherit the Windows cert.
-          CSC_LINK: ${{ runner.os == 'macOS' && secrets.MAC_CSC_LINK || runner.os == 'Windows' && secrets.WIN_CSC_LINK || '' }}
-          CSC_KEY_PASSWORD: ${{ runner.os == 'macOS' && secrets.MAC_CSC_KEY_PASSWORD || runner.os == 'Windows' && secrets.WIN_CSC_KEY_PASSWORD || '' }}
+          # CSC_LINK / CSC_KEY_PASSWORD come from the "Configure code-signing" step above — set ONLY
+          # when a real cert secret exists, never as '' (an empty CSC_LINK crashes the pkg build).
           # Only hunt the keychain for a mac identity when a mac cert is provided.
           CSC_IDENTITY_AUTO_DISCOVERY: ${{ runner.os == 'macOS' && secrets.MAC_CSC_LINK != '' }}
           # macOS notarization (electron-builder runs notarytool when these are set).

--- a/README.md
+++ b/README.md
@@ -426,15 +426,13 @@ keeps the cask wiring current (the app itself also self-updates via electron-upd
 brew tap mlcyclops/lucid https://github.com/mlcyclops/lucidagentide
 brew trust --cask mlcyclops/lucid/lucidagentide   # Homebrew >= 6 gates third-party taps
 brew install --cask lucidagentide
-
-# Builds are UNSIGNED, so clear macOS quarantine once before first launch:
-xattr -dr com.apple.quarantine "/Applications/LucidAgentIDE.app"
 ```
 
 `brew trust` is required on Homebrew 6+, which refuses to load casks from a third-party tap until you
-explicitly trust it (older Homebrew skips this step). The `xattr` step is needed because builds are currently
-**unsigned and not notarized** - macOS Gatekeeper blocks them otherwise, and Homebrew 6 removed the
-`--no-quarantine` install flag. The cask serves both Apple Silicon and Intel automatically. To remove it
+explicitly trust it (older Homebrew skips this step). The cask installs a `.pkg`: `installer(8)` places the
+app in `/Applications` **without** the macOS quarantine flag, so it launches with **no Gatekeeper prompt**
+even though the build is unsigned/not-notarized (a `postflight` strips quarantine as belt-and-suspenders, so
+there is no manual `xattr` step). The cask serves both Apple Silicon and Intel automatically. To remove it
 later: `brew uninstall --cask lucidagentide` (add `--zap` to also delete app data).
 
 ## <img src=".github/assets/icons/roadmap.svg" width="28" align="top" alt=""> Roadmap

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -17,7 +17,7 @@
     "start": "bun run build && electron .",
     "web": "bun run dev.ts",
     "typecheck": "tsc --noEmit",
-    "dist:mac": "bun run runtimes:mac && bun run icons && bun run build && bun run compile-lucid && electron-builder --mac --publish never",
+    "dist:mac": "bun run runtimes:mac && bun run icons && bun run build && bun run compile-lucid && electron-builder --mac pkg --arm64 --publish never && electron-builder --mac pkg --x64 --publish never && electron-builder --mac zip --arm64 --x64 --publish never",
     "dist:win": "bun run runtimes:win && bun run icons && bun run build && bun run compile-lucid && electron-builder --win --publish never",
     "dist:linux": "bun run runtimes:linux && bun run icons && bun run build && bun run compile-lucid && electron-builder --linux --publish never",
     "dist": "bun run runtimes && bun run icons && bun run build && bun run compile-lucid && electron-builder --publish never"
@@ -79,12 +79,21 @@
         {
           "target": "zip",
           "arch": ["arm64", "x64"]
+        },
+        {
+          "target": "pkg"
         }
       ],
       "hardenedRuntime": true,
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist",
       "gatekeeperAssess": false
+    },
+    "pkg": {
+      "isRelocatable": false,
+      "installLocation": "/Applications",
+      "mustClose": ["com.lucidagentide.desktop"],
+      "overwriteAction": "upgrade"
     },
     "win": {
       "icon": "build/icon.ico",


### PR DESCRIPTION
## What

Fixes the macOS `.pkg` build so the Homebrew cask actually installs (issue #153). The cask has pointed at a `.pkg` since #141, but that asset never shipped — the release build died, was reverted in #152, and `brew install --cask lucidagentide` 404s on `LucidAgentIDE-mac-<arch>.pkg`.

## Root cause — two bugs, the second masked by the first

**1. The workflow injected an empty `CSC_LINK`.** electron-builder's pkg target forces signing-cert resolution even for an unsigned (`identity: null`) build. The workflow set `CSC_LINK: ${{ … || '' }}`, i.e. an empty string when no Apple cert. `'' != null`, so electron-builder treats `''` as a cert path, `path.resolve(projectDir, '')` → the `desktop` project dir, and `importCertificate` throws `⨯ <projectDir> not a file`. Only the **pkg** target hits this; the **zip/app** path short-circuits earlier on `identity: null` (`macPackager.sign` returns before touching `codeSigningInfo`). That's the exact zip-green / pkg-red asymmetry from #153, and the only error #141/#147 ever reached.

**2. Multi-arch pkg in one invocation collides on shared intermediates.** With #1 fixed, the next failure surfaces: building `arm64` + `x64` pkg in a single `electron-builder --mac` run races on intermediate files derived from the bundle id only (`release/com.lucidagentide.desktop.pkg`, `distribution.xml`). `AsyncTaskManager` runs them under one unbounded `Promise.all`, so the cleanup `unlink` ENOENTs (`failedTask=build`) — and worse, the two `pkgbuild`/`productbuild` runs can clobber the shared inner pkg mid-build, contaminating one arch's `.pkg` with the other's binaries.

## Fix

- **`ci(desktop)`** — a `Configure code-signing` step exports `CSC_LINK`/`CSC_KEY_PASSWORD` to `$GITHUB_ENV` **only when a real cert secret exists**; the build step no longer sets them to `''`. (No-op on Linux; same conditional for the Windows cert.)
- **`build(desktop)`** — re-add the pkg mac target (reverted in #152) with **no per-target `arch`**, and split `dist:mac` into `electron-builder --mac pkg --arm64`, then `--mac pkg --x64`, then `--mac zip --arm64 --x64`. pkg builds one arch per process (no shared-intermediate race); zip stays in one invocation so `latest-mac.yml` keeps **both** arches for the electron-updater feed.
- **`docs(readme)`** — the cask installs a `.pkg` (`installer(8)` → `/Applications`, no quarantine, `postflight` strips it); dropped the stale zip-era manual `xattr` step.

## Evidence (real Mac, Apple M3 Max, electron-builder 25.1.8)

**Bug #1 reproduced verbatim, then fixed:**
```
$ CSC_LINK='' electron-builder --mac pkg --arm64
  • building        target=pkg arch=arm64 file=release/LucidAgentIDE-mac-arm64.pkg
  ⨯ /Users/…/desktop not a file          # == #153's "/Users/runner/work/…/desktop not a file"; exit 1
$ electron-builder --mac pkg --arm64     # CSC_LINK unset (the fixed path)
  • building        target=pkg arch=arm64 file=release/LucidAgentIDE-mac-arm64.pkg   # exit 0
```

**Bug #2 reproduced, then fixed:** single `--mac` (both arches at once) →
```
  ⨯ ENOENT: no such file or directory, unlink '…/release/com.lucidagentide.desktop.pkg'  failedTask=build
```
The per-arch `dist:mac` sequence exits 0 and yields a coherent `release/`:

| Check | Result |
|---|---|
| `dist:mac` electron-builder sequence | **exit 0** |
| Artifacts produced | `…-arm64.pkg`, `…-x64.pkg`, both `.zip` + `.blockmap`, `latest-mac.yml` |
| Per-arch payload (anti-contamination) | `arm64.pkg` → `arm64`, `x64.pkg` → `x86_64` (via `pkgutil --expand-full` + `lipo -archs`) |
| pkg shape | `install-location="/Applications"`, payload `LucidAgentIDE.app`, `enable_anywhere="true"`, unsigned |
| `latest-mac.yml` | lists **both** arch zips; `sha512` matches the zip byte-for-byte (`openssl dgst -sha512 -binary | base64` == feed) |
| Cask URL ↔ artifacts | `LucidAgentIDE-mac-#{arch}.pkg` matches `arm64`/`x64` names; workflow `*.pkg` globs match |
| Build size parity | `…-arm64.zip` = 350,808,910 B vs the shipped release's 350,808,805 B (≈ identical → matches the production zip pipeline) |

**End-to-end `brew install` on a real Mac** (via the isolated prerelease below, so the full path is exercised pre-merge):

| Step | Result |
|---|---|
| Asset URLs (were 404) | `arm64` + `x64` → **HTTP 200** |
| `brew info --cask` | parses, resolves `LucidAgentIDE-mac-arm64.pkg` (Pkg) |
| `brew fetch --cask` | **exit 0** (downloads via the cask) |
| `brew install --cask` | installs to `/Applications`, **no Gatekeeper prompt**; `xattr` shows no `com.apple.quarantine`; `pkgutil` receipt present |
| App launches | window opens; the bundled local engine (`bun run desktop/dev.ts`) answers `GET /api/health` → **200 `{"ok":true}`** |

> The local engine needs the bundled `repo/node_modules` (it imports `@oh-my-pi`/omp + `@duckdb`). That's produced by the root `bun install` the workflow already runs before `electron-builder` (extraResources copies `node_modules/**` → `repo/`). Confirmed in the built app: `repo/node_modules` = 467M including `@oh-my-pi/*` (with `pi-natives-darwin-arm64`) and `@duckdb`. First launch does one-time scanner provisioning via the bundled `uv` (behind the splash), then the engine comes up.

Only the macOS lane was exercised locally; the Windows/Linux lanes are unchanged except the new conditional signing-env step (Linux: neither branch matches → unsigned, as before).

## Test it before merge (no merge, no prod pollution)

`brew tap` only reads the repo's **default branch (master)**, and the cask downloads from `releases/download/latest/…` — so this branch can't be brew-tested directly. To verify `brew install` end-to-end *before* merge, the complete build from this branch is published to an isolated **prerelease**: [`pkg-test-153`](https://github.com/mlcyclops/lucidagentide/releases/tag/pkg-test-153) — both arches' `.pkg` + `.zip` + `.blockmap` + `latest-mac.yml`, with `repo/node_modules` bundled (verified launching above). It's **not** on the rolling `latest` release, the tag isn't `v*` so it **didn't trigger CI**, and a prerelease never takes GitHub's "Latest" label — `latest` and `master` are untouched.

Run this on any Mac (self-contained; recreates a throwaway cask + local tap, since Homebrew 6 requires casks to live in a tap):

```bash
cat > /tmp/lucidagentide.rb <<'RB'
cask "lucidagentide" do
  arch arm: "arm64", intel: "x64"
  version :latest
  sha256 :no_check
  url "https://github.com/mlcyclops/lucidagentide/releases/download/pkg-test-153/LucidAgentIDE-mac-#{arch}.pkg"
  name "LucidAgentIDE"
  homepage "https://github.com/mlcyclops/lucidagentide"
  depends_on macos: :big_sur
  pkg "LucidAgentIDE-mac-#{arch}.pkg", allow_untrusted: true
  postflight do
    system_command "/usr/bin/xattr",
                   args: ["-dr", "com.apple.quarantine", "/Applications/LucidAgentIDE.app"],
                   sudo: true
  end
  uninstall quit: "com.lucidagentide.desktop", pkgutil: "com.lucidagentide.desktop"
end
RB
TAP="$(brew --repository)/Library/Taps/lucidtest/homebrew-local"
mkdir -p "$TAP/Casks" && cp /tmp/lucidagentide.rb "$TAP/Casks/lucidagentide.rb"

brew install --cask lucidtest/local/lucidagentide   # prompts for password (sudo installer + postflight)
open -a LucidAgentIDE                                # launches; engine answers on port 5319
brew uninstall --cask lucidtest/local/lucidagentide
```

The **only** difference from the shipping flow (`brew tap mlcyclops/lucid … && brew install --cask lucidagentide`) is the source tag (`pkg-test-153` vs `latest`); the install logic — `allow_untrusted` installer, `/Applications`, no-Gatekeeper, postflight, receipt, uninstall/zap — is byte-identical.

Tear down the test artifacts when done:
```bash
brew untap lucidtest/local
gh release delete pkg-test-153 --repo mlcyclops/lucidagentide --cleanup-tag --yes
```

## After merge

Run **Actions → Build desktop installers → Run workflow** (`workflow_dispatch`) so the rolling `latest` release is republished with the `.pkg` assets. Then `brew tap mlcyclops/lucid … && brew install --cask lucidagentide` works for everyone.

Refs #153 (origin: #141, revert: #152)
