### PR TITLE
release: v1.9.2 — battery-aware performance epic (ADR-0129..0132)

### DIFF
--- a/desktop/about.test.ts
+++ b/desktop/about.test.ts
@@ -15,8 +15,8 @@ describe("version is single-sourced", () => {
     expect(pkg.version).toBe(APP_VERSION);
   });
 
-  test("app version is v1.9.0", () => {
-    expect(APP_VERSION).toBe("1.9.0");
+  test("app version is v1.9.2", () => {
+    expect(APP_VERSION).toBe("1.9.2");
   });
 });
 
@@ -25,7 +25,7 @@ describe("aboutHtml", () => {
 
   test("shows the dynamic version with a v prefix", () => {
     expect(html).toContain(`v${APP_VERSION}`);
-    expect(html).toContain("v1.9.0");
+    expect(html).toContain("v1.9.2");
   });
 
   test("carries the product + company identity", () => {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lucidagentide-desktop",
   "private": true,
-  "version": "1.9.0",
+  "version": "1.9.2",
   "trustedDependencies": ["electron", "@resvg/resvg-js"],
   "description": "Electron desktop shell for LucidAgentIDE + omp — gated agent chat + live security/memory dashboards.",
   "homepage": "https://github.com/mlcyclops/lucidagentide",

--- a/desktop/version.ts
+++ b/desktop/version.ts
@@ -95,4 +95,12 @@
 //   • CODE KNOWLEDGE GRAPH (ADR-0127/0128): ingest the workspace into a file-import OR TypeScript-AST symbol
 //     graph in the KG canvas (click a node → open the file in the IDE), with a level-picker and an opt-in
 //     read-only `codegraph_query` tool the AGENT can call to get blast-radius instead of reading many files.
-export const APP_VERSION = "1.9.0";
+// v1.9.1  = tag-only hotfix release (the #192 typescript-bundle fix so the packaged app starts); the in-repo
+//           version strings were not bumped for it - reconciled here.
+// v1.9.2  = battery-aware PERFORMANCE epic (ADR-0129..0132, #193): power/spec-aware render tiers (on battery
+//           the KG goes calm/capped; LOW battery pauses the visualization - the agent's knowledge access is
+//           never gated) + a #kgPerf mode chip; KG layout continuity (re-open = static paint, 0 sim frames)
+//           + kinetic-energy early settle (~87% of the O(n²) budget skipped); incremental session index
+//           (warm sidebar polls parse NOTHING) + tail-first transcript pages ("last N of M") + AC-only
+//           idle prefetch; optimistic model switch + write-behind lastModel + memoized settings load/picker.
+export const APP_VERSION = "1.9.2";


### PR DESCRIPTION
Version bump for the perf epic merged in #193.

- `APP_VERSION` + `desktop/package.json` → **1.9.2** (single-source contract; `about.test.ts` assertions updated).
- `version.ts` changelog documents **v1.9.1** as the tag-only #192 hotfix (its bump was never reconciled in-repo) and **v1.9.2** as the battery epic: power/spec-aware render tiers, KG layout continuity + energy-based settle, incremental session index + tail-first transcripts + AC-only prefetch, optimistic model switch + write-behind lastModel + memoized load/picker.

After merge: tag `v1.9.2` on master → the *Build desktop installers* workflow attaches mac/win/linux installers to the release.