### PR TITLE
feat(kg): fold Import/Export/CUI into a Data dropdown (P-KGUI.2, ADR-0185)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -12913,3 +12913,46 @@ menu showed "Code graph ✓"; toggling back returned the label to Personal.
 
 ADR-0158/0135 (popover + pure-builder conventions), ADR-0075 (relate mode, rewired not changed),
 ADR-0099/0100 (compiled-KB view), P-KG-CODE.1/P-KG-SYM.1 (code graph view).
+
+## ADR-0185 - P-KGUI.2: the Data dropdown (Import / Export / CUI fold into the menu pattern), BUILT
+
+**Date:** 2026-07-06
+**Status:** Accepted / Built + tested + verified live (menu opens, AI toggle persists across opens,
+all three actions route to the original handlers, CUI confirm intact).
+
+### Context
+
+The P-KGUI.1 follow-up, requested: Import history / Export vault / CUI archive (plus the
+AI-extraction checkbox tied to imports) still sat as three buttons + a label in the KG header. Fold
+them into a "Data" dropdown on the same pattern as the views menu.
+
+### Decision
+
+1. **`kg_header.kgDataMenuHtml(aiOn)`** (pure, tested): the three actions as self-describing menu
+   rows with stable `data-kgdata` handles - import explains the scan gate inline, export its
+   CUI-excluded boundary, the archive its 32 CFR 2002 / NARA framing; the CUI row keeps the danger
+   look. The shared `item` builder gained attr/class params (views menu unchanged).
+2. **The AI-extraction choice is module STATE**, not a live checkbox: the menu is transient DOM, so
+   `kgImportAiOn` renders the toggle each open and a `change` listener updates it - toggling never
+   closes the menu (the row carries no action handle), and the import flow reads the variable
+   (first-import-defaults-to-AI logic unchanged).
+3. **app.ts**: the three wire()-time listeners became named handlers (`kgImportHistory` /
+   `kgExportVault` / `kgCuiArchive`, bodies unchanged - same estimates, toasts, and the CUI confirm
+   with its danger action) invoked from `openKgDataMenu` (shared popover: outside-click/Esc close,
+   second click toggles). Header markup: one `#kgData` button whose hover tip says it's a dropdown
+   and lists the contents. The orphaned `.kg-ai` CSS removed; `.kgv-check`/`.kgv-danger` added.
+
+### Verified
+
+3 new kg_header tests (handles + inline copy, toggle-is-state-not-action + checked-follows-state,
+single danger row) - 8 total in the file. demo-P-KGUI.2 green. Root tsc clean. Full bun test 1914
+pass / 6 fail = the known Windows path-sep baseline. LIVE (worktree server): the old buttons and
+the AI label are gone (header stays one 51px row), "Data ▾" opened all four rows, flipping the AI
+toggle kept the menu open and the state survived close/reopen, Export ran the real flow (honest
+"Personalization is off or locked" on this fresh instance), and CUI raised its confirm toast
+(canceled).
+
+### Relates to
+
+ADR-0184 (P-KGUI.1 - the pattern + the follow-up note this fulfills), ADR-0034/0035 (the import
+flow, rewired not changed), ADR-0014 (CUI isolation the archive serves).

--- a/Makefile
+++ b/Makefile
@@ -604,3 +604,7 @@ demo-P-KGVIZ.1: ## P-KGVIZ.1 (ADR-0183): form in place - the KG/code-graph settl
 .PHONY: demo-P-KGUI.1
 demo-P-KGUI.1: ## P-KGUI.1 (ADR-0184): the KG header decluttered - title "KG" (hover: Knowledge Graph, icon dropped) and the Relate/Code-graph/Compiled-KB stack consolidated into ONE labeled dropdown (hover tip lists the options; the menu explains each inline; active view checked)
 	$(BUN) run desktop/scripts/demo_p_kgui_1.ts
