### PR TITLE
fix(agent): commit secret_guard.ts — .gitignore *secret* rule was hiding the guardrail source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ lucid-gui.json
 *secret*
 *credentials*
 **/auth.json
+# ...but these are first-party SOURCE files (the Agent Builder secret guardrail), not secrets:
+!**/secret_guard.ts
+!**/secret_guard.test.ts
 
 # desktop electron-builder output
 desktop/release/

--- a/harness/agent/secret_guard.test.ts
+++ b/harness/agent/secret_guard.test.ts
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 TechLead 187 LLC
+// SPDX-License-Identifier: BUSL-1.1
+
+// harness/agent/secret_guard.test.ts — P-AGENT.8 (ADR-0134): the secret guardrail (no credential can ride
+// inside an agent). High-signal: declared SecretRefs + env-var NAMES + ordinary prose stay clean.
+
+import { test, expect, describe } from "bun:test";
+import { scanSpecForSecrets, assertSecretFree } from "./secret_guard.ts";
+import { newSpecId, SPEC_VERSION, type AgentSpec } from "./spec.ts";
+
+function spec(over: Partial<AgentSpec> = {}): AgentSpec {
+  return {
+    spec_id: newSpecId(),
+    spec_version: SPEC_VERSION,
+    name: "gov-bd",
+    description: "search for DoD opportunities and log them to Salesforce",
+    persona: "You help with business development.",
+    mode: "built-agent",
+    tools: ["web_search"],
+    egress: ["*.salesforce.com", "*.govwin.com"],
+    // DECLARED secret refs (names only — this is the CORRECT way): must stay clean.
+    secrets: [
+      { name: "SALESFORCE_API_TOKEN", kind: "apikey", purpose: "Salesforce REST API; generate under Setup → API" },
+      { name: "GOVWIN_PASSWORD", kind: "basic", purpose: "your GovWin login password" },
+    ],
+    nodes: [{ id: "a", kind: "prompt", label: "Plan", prompt: "Plan the search using SALESFORCE_API_TOKEN from the vault." }],
+    edges: [],
+    selfEdit: "individual",
+    created_at: 1,
+    updated_at: 1,
+    ...over,
+  };
+}
+
+describe("scanSpecForSecrets (P-AGENT.8) — clean cases stay clean", () => {
+  test("a spec that DECLARES secret refs (names only) has no leaks", () => {
+    expect(scanSpecForSecrets(spec())).toEqual([]);
+  });
+  test("env-var-style ref names and ordinary prose don't false-positive", () => {
+    const s = spec({
+      persona: "Read the official docs to help the user generate an API token. Store it in the vault, never in chat.",
+      nodes: [{ id: "a", kind: "prompt", label: "Connect", prompt: "Use GOVWIN_PASSWORD and SALESFORCE_API_TOKEN from the vault." }],
+    });
+    expect(scanSpecForSecrets(s)).toEqual([]);
+  });
+});
+
+describe("scanSpecForSecrets (P-AGENT.8) — apparent secret VALUES are caught", () => {
+  test("a PEM private key in the persona is flagged", () => {
+    const leaks = scanSpecForSecrets(spec({ persona: "key:\n-----BEGIN RSA PRIVATE KEY-----\nMIIEabc\n-----END RSA PRIVATE KEY-----" }));
+    expect(leaks.length).toBeGreaterThan(0);
+    expect(leaks[0]!.pattern).toContain("PEM");
+    expect(leaks[0]!.where).toBe("persona");
+  });
+  test("an AWS access key in a node prompt is flagged", () => {
+    const leaks = scanSpecForSecrets(spec({ nodes: [{ id: "a", kind: "prompt", label: "x", prompt: "use AKIAIOSFODNN7EXAMPLE to sign" }] }));
+    expect(leaks.some((l) => l.pattern.includes("AWS"))).toBe(true);
+  });
+  test("an sk- style key is flagged", () => {
+    const leaks = scanSpecForSecrets(spec({ description: "the key is sk-abcdEFGH1234567890ijklMNOP" }));
+    expect(leaks.some((l) => l.pattern.includes("OpenAI/Anthropic"))).toBe(true);
+  });
+  test("an inline `password: <value>` assignment is flagged", () => {
+    const leaks = scanSpecForSecrets(spec({ description: "login with password: hunter2SuperSecret" }));
+    expect(leaks.some((l) => l.pattern.includes("credential assignment"))).toBe(true);
+  });
+  test("the snippet is redacted (never the full secret)", () => {
+    const leaks = scanSpecForSecrets(spec({ description: "sk-abcdEFGH1234567890ijklMNOP" }));
+    expect(leaks[0]!.snippet).toContain("redacted");
+    expect(leaks[0]!.snippet).not.toContain("ijklMNOP");
+  });
+});
+
+describe("assertSecretFree (P-AGENT.8)", () => {
+  test("does not throw for a clean spec (declared refs only)", () => {
+    expect(() => assertSecretFree(spec())).not.toThrow();
+  });
+  test("throws for a spec that embeds a secret, pointing the user to the vault", () => {
+    expect(() => assertSecretFree(spec({ persona: "token: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345" }))).toThrow(/vault/);
+  });
+});

