### PR TITLE
v1.11.4: gov hardening + RAG for everyone + better session sharing

### DIFF
--- a/desktop/about.test.ts
+++ b/desktop/about.test.ts
@@ -15,8 +15,8 @@ describe("version is single-sourced", () => {
     expect(pkg.version).toBe(APP_VERSION);
   });
 
-  test("app version is v1.11.3", () => {
-    expect(APP_VERSION).toBe("1.11.3");
+  test("app version is v1.11.4", () => {
+    expect(APP_VERSION).toBe("1.11.4");
   });
 });
 
@@ -25,7 +25,7 @@ describe("aboutHtml", () => {
 
   test("shows the dynamic version with a v prefix", () => {
     expect(html).toContain(`v${APP_VERSION}`);
-    expect(html).toContain("v1.11.3");
+    expect(html).toContain("v1.11.4");
   });
 
   test("carries the product + company identity", () => {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lucidagentide-desktop",
   "private": true,
-  "version": "1.11.3",
+  "version": "1.11.4",
   "trustedDependencies": ["electron", "@resvg/resvg-js"],
   "description": "Electron desktop shell for LucidAgentIDE + omp — gated agent chat + live security/memory dashboards.",
   "homepage": "https://github.com/mlcyclops/lucidagentide",

--- a/desktop/version.ts
+++ b/desktop/version.ts
@@ -211,4 +211,20 @@
 //           tiny sliver squeezed between the label and the Save/Clear buttons; the label now sits on its own
 //           line with a full-width input beneath it. ENHANCEMENT (ADR-0212): a written/edited file is one
 //           click from the chat feed to your OS file manager, HIGHLIGHTED in its folder (a "Reveal" button).
-export const APP_VERSION = "1.11.3";
+// v1.11.4 = GOV HARDENING + RAG FOR EVERYONE + BETTER SESSION SHARING (2026-07-14, ADR-0214-0222).
+//           ASKSAGE LOCKDOWN is now enforced SERVER-SIDE, fail-closed: every maker + checker + built-agent
+//           turn is clamped to the accredited gov gateway (it was renderer-only, so it silently fell back to a
+//           DIRECT model on a fresh launch or an omp respawn). CUI CONTROLS: a per-chat-session CUI vs Search
+//           mode - a CUI session fail-closed BLOCKS all public web egress (no spillage), a Search session may
+//           search while still gov-routed; a violet CUI banner, a DoD/STIG Notice & Consent banner (gov-gated,
+//           per launch), and the AskSage Datasets picker restored to the titlebar. New GPT-5.6 gov models
+//           (luna / sol / terra; the RAG route defaults to gpt-5.6-luna) verified live against the gateway.
+//           CLONE: Settings -> "Clone a git repo" now clones PRIVATE repos headlessly (a host token, incl. a
+//           vault-stored PAT) exactly like the agent does, instead of failing with a generic toast.
+//           RAG FOR NON-ASKSAGE USERS: a `knowledge_search` tool lets ANY model (Claude / GPT / local) ground
+//           on your OWN notes/docs - an Obsidian vault, folders, or imported chat history - LEXICAL today, and
+//           SEMANTIC via bring-your-own embeddings (a local Ollama for air-gap, or your OpenAI/Azure key; no
+//           bundled weights), with a "Semantic search" Settings card + a Test-endpoint probe + Re-index.
+//           SHARED SESSIONS: a viewer now sees the host's THINKING + TOOL CALLS (not just the final answer),
+//           and the watch window fills the app instead of a small centered modal.
+export const APP_VERSION = "1.11.4";


### PR DESCRIPTION
Cuts **v1.11.4** over the ADR-0214–0222 arc merged in #307. Bumps `APP_VERSION` 1.11.3 → 1.11.4 (`version.ts` + `package.json` + `about.test.ts` kept in sync) with the full changelog in `version.ts`.

**Highlights**
- **AskSage gov lockdown** enforced server-side, fail-closed (maker / checker / built-agent turns); **per-session CUI vs Search** egress control; violet CUI banner; **DoD/STIG** consent banner; titlebar Datasets picker; **GPT-5.6** luna/sol/terra (RAG default `gpt-5.6-luna`).
- **Clone** private repos headlessly from Settings (host token + vault PAT).
- **RAG for non-AskSage users**: `knowledge_search` (lexical) + **bring-your-own-embeddings** semantic search (local Ollama or OpenAI/Azure) + Test-endpoint + Re-index.
- **Shared-session viewer** shows the host's thinking + tool calls, full-window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)