### PR TITLE
fix(security): close CodeQL alerts — incomplete sanitization (HIGH) + missing origin check

### DIFF
--- a/extensions/vscode/media/chat.js
+++ b/extensions/vscode/media/chat.js
@@ -46,9 +46,9 @@
   // ── extension → webview ───────────────────────────────────────────────────────
   window.addEventListener("message", (e) => {
     // js/missing-origin-check (CWE-345): only trust messages from the VS Code extension host, which
-    // arrive on the webview's own `vscode-webview://` origin. Reject anything from an injected
-    // cross-origin frame before acting on it. (Older hosts may deliver an empty origin — allow that.)
-    if (e.origin && !e.origin.startsWith("vscode-webview://")) return;
+    // arrive on the webview's own `vscode-webview://` origin. Reject anything else — an injected
+    // cross-origin frame OR a message with no/empty origin — before touching e.data.
+    if (!e.origin || !e.origin.startsWith("vscode-webview://")) return;
     const m = e.data;
     switch (m.type) {
       case "ready": banner.hidden = true; break;

--- a/harness/brief/compliance.test.ts
+++ b/harness/brief/compliance.test.ts
@@ -59,6 +59,16 @@ describe("compliance crosswalk (P-REPORT.6)", () => {
     expect(md).toContain("**Rollup:**");
   });
 
+  test("table cell escapes backslashes AND pipes so a title can't break the columns (js/incomplete-sanitization)", () => {
+    const u: EngineeringUpdate = {
+      label: "TestRepo", loadBearingDependencies: [], techDebt: [], upcomingDecisions: [], risks: [],
+      recentlyShipped: [{ title: "Harden credential vault path C:\\keys | tokens", detail: "x", source: "PROGRESS.md" }],
+    };
+    const md = renderComplianceSection(u);
+    expect(md).toContain("C:\\\\keys");  // `\` escaped to `\\` (FIRST) so a trailing backslash can't eat the delimiter
+    expect(md).toContain("\\| tokens");  // `|` escaped to `\|` so it renders in-cell instead of splitting columns
+  });
+
   test("POA&M CSV has the eMASS headers, one row per mapped item, escaped", () => {
     const csv = renderPoamCsv(U, "TestRepo");
     const lines = csv.split("\r\n");

--- a/harness/brief/compliance.ts
+++ b/harness/brief/compliance.ts
@@ -123,7 +123,9 @@ export function renderComplianceSection(u: EngineeringUpdate): string {
   if (!rows.length) { out.push("_No security-relevant changes mapped to a control this cycle._", ""); return out.join("\n"); }
   out.push("| Change | Disposition | 800-171 | 800-53 | STIG CCIs |", "|---|---|---|---|---|");
   for (const r of rows) {
-    const title = plainTitle(r.item.title).replace(/\|/g, "\\|");
+    // Escape backslashes FIRST, then pipes — otherwise a title ending in `\` would turn the cell
+    // delimiter into an escaped `\|` and merge columns (js/incomplete-sanitization).
+    const title = plainTitle(r.item.title).replace(/\\/g, "\\\\").replace(/\|/g, "\\|");
     out.push(`| ${title} | ${r.disposition} | ${r.nist800171.join(", ")} | ${r.nist80053.join(", ")} | ${r.ccis.join(", ")} |`);
   }
   out.push("");


### PR DESCRIPTION
Resolves two open CodeQL code-scanning alerts with real fixes.

### #39 — `js/incomplete-sanitization` (HIGH) · `harness/brief/compliance.ts`
The compliance-crosswalk markdown table escaped `|` as `\|` but did **not** escape pre-existing backslashes first. A change title ending in `\` would produce `\|` at the cell boundary — an *escaped* pipe — and silently merge table columns (and could be abused to inject cells). Now escapes `\` → `\` **first**, then `|` → `\|`. Added a regression test asserting both are escaped.

### #38 — `js/missing-origin-check` · `extensions/vscode/media/chat.js`
The webview's `message` handler checked the origin as `if (e.origin && !e.origin.startsWith("vscode-webview://")) return;` — the `e.origin &&` short-circuit let a message with an **empty** origin through, so CodeQL (correctly) saw an unguarded path to `e.data`. Now requires the origin to be present **and** on the `vscode-webview://` scheme before touching the payload. VS Code always sets that origin for extension→webview messages, so this is stricter without a functional regression.

### Not in this PR — #49 `js/http-to-file-access` (`desktop/dev.ts`)
The Figma-import write is network-data-to-file **by design** (it caches Figma frame renders into a local board file) and is already mitigated on master: https-only fetch (SSRF guard), an 8 MB/frame size cap (DoS guard), HTML-escaped output via `figmaBoardHtml`, and a regex-validated path. The residual taint is inherent to the feature — handled separately as a documented dismissal rather than a code change.

## Verification
- `bun test harness/brief/compliance.test.ts` green (8 pass incl. the new escaping test); root `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)