--- a/harness/agent/secret_guard.ts
+++ b/harness/agent/secret_guard.ts
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 TechLead 187 LLC
+// SPDX-License-Identifier: BUSL-1.1
+
+// harness/agent/secret_guard.ts — P-AGENT.8 (ADR-0134): the SECRET guardrail for the conversational Agent
+// Builder. The user's #1 rule: the agent must NEVER collect or embed a secret VALUE in an agent — credentials
+// live only in the OS-encrypted vault (desktop/cred_vault.ts), referenced by name (SecretRef).
+//
+// `scanSpecForSecrets` inspects every piece of FREE TEXT in a spec (name/description/persona/node
+// labels+prompts + secret `purpose` help-text) for APPARENT secret values: PEM private keys, vendor API-key
+// shapes (AWS/OpenAI-style/GitHub/Slack/Google), bearer tokens, and `password/secret/token = <value>`
+// assignments. `assertSecretFree` throws on any hit — wired into save/compile/open so a spec carrying a
+// credential can NEVER be persisted, compiled, or run. High-signal patterns only (declared SecretRefs, env-var
+// NAMES, and ordinary prose stay clean — proven by the tests).
+
+import type { AgentSpec } from "./spec.ts";
+
+export interface SecretLeak {
+  where: string; // which field the apparent secret was found in
+  pattern: string; // which detector fired (human label)
+  snippet: string; // a short, REDACTED excerpt (first few chars only) for the message — never the full secret
+}
+
+interface Detector {
+  label: string;
+  re: RegExp;
+}
+
+// Each detector is high-precision: it matches shapes that are almost always real credentials, not prose.
+const DETECTORS: Detector[] = [
+  { label: "PEM private key", re: /-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----/ },
+  { label: "AWS access key id", re: /\bAKIA[0-9A-Z]{16}\b/ },
+  { label: "OpenAI/Anthropic-style key", re: /\bsk-[A-Za-z0-9_-]{20,}\b/ },
+  { label: "GitHub token", re: /\bgh[pousr]_[A-Za-z0-9]{20,}\b/ },
+  { label: "Slack token", re: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/ },
+  { label: "Google API key", re: /\bAIza[0-9A-Za-z_-]{20,}\b/ },
+  { label: "bearer token", re: /\bBearer\s+[A-Za-z0-9._-]{20,}\b/i },
+  // `password: hunter2secret` / `api_key = abc123def456...` — a credential-ish key with a non-trivial value.
+  { label: "inline credential assignment", re: /\b(?:pass(?:word|wd)?|secret|api[_-]?key|api[_-]?token|access[_-]?token|client[_-]?secret|auth[_-]?token)\b\s*[:=]\s*["']?[^\s"'{}<>]{8,}/i },
+];
+
+/** Every free-text field in a spec, tagged with where it came from. Tool names / ids / ref NAMES are excluded
+ *  (identifiers, not free text — and a ref name like SALESFORCE_API_TOKEN must NOT trip the guardrail). */
+function specTextFields(spec: AgentSpec): Array<{ where: string; text: string }> {
+  const out: Array<{ where: string; text: string }> = [];
+  const add = (where: string, text: unknown) => { if (typeof text === "string" && text) out.push({ where, text }); };
+  add("name", spec.name);
+  add("description", spec.description);
+  add("persona", spec.persona);
+  for (const n of spec.nodes ?? []) {
+    add(`node ${n.id} label`, n.label);
+    add(`node ${n.id} prompt`, n.prompt);
+  }
+  for (const r of spec.secrets ?? []) add(`secret ${r.name} purpose`, r.purpose); // help-text only; the NAME is skipped
+  return out;
+}
+
+/** Scan a spec for APPARENT embedded secret values. Returns one leak per (field, detector) hit; empty = clean. */
+export function scanSpecForSecrets(spec: AgentSpec): SecretLeak[] {
+  const leaks: SecretLeak[] = [];
+  for (const { where, text } of specTextFields(spec)) {
+    for (const d of DETECTORS) {
+      const m = d.re.exec(text);
+      if (m) leaks.push({ where, pattern: d.label, snippet: `${m[0].slice(0, 6)}…(redacted)` });
+    }
+  }
+  return leaks;
+}
+
+/** Throw (fail-closed) if the spec embeds any apparent secret. Wired into save/compile/open/run so a
+ *  credential can never ride along inside an agent. */
+export function assertSecretFree(spec: AgentSpec): void {
+  const leaks = scanSpecForSecrets(spec);
+  if (leaks.length === 0) return;
+  const where = leaks.map((l) => `${l.where} (${l.pattern})`).join(", ");
+  throw new Error(
+    `refusing: this agent appears to embed a secret in ${where}. Secrets must go in the LUCID credential vault, ` +
+      `not in the agent — declare a credential name (SecretRef) and add the value in the vault instead.`,
+  );
+}


### PR DESCRIPTION
## Hotfix for master (follow-up to #195)

The Agent Builder's load-bearing **secret guardrail** (`harness/agent/secret_guard.ts` + `.test.ts`) was never tracked by git: the security-hygiene rule `*secret*` in `.gitignore` matched the legitimate first-party source, so `git add -A` silently skipped it in every session. Local test runs passed only because the file existed in the working tree — it was in **no commit**, so it was absent from master after #195, **breaking the build**: `compiler.ts`, `spec.ts`, `store.ts`, `file_store.ts`, `handoff.ts`, and `demo_p_agent_8_1.ts` all import `assertSecretFree`/`scanSpecForSecrets` from it.

## Fix
- Add a **narrow** `.gitignore` negation (`!**/secret_guard.ts`, `!**/secret_guard.test.ts`) that keeps the broad `*secret*` guard intact for real secret files.
- Commit the two source files (BUSL-headered, ADR-0134).

## Verification
Root typecheck clean; the 9 `secret_guard` tests pass. This restores the keystone security invariant (a credential can never be compiled, saved, or run inside a built agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)