### PR TITLE
release: cut v1.11.2

### DIFF
--- a/desktop/about.test.ts
+++ b/desktop/about.test.ts
@@ -15,8 +15,8 @@ describe("version is single-sourced", () => {
     expect(pkg.version).toBe(APP_VERSION);
   });
 
-  test("app version is v1.11.1", () => {
-    expect(APP_VERSION).toBe("1.11.1");
+  test("app version is v1.11.2", () => {
+    expect(APP_VERSION).toBe("1.11.2");
   });
 });
 
@@ -25,7 +25,7 @@ describe("aboutHtml", () => {
 
   test("shows the dynamic version with a v prefix", () => {
     expect(html).toContain(`v${APP_VERSION}`);
-    expect(html).toContain("v1.11.1");
+    expect(html).toContain("v1.11.2");
   });
 
   test("carries the product + company identity", () => {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lucidagentide-desktop",
   "private": true,
-  "version": "1.11.1",
+  "version": "1.11.2",
   "trustedDependencies": ["electron", "@resvg/resvg-js"],
   "description": "Electron desktop shell for LucidAgentIDE + omp — gated agent chat + live security/memory dashboards.",
   "homepage": "https://github.com/mlcyclops/lucidagentide",

--- a/desktop/version.ts
+++ b/desktop/version.ts
@@ -183,4 +183,20 @@
 //           ran `bun test harness` only) AND its own sim mirrored the depth-1 copy - both fixed: the guard
 //           now copies desktop sources recursively, and CI runs it as a required step. This class (v1.9.0 /
 //           1.10.3 / 1.10.4 / 1.11.0) is now gated, not shipped.
-export const APP_VERSION = "1.11.1";
+// v1.11.2 = ENTERPRISE PROVIDERS + IMAGES IN CHAT (ADR-0208/0210) on top of the KG-Packs / marketplace arc
+//           (ADR-0205/0206/0207) landed since 1.11.1. Settings -> Providers now surfaces three omp-native
+//           first-party providers it hid before: AZURE OPENAI (your Microsoft tenant's own deployments -
+//           key + resource/base/version/deployment-map), GITHUB COPILOT via OAuth (the Business/Enterprise
+//           "easy button" - a device-code sign-in that also handles a GitHub Enterprise domain), and GOOGLE
+//           CLOUD - GEMINI ENTERPRISE (formerly Vertex AI: an API key, or gcloud ADC with project+location).
+//           The existing Gemini OAuth card also gained a GCP project field, which is what makes Workspace /
+//           Enterprise Google accounts sign in at all (without it omp aborts non-personal accounts). Under
+//           the hood the provider descriptor grew multi-field config that rides the same key->env->omp seam,
+//           so nothing new is stored. GENERATED / TOOL IMAGES now render INLINE in the chat reply (validated
+//           fail-closed - SVG refused), each with a Download and a "Send to preview" that drops the image
+//           under the markup canvas so you can annotate + Screenshot->chat to iterate (great for image gen).
+//           Plus KG PACKS (named, swappable Knowledge Graphs + signed, sellable .lkgpack packs plus the
+//           gated marketplace) and a headless `make kg-pack` builder. SECURITY: every dev-server error now
+//           returns a generic client message (the full error stays server-side) - CWE-209 - and the CodeQL
+//           SAST config excludes non-shipped mockups.
+export const APP_VERSION = "1.11.2";


### PR DESCRIPTION
Version bump to **v1.11.2** ahead of cutting the release builds.

## What changed
- `APP_VERSION` 1.11.1 → **1.11.2** in the three single-sourced spots: `desktop/version.ts`, `desktop/package.json`, and the `desktop/about.test.ts` drift guard + rendered-version assertion.
- Added the v1.11.2 changelog entry covering the batch landed since 1.11.1:
  - **Enterprise providers** — Azure OpenAI, GitHub Copilot OAuth, Google Cloud · Gemini Enterprise (Vertex), and the `GOOGLE_CLOUD_PROJECT` field that unblocks Workspace/Enterprise Gemini OAuth (ADR-0208/0210, #301).
  - **Generated / tool images inline in chat** — render + Download + Send-to-preview for markup (ADR-0208, #301).
  - **KG Packs + marketplace + headless `make kg-pack` builder** (ADR-0205/0206/0207, #297–#300).
  - **Security** — dev-server errors now return generic client messages (CWE-209); CodeQL excludes non-shipped `mockups/` (ADR-0209, #301).

## Build verification (the "ensure it builds correctly" part)
Ran the packaging steps that the merged code could break, locally:
- `bun run build` → `dist/main.js` + `dist/preload.js` bundle cleanly (Electron main/preload). ✅
- `bun run compile-lucid` → the `lucid` binary compiles (250 modules). ✅
- `desktop/packaged_boot.test.ts` (the ADR-0177/0178 packaged-boot guard) green. ✅
- Full `make test` green (**2229 pass, 0 fail**) + sidecar; version drift guard passes.

(The `electron` postinstall binary download and `electron-builder` packaging can't run in this sandbox — they run on the native macOS/Windows/Linux CI runners.)

## Release
On merge to `master`, pushing the **`v1.11.2`** tag triggers `build-desktop.yml` → macOS `.zip`+`.pkg`, Windows NSIS+portable, Linux AppImage/deb/rpm, attached to the `v1.11.2` GitHub Release (+ the electron-updater feed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARBLHjVfyBJJ3ujLqfAtcp)_