### PR TITLE
fix(demo): case-insensitive hostile-tag assertion (closes PR #223's CodeQL alert)

### DIFF
--- a/desktop/scripts/demo_p_toolfail_2.ts
+++ b/desktop/scripts/demo_p_toolfail_2.ts
@@ -55,7 +55,7 @@ ok("all 3 actions listed with reason + command attempted + detailed error");
 
 console.log("\n4) hostile output renders inert");
 const hostile = toolfailGroupHtml([{ tool: "<script>x</script>", reason: "<img src=x onerror=y>", command: "</code><script>z</script>", detail: "<iframe>" }], true);
-if (/<script>|<img |<iframe>/.test(hostile)) fail("unescaped hostile bytes reached the HTML");
+if (/<script|<img|<iframe/i.test(hostile)) fail("unescaped hostile bytes reached the HTML"); // case-insensitive prefix match (CodeQL js/bad-tag-filter)
 ok("tool/reason/command/detail all escaped");
 
 console.log("\n✓ P-TOOLFAIL.2 demo passed — benign probe failures are one quiet toolbox click away, never an alarm wall.");


### PR DESCRIPTION
## What

Closes the high-severity `js/bad-tag-filter` code-scanning alert raised on PR #223: the P-TOOLFAIL.2 demo's escaped-output assertion used `/<script>|<img |<iframe>/`, which misses case variants like `<SCRIPT>`. Now `/<script|<img|<iframe/i`.

Sanitization itself was never affected — escaping is `esc()`'s job and is covered by the unit tests; this regex is only the demo's tripwire that escaping happened.

## Verification

In a clean worktree of master + this change: `demo-P-TOOLFAIL.2` green (including uppercase hostile input against the real builders) and the 28 toolfail tests pass.