### PR TITLE
fix(ci): a mistyped release tag must not brick the desktop build (ADR-0213)

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -75,7 +75,21 @@ jobs:
         shell: bash
         working-directory: desktop
         run: |
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then V="${GITHUB_REF#refs/tags/v}"; else V="0.1.${GITHUB_RUN_NUMBER}"; fi
+          # Derive a CLEAN semver from the tag, tolerant of a mistyped `v` prefix. A malformed tag must never
+          # brick the release build: electron-builder rejects e.g. ".1.11.3" ("Invalid version"), which is
+          # exactly what the old `${GITHUB_REF#refs/tags/v}` produced from a `v.1.11.3` tag (it left the dot).
+          # Strip refs/tags/, then an OPTIONAL leading `v`, then an OPTIONAL leading `.`, so v1.2.3 / v.1.2.3 /
+          # 1.2.3 all yield 1.2.3. If the result still isn't a real semver, fall back to the version committed
+          # in package.json (the source of truth) rather than failing. Non-tag runs get a monotonic 0.1.<run#>.
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            V="${GITHUB_REF#refs/tags/}"; V="${V#v}"; V="${V#.}"
+            if [[ ! "$V" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+              echo "::warning::tag '${GITHUB_REF#refs/tags/}' is not a clean semver — using package.json version"
+              V="$(node -p "require('./package.json').version")"
+            fi
+          else
+            V="0.1.${GITHUB_RUN_NUMBER}"
+          fi
           node -e "const fs=require('fs'),p=require('./package.json');p.version=process.argv[1];fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')" "$V"
           echo "build version = $V"
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -14457,3 +14457,31 @@ the other `shell`-backed affordances (capturePreview, revealPath).
 
 The existing `lucid:revealPath` IPC (#115, extended here to file-level reveal), ADR-0104/P-CHAT.1 (the tool-step
 code preview bar this adds the button to), and ADR-0022 H1 (path-existence guard on the IPC).
+
+-----
+
+## ADR-0213 — P-RELEASE.1: a mistyped release tag must not brick the desktop build
+
+**Status:** Accepted (2026-07-13).
+
+**Context.** The `v1.11.3` release build failed on all three platforms: electron-builder rejected `Invalid
+version: ".1.11.3"`. Root cause was the TAG NAME — it was pushed as `v.1.11.3` (a dot after the `v`), and
+`build-desktop.yml` derived the version with `V="${GITHUB_REF#refs/tags/v}"`, which strips `refs/tags/v` and
+leaves the leading dot (`.1.11.3`). The code was fine; a single mistyped tag character bricked the entire
+cross-platform release build (the failure surfaces only in the tag-triggered `build-desktop.yml`, never in
+the PR CI, so it wasn't caught pre-merge).
+
+**Decision.** Make the version derivation tolerant + fail-safe. Strip `refs/tags/`, then an OPTIONAL leading
+`v`, then an OPTIONAL leading `.` — so `v1.2.3`, `v.1.2.3`, and `1.2.3` all yield `1.2.3`. If the result is
+still not a real semver (`^\d+\.\d+\.\d+`), fall back to the version already committed in `desktop/package.json`
+(the source of truth) with a workflow warning, rather than passing garbage to electron-builder. Non-tag runs
+keep the monotonic `0.1.<run#>`.
+
+**Verification.** The derivation was table-tested against `v1.11.3` / `v.1.11.3` / `1.11.3` (all → `1.11.3`)
+and a garbage tag (→ package.json fallback); the workflow YAML parses. The real cross-platform build is
+re-exercised when the corrected tag is pushed.
+
+### Relates to
+
+`build-desktop.yml` (the tag-triggered installer build), electron-builder's `fixVersionField` semver
+validation, and the auto-update monotonic-version requirement the version stamp exists for.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3480,3 +3480,8 @@ Roadmap phases (each its own future increment + ADR for its frozen-contract delt
 - **shipped:** the extra provider config fields (e.g. the Gemini "GCP project ID", Azure resource, Vertex project/location) stacked the label ON TOP of a full-width input instead of squishing a tiny input between the label and the Save/Clear buttons. CSS-only: `.prov-field` wraps with a 100%-basis label and a `flex:1 1 200px` input.
 - **verified:** renderer tsc green; full `make test` green.
 - **next:** none.
+
+**P-RELEASE.1 - a mistyped release tag no longer bricks the desktop build (ADR-0213)**
+- **shipped:** the v1.11.3 tag was pushed as `v.1.11.3` (dot after the `v`); `build-desktop.yml` stripped `refs/tags/v` and passed `.1.11.3` to electron-builder, which rejected it (`Invalid version`) and failed all three platform builds. Hardened the "Set build version" step: strip `refs/tags/` + an optional leading `v` + an optional leading `.` (so `v1.2.3`/`v.1.2.3`/`1.2.3` all → `1.2.3`), and fall back to the committed `desktop/package.json` version if the tag isn't a clean semver, instead of bricking the build.
+- **verified:** version-derivation table-tested for `v1.11.3`/`v.1.11.3`/`1.11.3`/garbage; workflow YAML parses. Real cross-platform build re-runs when the corrected tag is pushed.
+- **next:** re-push the release tag (the hardened workflow tolerates the `v.`-with-dot form too).


### PR DESCRIPTION
Autonomously diagnosed and fixed by Claude Code, 2026-07-13.

## What broke
The `v1.11.3` release build failed on **all three platforms** — `electron-builder` rejected `Invalid version: ".1.11.3"`. The build got cleanly through runtimes/icons/bundle/compile-lucid; only the version validation failed.

## Root cause
The tag was pushed as **`v.1.11.3`** (a dot after the `v`). `build-desktop.yml` derived the version with `V="${GITHUB_REF#refs/tags/v}"`, which strips `refs/tags/v` and leaves the leading dot → `.1.11.3`. The code was fine; one mistyped tag character bricked the whole cross-platform build. It only surfaces in the tag-triggered `build-desktop.yml` (never in PR CI), so it wasn't caught pre-merge.

## Fix
Harden the "Set build version" step so a mistyped tag can't brick the build:
- strip `refs/tags/`, then an **optional** leading `v`, then an **optional** leading `.` → `v1.2.3`, `v.1.2.3`, and `1.2.3` all yield `1.2.3`;
- if the result still isn't a clean semver, **fall back to the committed `desktop/package.json` version** (with a workflow warning) instead of passing garbage to electron-builder;
- non-tag runs keep the monotonic `0.1.<run#>`.

## Verification
Version derivation table-tested: `v1.11.3` / `v.1.11.3` / `1.11.3` → `1.11.3`; a garbage tag → package.json fallback. Workflow YAML parses. The real cross-platform build re-runs when the corrected tag is pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARBLHjVfyBJJ3ujLqfAtcp)_