+
+.PHONY: demo-P-KGUI.2
+demo-P-KGUI.2: ## P-KGUI.2 (ADR-0185): the Data dropdown - Import history / AI-extraction toggle / Export vault / CUI archive folded from three buttons + a checkbox into one self-describing menu; the AI toggle is remembered state (never closes the menu); CUI keeps its danger look + confirm toast
+	$(BUN) run desktop/scripts/demo_p_kgui_2.ts

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3237,3 +3237,8 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
 - **shipped:** the Relate / Code graph / Compiled KB triple stack is ONE labeled dropdown (`#kgViews`: label = the graph you're viewing, hover tip says it's a dropdown + lists the options, menu rows self-describe with the active view checked); title icon removed and "Knowledge graph" → "KG" with a Knowledge Graph hover; same handlers rewired (relate bar, level picker, re-sync icon all unchanged); pure `kg_header.ts` builders + 5 tests + demo-P-KGUI.1; verified live (one 51px header row, full dropdown flow, label/check tracking).
 - **stubbed:** the remaining header controls (search, lens seg, perf chip, AI toggle, Import/Export/CUI) stay as-is - they're single-height and were not the complaint.
 - **next:** if the header needs more room later, Import/Export/CUI could fold into the same dropdown pattern ("Data…" menu).
+
+**P-KGUI.2 - the Data dropdown in the KG header (ADR-0185)**
+- **shipped:** Import history / AI-extraction toggle / Export vault / CUI archive folded from three buttons + a checkbox into one "Data" dropdown (same pattern as the views menu): self-describing rows with stable data-kgdata handles, the AI choice as remembered module state (toggling never closes the menu), CUI keeps the danger look + confirm toast, handlers extracted unchanged; orphaned .kg-ai CSS removed. 3 new tests + demo-P-KGUI.2 green; verified live (one-row header, toggle persistence, real export/CUI flows).
+- **stubbed:** the header now has exactly two dropdowns (views + Data) - search, lens, perf chip stay as single controls by design.
+- **next:** none queued for the KG header; P-MARKET.2 / P-TRIV.4 / P-RAG.2 remain the open threads.

--- a/desktop/renderer/app.ts
+++ b/desktop/renderer/app.ts
@@ -33,7 +33,7 @@ import { renderMarkdown } from "./markdown.ts";
 import { type GraphHandle, kindLabel, mountGraph } from "./graph.ts";
 import { addEdgeOptimistic, applyForget, chainPairs, matchNodes, removeEdgeOptimistic, resolveRelationLabel } from "./kg_ops.ts";
 import { capGraph, graphOpts, pollDelay, watchPerfTier } from "./perf_tier.ts";
-import { kgViewActive, kgViewLabel, kgViewsMenuHtml } from "./kg_header.ts"; // P-KGUI.1 (ADR-0184)
+import { kgDataMenuHtml, kgViewActive, kgViewLabel, kgViewsMenuHtml } from "./kg_header.ts"; // P-KGUI.1/.2 (ADR-0184/0185)
 import { guardBlockedHtml, resourcePanelBodyHtml, resourcePanelHtml, type SystemStatusView } from "./system_guard.ts"; // P-SYSRES.1 (ADR-0182)
 import type { KbGraphView, PersonalGraphData } from "./bridge.ts";
 import { agentBuilderPanelHtml, specToGraphData, nodeEditorHtml, saveErrors, newCanvasSpec, runPanelHtml, secretsPanelHtml, agentInterviewPrompt, toolChipsHtml, trustBannerHtml, runApprovalHtml, runsPanelHtml, traceDetailHtml, schedulePanelHtml, historyPanelHtml, templatesPanelHtml } from "./agent_builder.ts"; // P-AGENT.2b/.4-live/.8/.9/.11a/.13/.14/.17
