### PR TITLE
release: v1.10.2 - the Trivia Wire + skills governance & compiled KB batch since 1.10.1

### DIFF
--- a/desktop/about.test.ts
+++ b/desktop/about.test.ts
@@ -15,8 +15,8 @@ describe("version is single-sourced", () => {
     expect(pkg.version).toBe(APP_VERSION);
   });
 
-  test("app version is v1.10.1", () => {
-    expect(APP_VERSION).toBe("1.10.1");
+  test("app version is v1.10.2", () => {
+    expect(APP_VERSION).toBe("1.10.2");
   });
 });
 
@@ -25,7 +25,7 @@ describe("aboutHtml", () => {
 
   test("shows the dynamic version with a v prefix", () => {
     expect(html).toContain(`v${APP_VERSION}`);
-    expect(html).toContain("v1.10.1");
+    expect(html).toContain("v1.10.2");
   });
 
   test("carries the product + company identity", () => {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lucidagentide-desktop",
   "private": true,
-  "version": "1.10.1",
+  "version": "1.10.2",
   "trustedDependencies": ["electron", "@resvg/resvg-js"],
   "description": "Electron desktop shell for LucidAgentIDE + omp — gated agent chat + live security/memory dashboards.",
   "homepage": "https://github.com/mlcyclops/lucidagentide",

--- a/desktop/version.ts
+++ b/desktop/version.ts
@@ -120,4 +120,13 @@
 //           (ADR-0162/0164), security review-ACKs + resumed-session history (ADR-0170/0171), a toolbox badge
 //           for failed tool calls (ADR-0163), the LUCID TUI theme + bare `lucid` (ADR-0160/0161), and the
 //           Plugin Marketplace popup (ADR-0158).
-export const APP_VERSION = "1.10.1";
+// v1.10.2 = the TRIVIA WIRE (P-TRIV.1-.3, ADR-0174/5/6): a role-aware word-game ticker in the status bar's
+//           idle gap - 100-question developer/security/manager banks + 50 executive, streak scoring, idle
+//           engagement, and the executive INTEL WIRE (curated defense/intel RSS, fetched first-party,
+//           scan-gated FAIL-CLOSED, host-only egress audit) interleaving live headlines between questions;
+//           status bar decluttered (model seg + gate-active pill removed, ticker text at chip white).
+//           Plus the SKILLS GOVERNANCE suite + compiled KNOWLEDGE BASE (P-SKILL.4/.5, P-SKILLREG.1/.2,
+//           P-KB.1/.2/.2b): the governed Skills directory + management menu, Skill Studio (draft skills
+//           from recent work, gated), the enterprise registry reader/publish seams (Ed25519 + scan-gate),
+//           and the compiled KB spine with graph migrations.
+export const APP_VERSION = "1.10.2";


### PR DESCRIPTION
Single-source version bump to **v1.10.2** (`desktop/version.ts` + `desktop/package.json`, lockstep enforced by `about.test.ts`).

## In this release (since v1.10.1)

- **The Trivia Wire** (P-TRIV.1-.3, ADR-0174/0175/0176, #241/#243): role-aware word-game ticker in the status bar's idle gap - 100-question developer/security/manager banks + 50 executive, streak scoring, idle engagement, and the executive **INTEL WIRE** (curated defense/intel RSS, first-party fetch, scan-gated fail-closed, host-only egress audit) interleaving live headlines between questions. Status bar decluttered.
- **Skills governance suite + compiled Knowledge Base** (P-SKILL.4/.5, P-SKILLREG.1/.2, P-KB.1/.2/.2b, #242): governed Skills directory + management menu, Skill Studio, enterprise registry reader/publish seams (Ed25519 + scan-gate), compiled KB spine + graph migrations.
- Engineering Reports accordion fix (#240).

After merge: tag `v1.10.2` triggers **Build desktop installers** (native mac/win/linux runners) and attaches all artifacts to the GitHub Release; electron-updater picks it up from `latest*.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)