### PR TITLE
fix(settings,models): Perplexity→Providers, readable notes, Gemini cards, v1.8.9

### DIFF
--- a/desktop/about.test.ts
+++ b/desktop/about.test.ts
@@ -15,8 +15,8 @@ describe("version is single-sourced", () => {
     expect(pkg.version).toBe(APP_VERSION);
   });
 
-  test("app version is v1.8.8", () => {
-    expect(APP_VERSION).toBe("1.8.8");
+  test("app version is v1.8.9", () => {
+    expect(APP_VERSION).toBe("1.8.9");
   });
 });
 
@@ -25,7 +25,7 @@ describe("aboutHtml", () => {
 
   test("shows the dynamic version with a v prefix", () => {
     expect(html).toContain(`v${APP_VERSION}`);
-    expect(html).toContain("v1.8.8");
+    expect(html).toContain("v1.8.9");
   });
 
   test("carries the product + company identity", () => {

--- a/desktop/auth_status.ts
+++ b/desktop/auth_status.ts
@@ -31,14 +31,15 @@ export const MAJORS = [
   { id: "google", name: "Google · Gemini", env: "GEMINI_API_KEY", oauthId: "google-gemini-cli", canOauth: true },
   { id: "anthropic", name: "Anthropic · Claude", env: "ANTHROPIC_API_KEY", oauthId: "anthropic", canOauth: true },
   { id: "xai", name: "xAI · Grok", env: "XAI_API_KEY", oauthId: "xai-oauth", canOauth: true },
+  // Perplexity (Sonar) is U.S.-based. omp supports OAuth too, but its login is interactive email-OTP /
+  // the macOS app token — neither works through our non-interactive broker spawn — so we expose the
+  // API-key path. canOauth:false hides the dead OAuth button.
+  { id: "perplexity", name: "Perplexity · Sonar", env: "PERPLEXITY_API_KEY", oauthId: "perplexity", canOauth: false },
 ];
 // More providers (third-party / non-U.S. / custom aggregators) - gated behind a typed acknowledgement
 // in the UI because they route to servers outside U.S. jurisdiction or aggregate many origins.
 export const OTHERS = [
   { id: "openrouter", name: "OpenRouter", env: "OPENROUTER_API_KEY", oauthId: "openrouter", canOauth: true },
-  // Perplexity (Sonar). omp supports OAuth too, but its login is interactive email-OTP / the macOS app
-  // token — neither works through our non-interactive broker spawn — so we expose the API-key path.
-  { id: "perplexity", name: "Perplexity · Sonar", env: "PERPLEXITY_API_KEY", oauthId: "perplexity", canOauth: false },
   { id: "deepseek", name: "DeepSeek", env: "DEEPSEEK_API_KEY", oauthId: "deepseek", canOauth: false },
   { id: "moonshot", name: "Moonshot · Kimi", env: "MOONSHOT_API_KEY", oauthId: "moonshot", canOauth: false },
   { id: "groq", name: "Groq", env: "GROQ_API_KEY", oauthId: "", canOauth: false },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lucidagentide-desktop",
   "private": true,
-  "version": "1.8.8",
+  "version": "1.8.9",
   "description": "Electron desktop shell for LucidAgentIDE + omp — gated agent chat + live security/memory dashboards.",
   "homepage": "https://github.com/mlcyclops/lucidagentide",
   "author": "TechLead 187 LLC <support@lucidagentide.com>",

--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -1491,7 +1491,7 @@ function secOthers(auth: import("./bridge.ts").AuthStatus | null): string {
       `<div class="set-note ok">${icon("check", 12)} You acknowledged the third-party risk. <button class="btn-link" id="thirdPartyRelock">Re-lock</button></div>${list}`, true);
   }
   return setCard("others", "More providers", "acknowledge to reveal",
-    `<div class="set-note danger">${icon("shield", 12)} <b>Third-party models (non-U.S. / custom)</b> - OpenRouter, Perplexity, DeepSeek, Kimi/Moonshot, Groq. These route to third-party or non-U.S. servers (or aggregate many origins) with <b>no U.S. data-sovereignty guarantee</b>; review each provider's terms before use.</div>
+    `<div class="set-note danger">${icon("shield", 12)} <b>Third-party models (non-U.S. / custom)</b> - OpenRouter, DeepSeek, Kimi/Moonshot, Groq. These route to third-party or non-U.S. servers (or aggregate many origins) with <b>no U.S. data-sovereignty guarantee</b>; review each provider's terms before use.</div>
      <div class="china-unlock"><input id="thirdPartyAckInput" placeholder="Type ACKNOWLEDGE to reveal" autocomplete="off" spellcheck="false" /><button class="btn-mini" id="thirdPartyAckBtn" disabled>Reveal</button></div>`, true);
 }
 // P-MCP.1 (ADR-0020): MCP connectors - auth + config only; omp owns the MCP transport.
@@ -4444,6 +4444,21 @@ const MODEL_INFO: Record<string, ModelInfo> = {
   "google-gemini-3.5-flash-gov": { exp: 2, iq: 3, eff: "Fast Gemini in GovCloud; 1M context.", best: "Fast long-context gov tasks.", ctx: "1M" },
   "google-gemini-2.5-pro": { exp: 3, iq: 4, eff: "Gemini 2.5 Pro; 1M context.", best: "Long-context reasoning.", ctx: "1M" },
   "google-gemini-2.5-flash": { exp: 1, iq: 3, eff: "Fast, cheap Gemini; 1M context.", best: "High-volume long-context work.", ctx: "1M" },
+  // Google · Gemini (direct - Antigravity / Gemini CLI). Keyed by the provider-stripped base id so a
+  // model routed through either provider inherits the same card. Pro tiers are frontier-class (5 stars);
+  // Flash/Lite are the fast, cheap tiers (3 stars). Gemini is 1M-context across the board.
+  "gemini-3.1-pro": { exp: 4, iq: 5, eff: "Google's flagship Gemini 3.1 Pro - top reasoning, 1M context.", best: "Complex reasoning, architecture, huge-context analysis.", ctx: "1M" },
+  "gemini-3.1-pro-preview": { exp: 4, iq: 5, eff: "Preview of Gemini 3.1 Pro - flagship reasoning, 1M context.", best: "Complex reasoning + huge-context analysis (preview).", ctx: "1M" },
+  "gemini-3-pro": { exp: 4, iq: 5, eff: "Gemini 3 Pro - top-tier reasoning, 1M context.", best: "Hard bugs, architecture, complex reasoning.", ctx: "1M" },
+  "gemini-3-pro-preview": { exp: 4, iq: 5, eff: "Preview of Gemini 3 Pro - top-tier reasoning, 1M context.", best: "Complex reasoning + architecture (preview).", ctx: "1M" },
+  "gemini-3.5-flash": { exp: 1, iq: 3, eff: "Fast, cost-efficient Gemini 3.5 Flash; 1M context.", best: "Quick edits, lookups, high-volume long-context tasks.", ctx: "1M" },
+  "gemini-3-flash": { exp: 1, iq: 3, eff: "Fast, cost-efficient Gemini 3 Flash; 1M context.", best: "Quick edits, lookups, high-volume tasks.", ctx: "1M" },
+  "gemini-3-flash-preview": { exp: 1, iq: 3, eff: "Preview of Gemini 3 Flash - fast + cheap; 1M context.", best: "Quick edits + high-volume tasks (preview).", ctx: "1M" },
+  "gemini-3.1-flash-image": { exp: 2, iq: 3, eff: "Gemini 3.1 Flash with image generation; 1M context.", best: "Fast multimodal + image-generation tasks.", ctx: "1M" },
+  "gemini-3.1-flash-lite": { exp: 1, iq: 3, eff: "Lightest, fastest Gemini; 1M context.", best: "High-volume, latency-sensitive tasks.", ctx: "1M" },
+  "gemini-3.1-flash-lite-preview": { exp: 1, iq: 3, eff: "Preview of the lightest, fastest Gemini; 1M context.", best: "High-volume, latency-sensitive tasks (preview).", ctx: "1M" },
+  "gemini-2.5-pro": { exp: 3, iq: 4, eff: "Gemini 2.5 Pro - strong balanced reasoning; 1M context.", best: "Long-context reasoning and everyday Pro work.", ctx: "1M" },
+  "gemini-2.5-flash": { exp: 1, iq: 3, eff: "Fast, cheap Gemini 2.5 Flash; 1M context.", best: "High-volume long-context work.", ctx: "1M" },
   // AskSage · RAG
   "rag": { exp: 3, iq: 4, eff: "Dataset-grounded answers with citations - only as good as your selected datasets.", best: "Questions over your selected knowledge bases.", ctx: "256K" },
 };
@@ -4455,7 +4470,9 @@ const FAMILY_LABEL: Record<string, string> = { claude: "Anthropic Claude", gemin
 function inferModelInfo(value: string): ModelInfo {
   const s = stripProvider(value).toLowerCase();
   const fam = familyOf(value).id;
-  const small = /mini|nano|lite|flash|haiku|oss|-8b|-7b/.test(s);
+  // `\bmini` (word boundary) so "ge·mini" no longer false-matches as small (it was downgrading EVERY
+  // inferred Gemini - incl. the Pro tiers - to 3 stars); "-mini" in gpt-5-mini etc. still matches.
+  const small = /\bmini|nano|lite|flash|haiku|oss|-8b|-7b/.test(s);
   const big = !small && /opus|pro|max|fable|mythos|ultra|gpt-5|gpt-o/.test(s);
   const iq = big ? 5 : small ? 3 : 4;
   const exp = big ? 4 : small ? 1 : 3;

--- a/desktop/renderer/styles.css
+++ b/desktop/renderer/styles.css
@@ -1658,10 +1658,13 @@ body.resizing .sidebar,body.resizing .inspector{transition:none}
 @keyframes setSkelSweep{0%{background-position:180% 0}100%{background-position:-80% 0}}
 /* shared skeleton keyframe kept available for other units' skeletons */
 @keyframes shimmer{0%{background-position:200% 0}100%{background-position:-200% 0}}
-.set-note{font-size:11.5px;color:var(--txt-3);line-height:1.6;display:flex;gap:7px;align-items:flex-start;
-  background:var(--bg-2);border:1px solid var(--line-soft);border-radius:9px;padding:11px 12px;margin-top:6px;
+/* Block (not flex): the leading icon is absolutely positioned in the left pad so the body text +
+   any number of inline <b>/<code>/buttons flow + wrap as normal prose. (A flex row turned each <b>
+   into its own column - see the More providers + MCP notes.) */
+.set-note{font-size:11.5px;color:var(--txt-3);line-height:1.6;position:relative;
+  background:var(--bg-2);border:1px solid var(--line-soft);border-radius:9px;padding:11px 12px 11px 31px;margin-top:6px;
   box-shadow:var(--emboss,inset 0 1px 0 rgba(255,255,255,.02))}
-.set-note .ic{color:var(--green);flex:none;margin-top:1px}
+.set-note>.ic:first-child{color:var(--green);position:absolute;left:11px;top:12px}
 .set-note.ok{color:var(--txt-2);border-color:color-mix(in srgb,var(--green) 30%,var(--line-soft));
   background:color-mix(in srgb,var(--green-dim) 60%,var(--bg-2))}
 .set-note code{font-family:var(--mono);color:var(--accent-2);font-size:11px}

--- a/desktop/scripts/demo_p_about_1.ts
+++ b/desktop/scripts/demo_p_about_1.ts
@@ -22,8 +22,8 @@ console.log("== P-ABOUT.1 — About panel + dynamic version ==");
 const pkg = JSON.parse(readFileSync(join(import.meta.dir, "..", "package.json"), "utf8")) as { version: string };
 if (pkg.version !== APP_VERSION) fail(`desktop/package.json (${pkg.version}) and version.ts (${APP_VERSION}) drifted`);
 ok(`version single-sourced: version.ts === desktop/package.json === ${APP_VERSION}`);
-if (APP_VERSION !== "1.8.8") fail(`app version must be 1.8.8, got ${APP_VERSION}`);
-ok("app version is v1.8.8");
+if (APP_VERSION !== "1.8.9") fail(`app version must be 1.8.9, got ${APP_VERSION}`);
+ok("app version is v1.8.9");
 
 // 2. The panel surfaces identity, company, license, and the live version (no hardcoded duplicate).
 const html = aboutHtml(APP_VERSION);
@@ -43,7 +43,7 @@ for (const [label, needle] of must) {
 }
 
 // The version is interpolated, never hardcoded in the markup — bumping version.ts moves the UI.
-if (aboutHtml("9.9.9").includes("v1.8.8")) fail("version is hardcoded in the markup");
+if (aboutHtml("9.9.9").includes("v1.8.9")) fail("version is hardcoded in the markup");
 ok("version is interpolated (dynamic), not hardcoded");
 
 // 3. The animated rail glyph matches the 24×24 / 1.6-stroke icon family and has the twinkle hook.

--- a/desktop/version.ts
+++ b/desktop/version.ts
@@ -8,5 +8,6 @@
 // MIRRORS this string (electron's app.getVersion() / electron-builder read package.json);
 // version.test.ts asserts the two stay equal, so a bump in one is forced into the other.
 //
-// Launch baseline: v1.8.7. Bumped to v1.8.8 (role onboarding + guided tour, providers reorg).
-export const APP_VERSION = "1.8.8";
+// Launch baseline: v1.8.7. v1.8.8 = role onboarding + tour + providers reorg.
+// v1.8.9 = Perplexity→Providers, set-note readability, Gemini model cards, macOS .pkg/cask.
+export const APP_VERSION = "1.8.9";


### PR DESCRIPTION
Follows up #155 (already merged) with UI/model fixes, then bumps to **v1.8.9**.

## Providers
- **Perplexity** (U.S.-based) moved from More providers into the **U.S.-frontier Providers** section → ChatGPT, Gemini, Anthropic, xAI Grok, Perplexity. Removed from the More-providers warning copy.

## `.set-note` readability (More providers + MCP notes)
- The note was `display:flex`, so each inline `<b>` became its own squeezed **column** (the garbled text in the screenshots). Now a **block** with the leading icon absolutely positioned, so text + any number of `<b>`/`<code>`/buttons flow and wrap as normal prose. Fixes every `.set-note` at once.

## Gemini model picker cards
- Root cause: `inferModelInfo`'s small-tier regex `/mini|…/` matched the **"mini" inside "ge·mini"**, downgrading **every** inferred Gemini (including the Pro tiers) to 3★.
- Fix: `\bmini` (word boundary) — `-mini` in `gpt-5-mini` still matches, `gemini` no longer does.
- Added curated entries for the direct Antigravity/CLI lineup: **3.x Pro = 5★ / exp 4**, Flash·Lite = 3★, **2.5 Pro = 4★**, each with a proper blurb + 1M context.

## v1.8.9
- Single-sourced bump (`version.ts` + `package.json`; tests + about demo updated). This release also carries the **macOS `.pkg`/Homebrew cask** fix from #155 (CI-verified green incl. the mac `.pkg` build).

## Verified
- Desktop **709/0**, root typecheck clean, license clean.
- Live in preview: Perplexity in Providers; both notes read as prose; `3.1 Pro / 3.1 Pro Preview / 3 Pro / 3 Pro Preview = 5★`, `2.5 Pro = 4★`, Flash/Lite = 3★.

🤖 Generated with [Claude Code](https://claude.com/claude-code)