@@ -269,10 +269,7 @@ function buildShell(): void {
             <button class="btn-mini" id="kgPerf" data-tip="Performance mode|Auto adapts rendering to battery + CPU: on battery the graph goes calm (no particle flow, shorter settle, capped nodes); LOW battery pauses the visualization entirely - the agent still uses your knowledge. Click to cycle auto → full → reduced → minimal.">${icon("gauge", 13)} Auto</button>
             <button class="btn-mini" id="kgViews" data-tip="Graph views & tools · dropdown|Opens a menu with three options: Relate nodes (author your own relationships), Code graph (this workspace as a file/symbol graph), and Compiled KB (the knowledge base as a page graph). The label shows the graph you're viewing.">${icon("graph", 13)} <span id="kgViewsLbl">Personal</span> <span class="kgv-caret">▾</span></button>
             <button class="btn-mini btn-icon" id="kgCodeUpdate" data-tip="Re-sync the code graph|Re-ingest the workspace to pick up new files + import changes since the last build." hidden>${icon("refresh", 14)}</button>
-            <label class="kg-ai" data-tip="AI extraction|Use the model to pull richer facts + real relationships from each message, instead of the fast offline heuristic. Slower and uses model quota; capped at 500 messages per import. Leave off for a free, instant pass."><input type="checkbox" id="kgImportAI"/> AI</label>
-            <button class="btn-mini" id="kgImport" data-tip="Import chat history|Bring in a ChatGPT, Claude, or Gemini data export to seed your graph. Easiest: just pick the unzipped export FOLDER (a modern ChatGPT export has no single conversations.json - it ships conversations-000.json, -001.json … and we merge them for you) - or point at the .zip / conversations.json / MyActivity.json directly. Every message is scanned by the security gate before anything is learned; only your own messages teach the profile.">${icon("download", 13)} Import history</button>
-            <button class="btn-mini" id="kgExport" data-tip="Export Obsidian vault|Decrypt and write your Personal + Work knowledge to a portable Obsidian vault (notes, [[wikilinks]], escaped). CUI is excluded by design. The export is audited.">${icon("folder", 13)} Export vault</button>
-            <button class="btn-mini danger" id="kgCui" data-tip="CUI archive · National Archives|Export ONLY the CUI compartment into a CUI-marked, records-managed package with a SHA-256 manifest (32 CFR 2002 · NARA). For archive/records requirements. Audited.">${icon("shield", 13)} CUI archive</button>
+            <button class="btn-mini" id="kgData" data-tip="Data · dropdown|Opens a menu with: Import chat history (a ChatGPT / Claude / Gemini export - every message scanned before anything is learned), the AI-extraction toggle for imports, Export Obsidian vault (CUI excluded by design), and the CUI archive (records-managed, 32 CFR 2002 · NARA). Everything is audited.">${icon("folder", 13)} Data <span class="kgv-caret">▾</span></button>
             <button class="set-close" id="kgClose" data-tip="Close">${icon("close", 16)}</button>
           </div>
         </div>
@@ -2793,6 +2790,77 @@ function openKgViewsMenu(anchor: HTMLElement): void {
     if (v === "relate") setRelateMode(!kgRelateMode);
     else if (v === "code") void toggleCodeGraph();
     else if (v === "kb") void toggleKbGraph();
+  });
+}
+
+// P-KGUI.2 (ADR-0185): the Data dropdown - Import history / AI toggle / Export vault / CUI archive,
+// folded from three header buttons + a checkbox into the same menu pattern as the views dropdown.
+// The AI-extraction choice lives in module state (the menu is transient DOM, so a live checkbox
+// would be lost the moment it closes); toggling it never closes the menu.
+let kgDataPop: { close: () => void } | null = null;
+let kgImportAiOn = false;
+function openKgDataMenu(anchor: HTMLElement): void {
+  if (kgDataPop) { kgDataPop.close(); return; } // second click on the button = toggle closed
+  const p = popover(anchor, kgDataMenuHtml(kgImportAiOn), () => { kgDataPop = null; });
+  kgDataPop = p;
+  p.node.addEventListener("change", (ev) => {
+    const t = ev.target as HTMLInputElement | null;
+    if (t?.id === "kgImportAI") kgImportAiOn = t.checked;
+  });
+  p.node.addEventListener("click", (ev) => {
+    const it = (ev.target as HTMLElement).closest("[data-kgdata]") as HTMLElement | null;
+    if (!it) return; // the AI toggle row (a label) lands here - it must not close the menu
+    const v = it.dataset.kgdata;
+    p.close();
+    if (v === "import") void kgImportHistory();
+    else if (v === "export") void kgExportVault();
+    else if (v === "cui") kgCuiArchive();
+  });
+}
+async function kgImportHistory(): Promise<void> {
+  const folder = await openFolderBrowser({ title: "Choose your ChatGPT / Claude / Gemini export", confirm: "Import from here" });
+  if (!folder) return;
+  // Read-only pre-import estimate → warn about AI-mode token cost + runtime before the paid run.
+  const est = await bridge.personalImportEstimate(folder);
+  if (!est?.ok) { showToast({ tone: "danger", title: "Couldn't read that export", desc: est?.error ?? "No conversations found in that export.", actions: [{ label: "OK" }], timeout: 6000 }); return; }
+  // First import (empty graph) defaults to AI extraction (best quality); after that, honor the menu toggle.
+  const status = await bridge.personal();
+  const totalFacts = status?.counts ? status.counts.work + status.counts.personal + status.counts.cui : 0;
+  const aiDefault = totalFacts === 0 ? true : kgImportAiOn;
+  const { tokens, secs, overCap } = estimateAiImport(est);
+  const vendorName = est.vendor === "openai" ? "ChatGPT" : est.vendor === "anthropic" ? "Claude" : "Gemini";
+  const aiLine = `AI: ~${fmtNum(tokens)} tokens · ${fmtDur(secs)}${overCap ? ` (first ${AI_IMPORT_CAP} of ${fmtNum(est.userMessages ?? 0)} msgs)` : ""} · Quick: free + instant, lower quality. Estimate is approximate.`;
+  const aiBtn = { label: `AI extraction (${fmtDur(secs)})`, run: () => void runPersonalImport(folder, true) };
+  const quickBtn = { label: "Quick (free)", run: () => void runPersonalImport(folder, false) };
+  showToast({
+    title: `Import ${fmtNum(est.conversations ?? 0)} ${vendorName} conversations?`,
+    desc: `${fmtNum(est.userMessages ?? 0)} of your messages will seed your private, encrypted graph.`,
+    meta: aiLine,
+    tone: "warn",
+    actions: [...(aiDefault ? [aiBtn, quickBtn] : [quickBtn, aiBtn]), { label: "Cancel" }],
+    timeout: 0, // require an explicit choice (AI mode is paid + slow)
+  });
+}
+async function kgExportVault(): Promise<void> {
+  showToast({ title: "Exporting vault…", desc: "Decrypting and writing your Obsidian notes.", timeout: 1400 });
+  const r = await bridge.personalExportVault({});
+  if (!r?.ok) showToast({ tone: "danger", title: "Vault not exported", desc: r?.error ?? "Personalization is off or locked.", actions: [{ label: "OK" }], timeout: 5000 });
+  else showExportToast("Vault exported", `${r.files} files · ${r.entities} notes · ${r.facts} facts · Personal + Work · CUI excluded by design · audited`, r.dest);
+}
+function kgCuiArchive(): void {
+  showToast({
+    title: "CUI archive · National Archives",
+    desc: "Exports ONLY the CUI compartment into a CUI-marked, records-managed package (SHA-256 manifest). Designation and records-schedule fields are scaffolded for an authorized CUI/records officer to complete. Continue?",
+    meta: "32 CFR 2002 · NARA records management · audited",
+    actions: [
+      { label: "Cancel" },
+      { label: "Export CUI archive", kind: "danger", run: async () => {
+        const r = await bridge.personalCuiArchive({});
+        if (!r?.ok) showToast({ tone: "danger", title: "CUI archive not written", desc: r?.error ?? "Personalization is off or locked.", actions: [{ label: "OK" }], timeout: 6000 });
+        else showExportToast("CUI archive written", `${r.files} files · ${r.facts} facts · sha256 ${(r.manifestSha256 ?? "").slice(0, 12)}… · complete the designation before transfer`, r.dest);
+      } },
+    ],
+    timeout: 0,
   });
 }
 
