### PR TITLE
fix(preview): readable empty-state in the preview panel

### DIFF
--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -251,7 +251,7 @@ function buildShell(): void {
         </div>
         <div class="preview-body" id="prevBody">
           <iframe id="prevFrame" class="preview-frame" sandbox="allow-scripts allow-forms" referrerpolicy="no-referrer" title="App preview" hidden></iframe>
-          <div class="empty preview-empty" id="prevEmpty">Open a local HTML file to preview it here - paste its path above and press <b>Open</b>. (The agent driving this itself is coming next; remote URLs are egress-gated.)</div>
+          <div class="empty preview-empty" id="prevEmpty"><span class="preview-empty-msg" id="prevEmptyMsg">Open a local HTML file to preview it here - paste its path above and press <b>Open</b>. (The agent driving this itself is coming next; remote URLs are egress-gated.)</span></div>
         </div>
       </aside>
     </div>
@@ -1915,7 +1915,9 @@ function loadPreview(target: string): void {
     frame.src = encodeURI(r.src); frame.hidden = false; empty.hidden = true;
   } else {
     frame.removeAttribute("src"); frame.hidden = true; empty.hidden = false;
-    empty.textContent = r.kind === "remote"
+    // Set the message on the inner span (not the flex container) so its width/contrast styling persists.
+    const msg = ($("#prevEmptyMsg") as HTMLElement | null) ?? empty;
+    msg.textContent = r.kind === "remote"
       ? `Remote URLs are egress-gated and not previewed yet (P-PREVIEW.3): ${r.label}`
       : `Can't preview that - ${r.reason ?? "open a local HTML file"}.`;
   }

--- a/desktop/renderer/styles.css
+++ b/desktop/renderer/styles.css
@@ -1456,7 +1456,11 @@ body.resizing .sidebar,body.resizing .inspector{transition:none}
 .preview-body{flex:1;min-height:0;position:relative;display:flex;background:var(--bg-0)}
 .preview-frame{flex:1;min-width:0;border:0;background:#fff}
 .preview-frame[hidden]{display:none}
-.preview-empty{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;text-align:center;padding:0 36px;color:var(--txt-4);font-size:13px;line-height:1.6}
+/* The flex container only CENTERS; the message lives in one inline child so its text + <b> never split into
+   separate flex items (that put "Open" alone in the middle). Brighter than --txt-4 + capped width for reading. */
+.preview-empty{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;padding:0 36px}
+.preview-empty-msg{max-width:46ch;text-align:center;color:var(--txt-2);font-size:13px;line-height:1.65}
+.preview-empty-msg b{color:var(--txt);font-weight:600}
 .preview-shot{flex-direction:column;align-items:flex-start;gap:6px}
 .preview-shot-img{max-width:100%;border:1px solid var(--line);border-radius:8px;margin-top:4px}
 .kg-tools{display:flex;align-items:center;gap:10px}


### PR DESCRIPTION
## What

Fixes the unreadable empty-state you flagged (screenshot: the copy split with **Open** floating alone in the middle).

**Cause:** `.preview-empty` was `display:flex`, so the message text and its `<b>Open</b>` became *separate flex items* in a row.

## Fix

- Wrap the message in a single inline `<span>` (`#prevEmptyMsg`) → the flex container has one child, and **Open** renders inline within the sentence.
- The flex container now only centers; the span carries the text styling: brighter (`--txt-2`, was the dim `--txt-4`), bold **Open** at full `--txt`, capped width (46ch), comfortable line-height.
- `loadPreview` sets the message on the inner span, so the remote/blocked states keep the same readable styling.

## Verification

- **Live DOM-verified** in the dev server: empty-state is now a single centered child (not split), **Open** inline, brighter color, capped width — screenshot in thread.
- `app.ts` typecheck clean.

Small CSS/markup follow-up to P-PREVIEW.1 (ADR-0096) — no contract or logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)