### PR TITLE
release: v1.10.5 - the quality batch since 1.10.4 (ADR-0179-0185)

### DIFF
--- a/desktop/about.test.ts
+++ b/desktop/about.test.ts
@@ -15,8 +15,8 @@ describe("version is single-sourced", () => {
     expect(pkg.version).toBe(APP_VERSION);
   });
 
-  test("app version is v1.10.4", () => {
-    expect(APP_VERSION).toBe("1.10.4");
+  test("app version is v1.10.5", () => {
+    expect(APP_VERSION).toBe("1.10.5");
   });
 });
 
@@ -25,7 +25,7 @@ describe("aboutHtml", () => {
 
   test("shows the dynamic version with a v prefix", () => {
     expect(html).toContain(`v${APP_VERSION}`);
-    expect(html).toContain("v1.10.4");
+    expect(html).toContain("v1.10.5");
   });
 
   test("carries the product + company identity", () => {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lucidagentide-desktop",
   "private": true,
-  "version": "1.10.4",
+  "version": "1.10.5",
   "trustedDependencies": ["electron", "@resvg/resvg-js"],
   "description": "Electron desktop shell for LucidAgentIDE + omp — gated agent chat + live security/memory dashboards.",
   "homepage": "https://github.com/mlcyclops/lucidagentide",

--- a/desktop/version.ts
+++ b/desktop/version.ts
@@ -140,4 +140,13 @@
 //           skills never appeared. Exclusion dropped; the packaging guard now materializes a REAL filtered
 //           install (excluded packages absent, stripped file types deleted) and requires boot + every lazy
 //           feature dep to load, so broken-but-quiet features fail CI too.
-export const APP_VERSION = "1.10.4";
+// v1.10.5 = the QUALITY batch (ADR-0179-0185): LIVE SUBAGENT ACTIVITY (the delegation card opens each
+//           subagent's thinking/tool calls/output, tailed from omp's per-subtask transcripts, P-TASK.5);
+//           graphs FORM IN PLACE (the KG/code-graph settle runs off-screen, opens snapped at the final
+//           center, parked - no on-screen shake, P-KGVIZ.1); the SYSTEM RESOURCE GUARD (a weak CPU under
+//           heavy load pauses the heavy graph builds behind a notice + top-processes panel + re-check,
+//           FAIL-OPEN, P-SYSRES.1); the ELECTRON PREVIEW explained + runnable outside LUCID (user-clicked,
+//           audited, P-PREVIEW.7); the KG header decluttered to "KG" + two labeled dropdowns (views + Data,
+//           P-KGUI.1/.2); and the marketplace curated for fit (Mermaid/Gitleaks/Semgrep/Trivy/Pandoc in,
+//           competitors out, P-MARKET.1b).
+export const APP_VERSION = "1.10.5";


### PR DESCRIPTION
## What

Version bump to **v1.10.5** in lockstep (`desktop/version.ts` + `desktop/package.json` + `about.test.ts`), with the consolidated changelog note in version.ts.

### In this release (since v1.10.4)

- **Live subagent activity** - the delegation card opens each subagent's thinking / tool calls / output, tailed live from omp's per-subtask transcripts (ADR-0180)
- **Graphs form in place** - the KG/code-graph settle runs off-screen; hundreds of nodes open settled, centered, parked (ADR-0183)
- **System resource guard** - weak CPU under heavy load pauses the heavy graph builds behind a notice + top-processes panel + re-check; fail-open (ADR-0182)
- **Electron preview** - the silent white pane explained, with a user-clicked external launch (audited) (ADR-0179)
- **KG header** - 'KG' title + two labeled dropdowns: views (Relate / Code graph / Compiled KB) and Data (Import / AI toggle / Export vault / CUI archive) (ADR-0184/0185)
- **Marketplace curated for fit** - Mermaid, Gitleaks, Semgrep, Trivy, Pandoc in; competitors out (ADR-0181)
- README refreshed to match (v1.10.5 what's-new, live ledger metrics, shipped-status scrub)

## Verification

- about.test.ts lockstep + packaged_boot guard (real materialized filtered install boots; lazy feature deps load): green
- Root tsc clean; full suite at the known Windows baseline on the pre-bump tree

After merge: tag `v1.10.5` → build-desktop.yml builds Windows/macOS/Linux installers onto the GitHub Release; shipped-artifact boot check to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)