@@ -7212,52 +7280,7 @@ function wire(): void {
   // no remount, so the layout the user is looking at never jumps.
   perfWatch.onChange(() => { paintPerfChip(); kgHandle?.setCalm(perfWatch.tier() !== "full"); });
   paintPerfChip();
-  $("#kgImport")!.addEventListener("click", async () => {
-    const folder = await openFolderBrowser({ title: "Choose your ChatGPT / Claude / Gemini export", confirm: "Import from here" });
-    if (!folder) return;
-    // Read-only pre-import estimate → warn about AI-mode token cost + runtime before the paid run.
-    const est = await bridge.personalImportEstimate(folder);
-    if (!est?.ok) { showToast({ tone: "danger", title: "Couldn't read that export", desc: est?.error ?? "No conversations found in that export.", actions: [{ label: "OK" }], timeout: 6000 }); return; }
-    // First import (empty graph) defaults to AI extraction (best quality); after that, honor the box.
-    const status = await bridge.personal();
-    const totalFacts = status?.counts ? status.counts.work + status.counts.personal + status.counts.cui : 0;
-    const aiDefault = totalFacts === 0 ? true : (($("#kgImportAI") as HTMLInputElement | null)?.checked ?? false);
-    const { tokens, secs, overCap } = estimateAiImport(est);
-    const vendorName = est.vendor === "openai" ? "ChatGPT" : est.vendor === "anthropic" ? "Claude" : "Gemini";
-    const aiLine = `AI: ~${fmtNum(tokens)} tokens · ${fmtDur(secs)}${overCap ? ` (first ${AI_IMPORT_CAP} of ${fmtNum(est.userMessages ?? 0)} msgs)` : ""} · Quick: free + instant, lower quality. Estimate is approximate.`;
-    const aiBtn = { label: `AI extraction (${fmtDur(secs)})`, run: () => void runPersonalImport(folder, true) };
-    const quickBtn = { label: "Quick (free)", run: () => void runPersonalImport(folder, false) };
-    showToast({
-      title: `Import ${fmtNum(est.conversations ?? 0)} ${vendorName} conversations?`,
-      desc: `${fmtNum(est.userMessages ?? 0)} of your messages will seed your private, encrypted graph.`,
-      meta: aiLine,
-      tone: "warn",
-      actions: [...(aiDefault ? [aiBtn, quickBtn] : [quickBtn, aiBtn]), { label: "Cancel" }],
-      timeout: 0, // require an explicit choice (AI mode is paid + slow)
-    });
-  });
-  $("#kgExport")!.addEventListener("click", async () => {
-    showToast({ title: "Exporting vault…", desc: "Decrypting and writing your Obsidian notes.", timeout: 1400 });
-    const r = await bridge.personalExportVault({});
-    if (!r?.ok) showToast({ tone: "danger", title: "Vault not exported", desc: r?.error ?? "Personalization is off or locked.", actions: [{ label: "OK" }], timeout: 5000 });
-    else showExportToast("Vault exported", `${r.files} files · ${r.entities} notes · ${r.facts} facts · Personal + Work · CUI excluded by design · audited`, r.dest);
-  });
-  $("#kgCui")!.addEventListener("click", () => {
-    showToast({
-      title: "CUI archive · National Archives",
-      desc: "Exports ONLY the CUI compartment into a CUI-marked, records-managed package (SHA-256 manifest). Designation and records-schedule fields are scaffolded for an authorized CUI/records officer to complete. Continue?",
-      meta: "32 CFR 2002 · NARA records management · audited",
-      actions: [
-        { label: "Cancel" },
-        { label: "Export CUI archive", kind: "danger", run: async () => {
-          const r = await bridge.personalCuiArchive({});
-          if (!r?.ok) showToast({ tone: "danger", title: "CUI archive not written", desc: r?.error ?? "Personalization is off or locked.", actions: [{ label: "OK" }], timeout: 6000 });
-          else showExportToast("CUI archive written", `${r.files} files · ${r.facts} facts · sha256 ${(r.manifestSha256 ?? "").slice(0, 12)}… · complete the designation before transfer`, r.dest);
-        } },
-      ],
-      timeout: 0,
-    });
-  });
+  $("#kgData")?.addEventListener("click", (e) => openKgDataMenu(e.currentTarget as HTMLElement)); // P-KGUI.2 dropdown
   $("#knowledge")!.addEventListener("click", async (e) => {
     const t = e.target as HTMLElement;
     const lens = t.closest("[data-lens]") as HTMLElement | null;

--- a/desktop/renderer/kg_header.test.ts
+++ b/desktop/renderer/kg_header.test.ts
@@ -45,3 +45,31 @@ describe("kgViewsMenuHtml", () => {
     expect(h).not.toContain("Relate nodes ✓");
   });
 });
+
+// ───────────── P-KGUI.2 (ADR-0185): the Data dropdown ─────────────
+
+import { kgDataMenuHtml } from "./kg_header.ts";
+
+describe("kgDataMenuHtml", () => {
+  test("all three former buttons live in the menu with stable handles and self-describing copy", () => {
+    const h = kgDataMenuHtml(false);
+    for (const v of ["import", "export", "cui"]) expect(h).toContain(`data-kgdata="${v}"`);
+    expect(h).toContain("Import chat history");
+    expect(h).toContain("Export Obsidian vault");
+    expect(h).toContain("CUI archive");
+    expect(h).toContain("scanned by the security gate"); // import explains the gate inline
+    expect(h).toContain("CUI excluded by design");       // export explains its boundary inline
+  });
+  test("the AI-extraction toggle is a row, not an action: no data-kgdata handle, checked follows state", () => {
+    const off = kgDataMenuHtml(false);
+    expect(off).toContain('id="kgImportAI"');
+    expect(off).not.toContain('id="kgImportAI" checked');
+    expect(off.match(/data-kgdata=/g)?.length).toBe(3); // the toggle never closes/act as a menu action
+    expect(kgDataMenuHtml(true)).toContain('id="kgImportAI" checked');
+  });
+  test("the CUI row keeps its danger look", () => {
+    const h = kgDataMenuHtml(false);
+    expect(h).toContain("kgv-danger");
+    expect(h.match(/kgv-danger/g)?.length).toBe(1); // only CUI
+  });
+});

--- a/desktop/renderer/kg_header.ts
+++ b/desktop/renderer/kg_header.ts
@@ -22,8 +22,8 @@ export function kgViewActive(s: KgViewState): boolean {
   return s.relateOn || s.codeMode || s.kbMode;
 }
 
-const item = (view: string, title: string, desc: string, on: boolean): string =>
-  `<button class="kgv-item${on ? " on" : ""}" data-kgview="${view}">
+const item = (view: string, title: string, desc: string, on: boolean, attr = "data-kgview", cls = ""): string =>
+  `<button class="kgv-item${on ? " on" : ""}${cls ? ` ${cls}` : ""}" ${attr}="${view}">
     <span class="kgv-t">${title}${on ? " ✓" : ""}</span>
     <span class="kgv-d">${desc}</span>
   </button>`;
@@ -36,5 +36,21 @@ export function kgViewsMenuHtml(s: KgViewState): string {
     ${item("relate", "Relate nodes", "Drag one node onto another - or click several, then Relate - to author your own relationships.", s.relateOn)}
     ${item("code", "Code graph", "This workspace as a graph: files or symbols as nodes, imports and references as edges.", s.codeMode)}
     ${item("kb", "Compiled KB", "The compiled knowledge base as a page graph - click a page to read it as data.", s.kbMode)}
+  </div>`;
+}
+
+/** P-KGUI.2 (ADR-0185): the Data dropdown - Import history / Export vault / CUI archive, folded from
+ *  three header buttons into the same menu pattern as the views dropdown. `aiOn` renders the
+ *  AI-extraction toggle (a menu row, not an action - toggling it never closes the menu). The CUI row
+ *  keeps its danger look; its own confirm toast still guards the export. */
+export function kgDataMenuHtml(aiOn: boolean): string {
+  return `<div class="kgv-menu">
+    ${item("import", "Import chat history", "Bring in a ChatGPT, Claude, or Gemini export - every message is scanned by the security gate before anything is learned.", false, "data-kgdata")}
+    <label class="kgv-item kgv-check">
+      <span class="kgv-t"><input type="checkbox" id="kgImportAI"${aiOn ? " checked" : ""}/> AI extraction on import</span>
+      <span class="kgv-d">Use the model to pull richer facts + real relationships from each message. Slower, uses model quota (capped at 500 messages); off = the free, instant pass.</span>
+    </label>
+    ${item("export", "Export Obsidian vault", "Decrypt your Personal + Work knowledge into a portable vault - notes + wikilinks, CUI excluded by design, audited.", false, "data-kgdata")}
+    ${item("cui", "CUI archive", "Export ONLY the CUI compartment as a CUI-marked, records-managed package with a SHA-256 manifest (32 CFR 2002 · NARA). Audited.", false, "data-kgdata", "kgv-danger")}
   </div>`;
 }

