### PR TITLE
hotfix: v1.11.1 — package desktop/collab (v1.11.0 bricked at boot) + gate the boot guard in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,14 @@ jobs:
           bun install
           bun x tsc --noEmit
 
+      # ADR-0177/0178: the RELEASE must BOOT under the packaging filter. This guard materializes a filtered
+      # install (the extraResources exclusions applied for real) and boots the real dev.ts, then requires
+      # lazily-imported feature deps to load. A filter/import mismatch - e.g. v1.11.0's `desktop/collab`
+      # excluded because the filter's `desktop/*.ts` glob was depth-1 only - now FAILS CI, not users.
+      # (Runs at repo root; needs the root install above so it can link node_modules into the sim.)
+      - name: Packaged-boot guard (release boots under the packaging filter)
+        run: bun test desktop/packaged_boot.test.ts
+
   scanner:
     name: Unicode scanner tests (Python)
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ via the same read-only-safe JSONL-sink pattern as the rest of the observer store
 - [<img src=".github/assets/icons/memory.svg" width="16" alt=""> Memory and the personalization graph](#-memory-and-the-personalization-graph)
 - [<img src=".github/assets/icons/gateway.svg" width="16" alt=""> Models and the AskSage gateway](#-models-and-the-asksage-gateway)
 - [📚 Knowledge & RAG](#-knowledge--rag)
+- [🤝 Live collaboration](#-live-collaboration)
 - [<img src=".github/assets/icons/builton.svg" width="16" alt=""> Built on](#-built-on)
 - [<img src=".github/assets/icons/quickstart.svg" width="16" alt=""> Quick start](#-quick-start)
 - [<img src=".github/assets/icons/desktop.svg" width="16" alt=""> Desktop app](#-desktop-app)
@@ -618,6 +619,35 @@ if poisoned, *before* it can ever be embedded or recalled. (Keystone #2 holds fo
 - 🛠️ **Skill Studio - turn your week into skills (shipped).** Built in [ADR-0101](DECISIONS.md) (`P-SKILL.5`), a one-click button that analyzes your **day's or week's** work (sessions, AI-authored edits, loop outcomes) and **drafts Agent Skills** with your most-used model - each one **scanned before it's saved** and **reviewed before it's codified** (a reviewed draft is excellent; an un-reviewed one is worse than none). Codified skills land in your **Local Skills Registry**.
 - 🏛️ **Enterprise skills registry - reader seam ships now (`P-SKILLREG.1`).** The source-available app carries the read-only **registry reader**: an install is **fetch → verify (Ed25519 signature vs. your trusted keys) → scan-gate (the same fail-closed gate) → install**, and an **unsigned, signature-mismatched, unconfigured-key, or scan-flagged** skill is **blocked, never written** (keystone #2: an installed registry skill is shown `untrusted`, never auto-promoted to trusted). Installed skills appear in the directory above under a **Registry** source. The hosting side - publish/version/**sign (Cosign + SLSA)**/distribute as portable **OCI artifacts on an S3-compatible backend** that stands up identically on **AWS, Azure, Google Cloud, OCI, IBM Cloud, VMware, Nutanix, NetApp ONTAP, and KVM** via Terraform, incl. **air-gapped and IL5** partitions - is the separately-licensed add-on (server + runbooks are private IP).
 - 🚀 **Push to where your org already lives - publish seam ships now (`P-SKILLREG.2`).** A single **`RegistryPublisher`** seam ships in the core with a default **`LocalRegistryPublisher`** (serves your skills as the Local Skills Registry) + a fail-safe `PublishDispatcher` (a dead/missing publisher never throws into a turn; a declared remote with no publisher is a clean no-op). The remote publishers - enterprise cloud OCI registries (AWS/Azure/GCP/Oracle/IBM) and **custom git** (Enterprise GitLab, GitHub, Azure DevOps) - implement the same interface and are a separately-licensed add-on. Publishing establishes **no trust**: the read side still verifies the signature + scan-gates before install; every remote push is **egress-gated** and centrally policy-clamped.
+
+## 🤝 Live collaboration
+
+> **Shipped** ([ADR-0192-0204](DECISIONS.md), `P-COLLAB`). Share a **running** LUCID session with another
+> LUCID, live and **end-to-end encrypted** - a teammate watches your agent work in real time, or drives it -
+> without handing over your machine, your keys, or your approvals.
+
+<div align="center">
+<img src=".github/assets/live-collaboration.png" alt="LucidAgentIDE live collaboration - the Share panel: an end-to-end-encrypted invite link, a self-hosted relay toggle, and the live participant roster. A guest watches read-only or drives, with every guest prompt still gated on the host." width="640" />
+<br />
+<sub><i>The Share panel - an end-to-end-encrypted invite, the self-hosted relay toggle, and the live roster. <b>Drop your screenshot at <code>.github/assets/live-collaboration.png</code>.</b></i></sub>
+</div>
+
+- 🔐 **End-to-end encrypted, host-authoritative.** The host broadcasts its own `ChatEvent` stream over an
+  E2E-sealed relay (**AES-256-GCM**; the relay only ever sees ciphertext, never the room key). The key rides
+  the **invite link**, never the wire.
+- 👀 **Watch, or drive.** A **view** link is read-only; a **full/edit** link lets a guest **drive** the host's
+  session - but every guest prompt still runs **on the host**, through *your* fail-closed scan gate +
+  exec/egress approvals, so a guest bypasses nothing.
+- 🏠 **Self-hosted by default.** **Be the relay** on your own device (loopback / LAN / VPN bind picker) so no
+  third party ever touches the session - even encrypted - or run the **standalone broker** on an office server
+  / DGX / Ubuntu jumpbox. The public relay is strictly opt-in.
+- 🏢 **Enterprise-governed, fail-closed.** Group policy / MDM can clamp **who may host a relay** and **which
+  bind addresses + relay endpoints** are allowed - tighten-only, refused unless explicitly permitted.
+- ⚡ **Optional direct P2P (WebRTC).** Flip on *"prefer a direct connection"* and a share upgrades to a direct
+  **DTLS DataChannel** - the relay only brokers the SDP/ICE signaling handshake, then peers go peer-to-peer,
+  with **automatic relay fallback** when a NAT blocks the direct path.
+- 🧾 **Audited.** A **metadata-only** audit trail records share/join start/stop over both transports (transport,
+  access, opaque room id, guest name) - **never** the room key, invite links, or any session content.
 
 ## <img src=".github/assets/icons/builton.svg" width="28" align="top" alt=""> Built on
 

--- a/desktop/about.test.ts
+++ b/desktop/about.test.ts
@@ -15,8 +15,8 @@ describe("version is single-sourced", () => {
     expect(pkg.version).toBe(APP_VERSION);
   });
 
-  test("app version is v1.11.0", () => {
-    expect(APP_VERSION).toBe("1.11.0");
+  test("app version is v1.11.1", () => {
+    expect(APP_VERSION).toBe("1.11.1");
   });
 });
 
@@ -25,7 +25,7 @@ describe("aboutHtml", () => {
 
   test("shows the dynamic version with a v prefix", () => {
     expect(html).toContain(`v${APP_VERSION}`);
-    expect(html).toContain("v1.11.0");
+    expect(html).toContain("v1.11.1");
   });
 
   test("carries the product + company identity", () => {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lucidagentide-desktop",
   "private": true,
-  "version": "1.11.0",
+  "version": "1.11.1",
   "trustedDependencies": ["electron", "@resvg/resvg-js"],
   "description": "Electron desktop shell for LucidAgentIDE + omp — gated agent chat + live security/memory dashboards.",
   "homepage": "https://github.com/mlcyclops/lucidagentide",
@@ -48,7 +48,7 @@
           "scanner-sidecar/**/*",
           "!scanner-sidecar/.venv/**",
           "!**/__pycache__/**",
-          "desktop/*.ts",
+          "desktop/**/*.ts",
           "desktop/renderer/**/*",
           "desktop/package.json",
           "node_modules/**/*",

--- a/desktop/packaged_boot.test.ts
+++ b/desktop/packaged_boot.test.ts
@@ -55,6 +55,23 @@ function linkTreeFiltered(src: string, dst: string, dropSuffixes: string[]): voi
 
 const linkDir = (target: string, path: string): void => symlinkSync(target, path, process.platform === "win32" ? "junction" : "dir");
 
+/** Copy the desktop repo sources the way the `to:"repo"` extraResources filter ships them: EVERY
+ *  `desktop/**\/*.ts` (any depth), the whole `desktop/renderer/**`, and desktop/package.json - so a new
+ *  desktop subdir the engine imports (v1.11.0 shipped `desktop/collab` and the filter's `desktop/*.ts` was
+ *  depth-1 only, bricking boot) is present in the sim exactly as in the real package. Skips build-output. */
+function copyDesktopSources(srcRoot: string, dstRoot: string, rel = ""): void {
+  for (const e of readdirSync(join(srcRoot, rel), { withFileTypes: true })) {
+    const r = rel ? `${rel}/${e.name}` : e.name;
+    if (e.isDirectory()) {
+      if (!rel && (e.name === "node_modules" || e.name === "release" || e.name === "dist")) continue;
+      copyDesktopSources(srcRoot, dstRoot, r);
+    } else if (e.isFile() && (e.name.endsWith(".ts") || r === "package.json" || r.startsWith("renderer/"))) {
+      mkdirSync(join(dstRoot, rel), { recursive: true });
+      cpSync(join(srcRoot, r), join(dstRoot, r));
+    }
+  }
+}
+
 /** Materialize the filtered install: repo sources + node_modules with the LIVE exclusions applied. */
 function buildFilteredInstall(): string {
   const exclusions = nodeModulesExclusions();
@@ -64,12 +81,7 @@ function buildFilteredInstall(): string {
 
   // Repo sources, the way extraResources ships them (the subset the engine needs to boot).
   cpSync(join(REPO, "package.json"), join(sim, "package.json"));
-  mkdirSync(join(sim, "desktop"), { recursive: true });
-  for (const e of readdirSync(join(REPO, "desktop"), { withFileTypes: true })) {
-    if (e.isFile() && e.name.endsWith(".ts")) cpSync(join(REPO, "desktop", e.name), join(sim, "desktop", e.name));
-  }
-  cpSync(join(REPO, "desktop", "package.json"), join(sim, "desktop", "package.json"));
-  cpSync(join(REPO, "desktop", "renderer"), join(sim, "desktop", "renderer"), { recursive: true });
+  copyDesktopSources(join(REPO, "desktop"), join(sim, "desktop")); // desktop/**/*.ts + renderer/** + package.json
   for (const top of ["harness", "tools"]) cpSync(join(REPO, top), join(sim, top), { recursive: true });
   if (existsSync(join(REPO, "bin"))) cpSync(join(REPO, "bin"), join(sim, "bin"), { recursive: true });
 

--- a/desktop/version.ts
+++ b/desktop/version.ts
@@ -174,4 +174,13 @@
 //           Plus: a Copy button + right-click Copy for chat text & code blocks (P-COPY.1); the product website
 //           in the About panel with its brand emblem inlined so it paints instantly; and the default zoom
 //           pulled back a notch (what used to read 90% is the new 100%).
-export const APP_VERSION = "1.11.0";
+// v1.11.1 = HOTFIX: v1.11.0's packaged engine bricked at boot ("Cannot find module './collab/relay_server.ts'
+//           ... could not start its local engine / blank window") - the extraResources `to:"repo"` filter
+//           shipped `desktop/*.ts` (DEPTH-1 only) + `desktop/renderer/**`, so the brand-new `desktop/collab/`
+//           dir (P-COLLAB, which dev.ts imports at boot) was excluded from the package. Fix: the filter now
+//           ships `desktop/**/*.ts` (any depth), so a new desktop subdir can't be left out. Root cause of the
+//           MISS: the packaged-boot guard (ADR-0177/0178) that exists to catch this NEVER RAN in CI (the job
+//           ran `bun test harness` only) AND its own sim mirrored the depth-1 copy - both fixed: the guard
+//           now copies desktop sources recursively, and CI runs it as a required step. This class (v1.9.0 /
+//           1.10.3 / 1.10.4 / 1.11.0) is now gated, not shipped.
+export const APP_VERSION = "1.11.1";


### PR DESCRIPTION
## The brick
v1.11.0's packaged engine died at boot:
```
error: Cannot find module './collab/relay_server.ts' from '…\resources\repo\desktop\dev.ts'
→ "LucidAgentIDE could not start its local engine" (blank window; port 5319 never binds)
```
It reached users **via auto-update**.

## Root cause
The electron-builder `extraResources` `to:"repo"` filter shipped **`desktop/*.ts` (depth-1 only)** + `desktop/renderer/**` — so the brand-new **`desktop/collab/`** directory (P-COLLAB), which `dev.ts` imports at boot, was never copied into the packaged repo. Same class as the v1.9.0 / 1.10.3 / 1.10.4 packaging bricks.

## Fixes
- **`desktop/package.json`** — the filter now ships **`desktop/**/*.ts`** (any depth), so a new desktop subdir can't be left out again.
- **Why the guard missed it** — the packaged-boot guard (ADR-0177/0178) that exists to catch this **never ran in CI** (the job ran `bun test harness` only), *and* its own materialized sim mirrored the same depth-1 copy. Both fixed:
  - **`desktop/packaged_boot.test.ts`** now copies desktop sources **recursively** (`desktop/**/*.ts` + `renderer/**` + `package.json`), so its sim matches the real package and a missing subdir fails the boot.
  - **`.github/workflows/ci.yml`** runs the guard as a **required step**.

## Verified
- The guard boots the engine from a **real filtered install** — **2/2 pass** (materializes the filter, runs `dev.ts`, requires `/api/health`).
- Ran it locally against the fix: boots clean with `collab/` present.
- about/version tests + desktop `tsc` green; version 1.11.0 → **1.11.1** (version.ts + package.json + tests).

## Deploy
Tagging **`v1.11.1`** after merge triggers `build-desktop.yml` → rebuilds + republishes the electron-updater feed, so auto-update pulls the working build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)