### PR TITLE
fix(desktop): bundle typescript so packaged app starts (v1.9.0 blank-window hotfix)

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -65,7 +65,6 @@
           "!node_modules/onnxruntime-node/**",
           "!node_modules/onnxruntime-web/**",
           "!node_modules/@opentelemetry/**",
-          "!node_modules/typescript/**",
           "!node_modules/date-fns/**",
           "!node_modules/lucide-react/**"
         ]


### PR DESCRIPTION
## Problem
v1.9.0 installs fail to start: **"LucidAgentIDE could not start its local engine"** with a blank window. The background server never binds port 5319.

## Root cause
v1.9.0 added [`desktop/symbol_graph.ts`](../blob/master/desktop/symbol_graph.ts) (P-KG-SYM.1, AST symbol graph), which does a top-level `import ts from "typescript"`. [`desktop/dev.ts`](../blob/master/desktop/dev.ts) imports that module at the top of its graph, so a missing `typescript` crashes the **entire** engine on boot.

`desktop/package.json`'s `extraResources` filter excluded `node_modules/typescript/**` (an installer-size trim from before this feature existed), so the packaged app shipped without it. It never reproduced in the dev repo, which always has the full `node_modules`.

## Fix
Remove the `!node_modules/typescript/**` exclusion so the packaged bundle includes it.

## Verification
- Reproduced the exact crash by running the **installed** app's bundled bun + repo: `error: Cannot find package 'typescript' from ...symbol_graph.ts`.
- Copied `typescript` into the installed bundle → server binds 5319 and returns HTTP 200. Fix confirmed on a real install.
- Verified the other excluded packages (onnxruntime-node/web, @opentelemetry, date-fns, lucide-react) have **no** first-party runtime imports, so they stay excluded.

## Follow-up (separate)
Harden `symbol_graph.ts` to lazy-load the TS compiler so one optional feature dep can never brick the whole engine again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)