### PR TITLE
fix(reports): collapse the Repositories block into a chevron accordion on Generate

### DIFF
--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -5770,7 +5770,10 @@ function openReportsPanel(): void {
         <div class="goal-row" id="rpVoiceRow" hidden><label class="goal-lbl" for="rpVoice">Voice</label><select id="rpVoice" class="prov-key"><option value="">default voice</option></select></div>
         <div class="goal-eu-cost" id="rpCost" hidden></div>
         <div class="rp-repos" id="rpRepos">
-          <div class="rp-repos-h"><label class="goal-lbl">${icon("git", 12)} Repositories</label><span class="goal-opt">tick repos to fold their remote commits &amp; PRs into the report</span>
+          <div class="rp-repos-h" id="rpReposH" role="button" tabindex="0" aria-expanded="true" data-tip="Repositories|Click to collapse or expand. Collapses automatically after you generate a report so the snapshot below is in view.">
+            <span class="rp-chev" aria-hidden="true"><svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6"/></svg></span>
+            <label class="goal-lbl">${icon("git", 12)} Repositories</label><span class="goal-opt rp-repos-hint">tick repos to fold their remote commits &amp; PRs into the report</span>
+            <span class="rp-repos-count" id="rpReposCount"></span>
             <select id="rpRepoSort" class="rp-repo-sort" data-tip="Sort order|Order the repo list by most recent activity, or alphabetically by name"><option value="recent">Recent</option><option value="name">Name</option></select></div>
           <div class="rp-repo-list" id="rpRepoList"><div class="goal-opt">loading repos…</div></div>
           <div class="rp-repo-add">
@@ -5883,6 +5886,23 @@ function openReportsPanel(): void {
       (t as HTMLInputElement).checked ? repoPrs.add(path) : repoPrs.delete(path);
     }
   });
+  // Repositories accordion: collapse/expand, and auto-collapse after Generate so the report snapshot below
+  // comes into view (the count summarizes the selection while collapsed). The sort control never toggles it.
+  const reposEl = $("#rpRepos", ov) as HTMLElement;
+  const reposH = $("#rpReposH", ov) as HTMLElement;
+  const setReposCollapsed = (collapsed: boolean): void => {
+    reposEl.classList.toggle("collapsed", collapsed);
+    reposH.setAttribute("aria-expanded", String(!collapsed));
+    const n = repoChecked.size;
+    ($("#rpReposCount", ov) as HTMLElement).textContent = collapsed ? `${n} repo${n === 1 ? "" : "s"} selected` : "";
+  };
+  reposH.addEventListener("click", (e) => {
+    if ((e.target as HTMLElement).closest("select,input,button,a")) return;
+    setReposCollapsed(!reposEl.classList.contains("collapsed"));
+  });
+  reposH.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setReposCollapsed(!reposEl.classList.contains("collapsed")); }
+  });
   const addInput = $("#rpRepoAdd", ov) as HTMLInputElement;
   const addRepo = async (): Promise<void> => {
     const v = addInput.value.trim(); if (!v) return;
@@ -5993,6 +6013,7 @@ function openReportsPanel(): void {
   $("#rpGenerate", ov)?.addEventListener("click", async () => {
     const btn = $("#rpGenerate", ov) as HTMLButtonElement;
     const out = $("#rpResult", ov) as HTMLElement;
+    setReposCollapsed(true); // fold the repo picker so the report snapshot below is in view
     const role = ($("#rpRole", ov) as HTMLSelectElement).value;
     const provider = prov.value;
     // P-REPORT.9: gather the ticked repos + per-repo PR choice; a fetch checkbox gates the read-only sync.

--- a/desktop/renderer/styles.css
+++ b/desktop/renderer/styles.css
@@ -985,8 +985,17 @@ body.resizing .sidebar,body.resizing .inspector{transition:none}
 .rp-sec-exports .btn-mini{flex:1 1 auto;justify-content:center}
 /* P-REPORT.9 (ADR-0162): the multi-repo picker in the Reports panel */
 .rp-repos{display:flex;flex-direction:column;gap:7px;padding:9px;border:1px solid var(--line);border-radius:10px;background:var(--bg-2)}
-.rp-repos-h{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+.rp-repos-h{display:flex;align-items:center;gap:8px;flex-wrap:wrap;cursor:pointer;user-select:none;border-radius:7px;margin:-2px;padding:2px}
+.rp-repos-h:hover{background:color-mix(in srgb,var(--txt) 5%,transparent)}
+.rp-repos-h:focus-visible{outline:2px solid var(--accent-2);outline-offset:1px}
 .rp-repos-h .goal-lbl{display:flex;align-items:center;gap:5px;margin:0}
+.rp-chev{display:inline-flex;align-items:center;color:var(--txt-3);flex:none;transition:transform var(--t,.18s) ease}
+.rp-repos:not(.collapsed) .rp-chev{transform:rotate(180deg)} /* expanded → chevron up; collapsed → down */
+.rp-repos-count{font-size:11px;color:var(--txt-3)}
+.rp-repos:not(.collapsed) .rp-repos-count{display:none} /* the count is a collapsed-state summary */
+.rp-repos.collapsed{gap:0}
+.rp-repos.collapsed .rp-repo-list,.rp-repos.collapsed .rp-repo-add,.rp-repos.collapsed .rp-repo-fetch{display:none}
+.rp-repos.collapsed .rp-repos-hint{display:none} /* keep the collapsed header to one tidy line */
 .rp-repo-list{display:flex;flex-direction:column;gap:4px;max-height:168px;overflow:auto}
 .rp-repo{display:flex;align-items:center;gap:8px;padding:5px 8px;border:1px solid var(--line);border-radius:8px;background:var(--bg);transition:border-color .12s,background .12s}
 .rp-repo.on{border-color:var(--accent-2);background:color-mix(in srgb,var(--accent-2) 8%,var(--bg))}


### PR DESCRIPTION
## Repositories → collapsible accordion; auto-folds on Generate

**Problem:** in the Engineering Reports panel, the **Repositories** picker (repo list + add field + fetch checkbox) filled the left column, so the generated **report snapshot** below the Generate button was barely visible.

**Fix:** the Repositories block is now a collapsible accordion.
- A **downward chevron** in the header; **click** (or **Enter/Space**) toggles it.
- **Hitting Generate auto-collapses it**, so the report snapshot comes into view.
- Collapsed = one tidy header line: chevron (down) + "Repositories" + an **"N repos selected"** summary. Expanded = chevron up, full list.
- The **sort control** inside the header never toggles the accordion (click-guarded).
- a11y: `role="button"` + `tabindex` + `aria-expanded` + keyboard.

Small, self-contained: `desktop/renderer/app.ts` (markup + a `setReposCollapsed` toggle wired to the header + the Generate handler) and `desktop/renderer/styles.css` (`.rp-repos.collapsed` rules + chevron rotation + hover/focus).

### Verified live in the preview
Expand↔collapse both ways, auto-collapse on Generate, the count summary, chevron flip (up expanded / down collapsed), no console errors. Renderer `tsc` clean; desktop suite **979 pass / 5 fail** (the pre-existing Windows-only `listDir` failures, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)