--- a/desktop/renderer/styles.css
+++ b/desktop/renderer/styles.css
@@ -2002,7 +2002,11 @@ body.resizing .sidebar,body.resizing .inspector{transition:none}
 .kgv-item.on .kgv-t{color:var(--accent-2)}
 .kgv-t{font-size:12.5px;font-weight:600;color:var(--txt)}
 .kgv-d{font-size:11px;color:var(--txt-3);line-height:1.4}
-/* icon-only button (the code-graph re-sync sits between the views dropdown and the AI checkbox) */
+/* P-KGUI.2 (ADR-0185): the Data menu's AI toggle row + the CUI danger row */
+.kgv-check{cursor:pointer}
+.kgv-check input{accent-color:var(--accent);cursor:pointer;margin:0 5px 0 0;vertical-align:-2px}
+.kgv-item.kgv-danger .kgv-t{color:var(--danger,#d96a6a)}
+/* icon-only button (the code-graph re-sync sits between the views and Data dropdowns) */
 .btn-mini.btn-icon{padding:0;width:30px;justify-content:center;flex:none}
 .btn-mini.btn-icon .ic{width:14px;height:14px}
 /* code-node side panel */
@@ -2094,8 +2098,6 @@ body.resizing .sidebar,body.resizing .inspector{transition:none}
 .kg-lens button{-webkit-app-region:no-drag;border:0;background:transparent;color:var(--txt-3);font-size:11px;font-weight:600;padding:4px 11px;border-radius:6px;cursor:pointer;transition:background var(--t),color var(--t),box-shadow var(--t)}
 .kg-lens button:hover{color:var(--txt-2)}
 .kg-lens button.on{background:var(--bg-4);color:var(--txt);box-shadow:inset 0 0 0 1px var(--line-strong),0 1px 2px rgba(0,0,0,.35)}
-.kg-ai{-webkit-app-region:no-drag;display:flex;align-items:center;gap:5px;font-size:11px;font-weight:600;color:var(--txt-3);cursor:pointer;user-select:none}
-.kg-ai input{accent-color:var(--accent);cursor:pointer;margin:0}
 .kg-main{flex:1;min-height:0;display:flex;position:relative}
 .kg-canvas{flex:1;min-width:0;position:relative;background:radial-gradient(120% 90% at 50% 34%,#12141d 0%,var(--bg-1) 42%,var(--bg-0) 100%);overflow:hidden;cursor:grab}
 /* faint vignette so nodes feel lit from within the canvas rather than floating on flat fill */

--- a/desktop/scripts/demo_p_kgui_2.ts
+++ b/desktop/scripts/demo_p_kgui_2.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 TechLead 187 LLC
+// SPDX-License-Identifier: BUSL-1.1
+
+// Increment P-KGUI.2 — the Data dropdown (ADR-0185). The follow-up P-KGUI.1 promised: Import history /
+// Export vault / CUI archive (plus the AI-extraction checkbox) fold from three header buttons into ONE
+// "Data" dropdown on the same pattern as the views menu - hover tip lists the options, menu rows
+// self-describe, the AI toggle is remembered state (never closes the menu), CUI keeps its danger look
+// and its confirm toast.
+//
+// Run with: bun run desktop/scripts/demo_p_kgui_2.ts
+
+import { kgDataMenuHtml } from "../renderer/kg_header.ts";
+
+function assert(cond: unknown, msg: string): void {
+  if (!cond) { console.error("  ✗ " + msg); process.exit(1); }
+  console.log("  ✓ " + msg);
+}
+
+console.log("== #ADR-0185 P-KGUI.2: the Data dropdown ==\n");
+
+console.log("[1] three buttons + a checkbox become one menu");
+const h = kgDataMenuHtml(false);
+assert(["import", "export", "cui"].every((v) => h.includes(`data-kgdata="${v}"`)), "Import / Export vault / CUI archive all live in the menu");
+assert(h.includes("scanned by the security gate") && h.includes("CUI excluded by design") && h.includes("32 CFR 2002"),
+  "every option explains itself inline - gate on import, CUI boundary on export, NARA on the archive");
+
+console.log("\n[2] the AI-extraction toggle is state, not an action");
+assert(h.includes('id="kgImportAI"') && !h.includes('id="kgImportAI" checked'), "toggle renders unchecked from state=false");
+assert(kgDataMenuHtml(true).includes('id="kgImportAI" checked'), "…and checked from state=true (remembered across menu opens)");
+assert((h.match(/data-kgdata=/g) ?? []).length === 3, "the toggle row carries NO action handle - flipping it never closes the menu");
+
+console.log("\n[3] CUI keeps its guard rails");
+assert((h.match(/kgv-danger/g) ?? []).length === 1, "only the CUI row carries the danger look (its confirm toast still guards the export)");
+
+console.log("\n✓ P-KGUI.2 demo passed — the KG header is two labeled dropdowns instead of six controls.");


### PR DESCRIPTION
## What

The follow-up noted in P-KGUI.1: the remaining KG-header data controls fold into the same dropdown pattern.

- **One "Data ▾" button** replaces Import history / Export vault / CUI archive + the AI checkbox. Its hover tip says it's a dropdown and lists the contents; the menu rows self-describe (import explains the scan gate, export its CUI-excluded boundary, the archive its 32 CFR 2002 / NARA framing).
- **The AI-extraction choice is remembered state**, not a live checkbox: the menu is transient DOM, so `kgImportAiOn` renders the toggle each open and a change listener updates it - flipping it never closes the menu, and the import flow's first-import-defaults-to-AI logic is unchanged.
- **Same behavior underneath**: the three handlers moved verbatim into named functions (`kgImportHistory` / `kgExportVault` / `kgCuiArchive`) - same estimate toast, same export toasts, same CUI danger confirm.
- The header is now two labeled dropdowns (views + Data) on one thin row; orphaned `.kg-ai` CSS removed.

## Verification

- 3 new kg_header tests (stable handles + inline copy, toggle-is-state-not-action + checked-follows-state, single danger row); `demo-P-KGUI.2` green
- Root `tsc --noEmit` clean; full `bun test` 1914 pass / 6 fail = known Windows path-sep baseline
- **Verified live**: old buttons + AI label gone (header stays 51px), the menu opened with all four rows, the AI toggle kept the menu open and survived close/reopen, Export ran the real flow (honest locked-store toast on the fresh instance), CUI raised its confirm (canceled) - screenshot in session

ADR-0185 + PROGRESS entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)