### PR TITLE
release: v1.10.6 - the agent-turn + Model-Evaluation batch since 1.10.5

### DIFF
--- a/desktop/about.test.ts
+++ b/desktop/about.test.ts
@@ -15,8 +15,8 @@ describe("version is single-sourced", () => {
     expect(pkg.version).toBe(APP_VERSION);
   });
 
-  test("app version is v1.10.5", () => {
-    expect(APP_VERSION).toBe("1.10.5");
+  test("app version is v1.10.6", () => {
+    expect(APP_VERSION).toBe("1.10.6");
   });
 });
 
@@ -25,7 +25,7 @@ describe("aboutHtml", () => {
 
   test("shows the dynamic version with a v prefix", () => {
     expect(html).toContain(`v${APP_VERSION}`);
-    expect(html).toContain("v1.10.5");
+    expect(html).toContain("v1.10.6");
   });
 
   test("carries the product + company identity", () => {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lucidagentide-desktop",
   "private": true,
-  "version": "1.10.5",
+  "version": "1.10.6",
   "trustedDependencies": ["electron", "@resvg/resvg-js"],
   "description": "Electron desktop shell for LucidAgentIDE + omp — gated agent chat + live security/memory dashboards.",
   "homepage": "https://github.com/mlcyclops/lucidagentide",

--- a/desktop/version.ts
+++ b/desktop/version.ts
@@ -149,4 +149,15 @@
 //           audited, P-PREVIEW.7); the KG header decluttered to "KG" + two labeled dropdowns (views + Data,
 //           P-KGUI.1/.2); and the marketplace curated for fit (Mermaid/Gitleaks/Semgrep/Trivy/Pandoc in,
 //           competitors out, P-MARKET.1b).
-export const APP_VERSION = "1.10.5";
+// v1.10.6 = the AGENT-TURN + MODEL-EVALUATION batch (ADR-0186-0191): the CHAT TURN REDESIGN - a settled
+//           answer splits into collapsible sections on its own headings (P-CHAT.A), each tool call threads
+//           back inline as an expandable chip with a +/- diffstat + code drilldown when it genuinely
+//           interleaves - otherwise the rich activity window (tool steps + diffstats) and the expanded
+//           subagent detail stay (P-CHAT.B/.B.1), and a settled file-writing turn offers a thin, subdued
+//           "Generate engineering report" (P-CHAT.C/.C.1). The MODEL-EVALUATION suite: a pure metrics +
+//           per-model API-latency core with direct/proxy/needs_signal honesty tiers (P-EVAL.1), the latency
+//           capture hook + frozen api_latency/eval_metrics DuckDB tables (P-EVAL.2), per-run metrics
+//           persistence + a cross-run rollup report kind in the Reports panel (P-EVAL.3). PATIENCE for
+//           overloaded providers - a 10-min turn with an honest "still waiting" notice (P-STALL.1); and an
+//           AI RE-SEED for the Trivia Wire (now default-OFF, an opt-in easter egg, P-TRIV.4).
+export const APP_VERSION = "1.10.6";


### PR DESCRIPTION
Bumps `APP_VERSION` + `desktop/package.json` to **1.10.6** (+ the about-test version gates).

## Batch since v1.10.5
- **P-STALL.1** (ADR-0186) - patience for overloaded providers: a 10-min turn with an honest "still waiting" notice.
- **P-CHAT.A-C + .B.1/.C.1** (ADR-0188-0190) - the chat-turn redesign: collapsible sections on the model's headings; inline tool chips *only when they genuinely interleave* (else the rich activity window + expanded subagent detail stay); a thin, subdued "Generate engineering report" that shows only on file-writing turns.
- **P-EVAL.1/.2/.3** (ADR-0187) - Model-Evaluation metrics + per-model API-latency (honesty-tiered), the capture hook + frozen `api_latency`/`eval_metrics` DuckDB tables, per-run persistence + a cross-run rollup report kind in the Reports panel.
- **P-TRIV.4** (ADR-0191) - AI re-seed for the Trivia Wire (now **default-OFF**, opt-in).

Tag `v1.10.6` will be cut on the merge commit to trigger the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)